### PR TITLE
chore: make clang-tidy only run on files in PR & make cancellable

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,4 +1,7 @@
 name: lint
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -46,7 +49,7 @@ jobs:
           # Set this option to 'true' to only analyze changes in the event's diff. Defaults to 'false'.
           #lines-changed-only: # optional
           # Set this option to 'false' to analyze any source files in the repo. Defaults to 'true'.
-          files-changed-only: false
+          files-changed-only: true
           # Set this option with string of path(s) to ignore.
           ignore: '.github|.idea|.vscode|extern'
           # The directory containing compile_commands.json file.


### PR DESCRIPTION
This contains two improvements to address the slowness of the linter:
1) Make it cancel if a new commit comes through
2) Only run on files in the PR.

I had (2) disabled because I wanted it to scan the whole repo (it was introduced after there was already code in the repo.) I think we can change that now. I should probably have changed that a couple days ago but I forgot about it.

