### PR TITLE
fix: remove extra call to data_source->Start() in api.cpp

### DIFF
--- a/libs/client-sdk/src/api.cpp
+++ b/libs/client-sdk/src/api.cpp
@@ -49,8 +49,6 @@ Client::Client(Config config, Context context)
         event_processor_ = std::make_unique<detail::NullEventProcessor>();
     }
 
-    data_source_->Start();
-
     status_manager_.OnDataSourceStatusChange([this](auto status) {
         if (status.State() == DataSourceStatus::DataSourceState::kValid ||
             status.State() == DataSourceStatus::DataSourceState::kShutdown ||


### PR DESCRIPTION
data_source->Start() was being called twice. Having two async operations going at the same time is a no-no.

Looks like it was a bad merge from me.