### PR TITLE
chore: fix build on mac due to ValueOrDefault template inference

### DIFF
--- a/libs/common/src/serialization/json_evaluation_result.cpp
+++ b/libs/common/src/serialization/json_evaluation_result.cpp
@@ -12,7 +12,8 @@ EvaluationResult tag_invoke(
         auto json_obj = json_value.as_object();
 
         auto* version_iter = json_obj.find("version");
-        auto version = ValueOrDefault(version_iter, json_obj.end(), 0UL);
+        auto version =
+            ValueOrDefault<uint64_t>(version_iter, json_obj.end(), 0);
 
         auto* flag_version_iter = json_obj.find("flagVersion");
         auto flag_version =


### PR DESCRIPTION
```
/value_mapping.hpp:24:5: error: static_assert failed due to requirement 'sizeof(unsigned long) == -1' "Must be specialized to use ValueOrDefault"
    static_assert(sizeof(Type) == -1,
    ^             ~~~~~~~~~~~~~~~~~~
/Users/cwaldren/code/launchdarkly/sdk/cpp-sdks-private/libs/common/src/serialization/json_evaluation_result.cpp:15:24: note: in instantiation of function template specialization 'launchdarkly::ValueOrDefault<unsigned long>' requested here
        auto version = ValueOrDefault(version_iter, json_obj.end(), 0UL);
                       ^
```