### PR TITLE
event-processor/definitions: Add struct definitions for Input and Output events

### DIFF
--- a/libs/common/include/events/events.hpp
+++ b/libs/common/include/events/events.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "attribute_reference.hpp"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <variant>
+
+#include <stdint.h>
+
+namespace launchdarkly::events {
+
+// TODO: Replace with actual types when available.
+using Value = std::string;
+using VariationIndex = size_t;
+using Reason = std::string;
+using Context = std::string;
+using Json = std::string;
+using Version = std::uint64_t;
+
+struct BaseEvent {
+    std::chrono::milliseconds creation_date;
+    bool inline_;
+    bool all_attributes_private;
+    std::unordered_set<AttributeReference> global_private_attributes;
+    Context context;
+};
+
+struct FeatureEvent {
+    BaseEvent base;
+    std::string key;
+    Value value;
+    std::optional<VariationIndex> variation;
+    Value default_;
+    std::optional<Reason> reason;
+    std::optional<Version> version;
+};
+
+struct PrerequisiteEvent {
+    BaseEvent base;
+    std::string key;
+    Value value;
+    std::optional<VariationIndex> variation;
+    std::optional<Reason> reason;
+    std::optional<Version> version;
+    std::string prereq_of;
+};
+
+using IndexEvent = BaseEvent;
+
+struct IdentifyEvent {
+    BaseEvent base;
+    std::string key;
+};
+
+struct CustomEvent {
+    BaseEvent base;
+    std::string key;
+    std::optional<Json> data;
+    std::optional<double> metric_value;
+};
+
+struct DebugEvent {
+    FeatureEvent feature;
+};
+
+struct VariationSummary {
+    std::size_t count;
+    Value value;
+};
+
+struct VariationKey {
+    std::optional<Version> version;
+    std::optional<VariationIndex> variation;
+};
+
+struct FlagSummary {
+    std::unordered_map<VariationKey, VariationSummary> counters;
+    Value default_;
+    std::unordered_set<std::string> context_kinds;
+};
+struct SummaryEvent {
+    std::chrono::milliseconds start_date;
+    std::chrono::milliseconds end_date;
+    std::unordered_map<std::string, FlagSummary> features;
+};
+
+using InputEvent = std::variant<FeatureEvent, IdentifyEvent, CustomEvent>;
+
+using OutputEvent = std::variant<IndexEvent,
+                                 DebugEvent,
+                                 FeatureEvent,
+                                 IdentifyEvent,
+                                 CustomEvent,
+                                 SummaryEvent>;
+
+}  // namespace launchdarkly::events

--- a/libs/common/include/events/outbox.hpp
+++ b/libs/common/include/events/outbox.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 file(GLOB HEADER_LIST CONFIGURE_DEPENDS
         "${LaunchDarklyCPPCommon_SOURCE_DIR}/include/*.hpp"
         "${LaunchDarklyCPPCommon_SOURCE_DIR}/include/config/*.hpp"
+        "${LaunchDarklyCPPCommon_SOURCE_DIR}/include/events/*.hpp"
         )
 
 # Automatic library: static or dynamic based on user config.


### PR DESCRIPTION
Going to try having a feature branch for the event processor and see how that goes.

First up is the definitions for the various input/output events. I'm not entirely sure whether using a `variant` for these will be the best choice, but I'll figure that out as I go.