### PR TITLE
feat: add error.hpp and tl::expected library

### DIFF
--- a/cmake/expected.cmake
+++ b/cmake/expected.cmake
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(FetchContent)
+
+FetchContent_Declare(tl-expected
+        GIT_REPOSITORY https://github.com/TartanLlama/expected.git
+        GIT_TAG 292eff8bd8ee230a7df1d6a1c00c4ea0eb2f0362
+        )
+
+FetchContent_MakeAvailable(tl-expected)

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -30,6 +30,8 @@ set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.80 REQUIRED)
 message(STATUS "LaunchDarkly: using Boost v${Boost_VERSION}")
 
+include(${CMAKE_FILES}/expected.cmake)
+
 # Add main SDK sources.
 add_subdirectory(src)
 

--- a/libs/common/include/config/detail/endpoints_builder.hpp
+++ b/libs/common/include/config/detail/endpoints_builder.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "service_endpoints.hpp"
+#include "config/detail/service_endpoints.hpp"
+#include "error.hpp"
+
+#include <tl/expected.hpp>
 
 #include <memory>
 #include <optional>
@@ -68,7 +71,7 @@ class EndpointsBuilder {
      * returns nullptr.
      * @return Unique pointer to ServiceEndpoints, or nullptr.
      */
-    [[nodiscard]] std::unique_ptr<ServiceEndpoints> build();
+    [[nodiscard]] tl::expected<ServiceEndpoints, Error> build();
 };
 
 }  // namespace launchdarkly::config::detail

--- a/libs/common/include/error.hpp
+++ b/libs/common/include/error.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace launchdarkly {
+
+enum class Error : std::uint32_t {
+    KReserved1 = 0,
+    KReserved2 = 1,
+    /* Common lib errors: 2-99 */
+    kConfig_Endpoints_EmptyURL = 2,
+    kConfig_Endpoints_AllURLsMustBeSet = 3,
+    /* Client-side errors: 100-199 */
+    /* Server-side errors: 200-299 */
+
+    kMax = std::numeric_limits<std::uint32_t>::max()
+};
+
+}  // namespace launchdarkly

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(${LIBNAME}
 
 add_library(launchdarkly::common ALIAS ${LIBNAME})
 
-target_link_libraries(${LIBNAME} Boost::headers)
+target_link_libraries(${LIBNAME} Boost::headers tl::expected)
 
 # Need the public headers to build.
 target_include_directories(${LIBNAME} PUBLIC ../include)

--- a/libs/common/tests/service_endpoints_test.cpp
+++ b/libs/common/tests/service_endpoints_test.cpp
@@ -2,12 +2,15 @@
 
 #include "config/client.hpp"
 #include "config/server.hpp"
+#include "error.hpp"
 
 class ServiceEndpointTest : public testing::Test {};
 
 using ClientEndpointsBuilder = launchdarkly::client::EndpointsBuilder;
 
 using ServerEndpointsBuilder = launchdarkly::server::EndpointsBuilder;
+
+using launchdarkly::Error;
 
 TEST(ServiceEndpointTest, DefaultClientBuilderURLs) {
     ClientEndpointsBuilder builder;
@@ -28,28 +31,22 @@ TEST(ServiceEndpointTest, DefaultServerBuilderURLs) {
     ASSERT_EQ(eps->events_base_url(), "https://events.launchdarkly.com");
 }
 
-TEST(ServiceEndpointTest, ModifySingleURLCausesError_Polling) {
-    ClientEndpointsBuilder builder;
-    builder.polling_base_url("foo");
-    ASSERT_FALSE(builder.build());
-}
+TEST(ServiceEndpointTest, ModifySingleURLCausesError) {
+    auto result = ClientEndpointsBuilder().polling_base_url("foo").build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
 
-TEST(ServiceEndpointTest, ModifySingleURLCausesError_Streaming) {
-    ClientEndpointsBuilder builder;
-    builder.streaming_base_url("foo");
-    ASSERT_FALSE(builder.build());
-}
+    result = ClientEndpointsBuilder().streaming_base_url("foo").build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
 
-TEST(ServiceEndpointTest, ModifySingleURLCausesError_Events) {
-    ClientEndpointsBuilder builder;
-    builder.events_base_url("foo");
-    ASSERT_FALSE(builder.build());
+    result = ClientEndpointsBuilder().events_base_url("foo").build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
 }
 
 TEST(ServiceEndpointsTest, RelaySetsAllURLS) {
-    ClientEndpointsBuilder builder;
-    builder.relay_proxy("foo");
-    auto eps = builder.build();
+    auto eps = ClientEndpointsBuilder().relay_proxy("foo").build();
     ASSERT_TRUE(eps);
     ASSERT_EQ(eps->streaming_base_url(), "foo");
     ASSERT_EQ(eps->polling_base_url(), "foo");
@@ -58,52 +55,50 @@ TEST(ServiceEndpointsTest, RelaySetsAllURLS) {
 
 TEST(ServiceEndpointsTest, TrimsTrailingSlashes) {
     {
-        ClientEndpointsBuilder builder;
-        builder.relay_proxy("foo/");
-        auto eps = builder.build();
+        auto eps = ClientEndpointsBuilder().relay_proxy("foo/").build();
         ASSERT_TRUE(eps);
         ASSERT_EQ(eps->streaming_base_url(), "foo");
     }
 
     {
-        ClientEndpointsBuilder builder;
-        builder.relay_proxy("foo////////");
-        auto eps = builder.build();
+        auto eps = ClientEndpointsBuilder().relay_proxy("foo////////").build();
         ASSERT_TRUE(eps);
         ASSERT_EQ(eps->streaming_base_url(), "foo");
     }
 
     {
-        ClientEndpointsBuilder builder;
-        builder.relay_proxy("/");
-        auto eps = builder.build();
+        auto eps = ClientEndpointsBuilder().relay_proxy("/").build();
         ASSERT_TRUE(eps);
         ASSERT_EQ(eps->streaming_base_url(), "");
     }
 }
 
 TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
-    {
-        ClientEndpointsBuilder builder;
-        builder.relay_proxy("");
-        auto eps = builder.build();
-        ASSERT_FALSE(eps);
-    }
-    {
-        ClientEndpointsBuilder builder;
-        auto eps = builder.streaming_base_url("")
-                       .events_base_url("foo")
-                       .polling_base_url("bar")
-                       .build();
-        ASSERT_FALSE(eps);
-    }
+    auto result = ClientEndpointsBuilder().relay_proxy("").build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
 
-    {
-        ClientEndpointsBuilder builder;
-        auto eps = builder.streaming_base_url("foo")
-                       .events_base_url("bar")
-                       .polling_base_url("")
-                       .build();
-        ASSERT_FALSE(eps);
-    }
+    result = ClientEndpointsBuilder()
+                 .streaming_base_url("")
+                 .events_base_url("foo")
+                 .polling_base_url("bar")
+                 .build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+
+    result = ClientEndpointsBuilder()
+                 .streaming_base_url("foo")
+                 .events_base_url("")
+                 .polling_base_url("bar")
+                 .build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+
+    result = ClientEndpointsBuilder()
+                 .streaming_base_url("foo")
+                 .events_base_url("bar")
+                 .polling_base_url("")
+                 .build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
 }


### PR DESCRIPTION
Pulls in the `tl::expected` library for error handling. The idea is that we can return value types, as well as an error code from functions. I believe something similar is slated for `std::`. 

It has nice things like `map` built in.

I'm not 100% all in on having a single `Error` enum, I just thought it'd be simpler to ensure unique unique error codes from a C standpoint.