### PR TITLE
fix: disable events in contract tests when requested

### DIFF
--- a/apps/sdk-contract-tests/src/entity_manager.cpp
+++ b/apps/sdk-contract-tests/src/entity_manager.cpp
@@ -72,14 +72,14 @@ std::optional<std::string> EntityManager::create(ConfigParams in) {
         }
     }
 
+    auto event_config = EventsBuilder();
+
     if (in.events) {
         ConfigEventParams const& events = *in.events;
 
         if (events.baseUri) {
             endpoints.EventsBaseUrl(*events.baseUri);
         }
-
-        auto event_config = EventsBuilder();
 
         if (events.allAttributesPrivate) {
             event_config.AllAttributesPrivate(*events.allAttributesPrivate);
@@ -101,8 +101,11 @@ std::optional<std::string> EntityManager::create(ConfigParams in) {
                 std::chrono::milliseconds(*events.flushIntervalMs));
         }
 
-        config_builder.Events(std::move(event_config));
+    } else {
+        event_config.Disable();
     }
+
+    config_builder.Events(std::move(event_config));
 
     config_builder.ServiceEndpoints(std::move(endpoints));
 

--- a/apps/sdk-contract-tests/test-suppressions.txt
+++ b/apps/sdk-contract-tests/test-suppressions.txt
@@ -47,9 +47,7 @@ events/context properties/custom attribute with value {}/debug event
 events/context properties/custom attribute with value {}/identify event
 events/context properties/custom attribute with value {"a":1}/debug event
 events/context properties/custom attribute with value {"a":1}/identify event
-events/disabling/evaluation
 events/disabling/identify event
-events/disabling/custom event
 streaming/requests/query parameters/evaluationReasons set to true/GET
 streaming/requests/query parameters/evaluationReasons set to true/REPORT
 tags/disallowed characters


### PR DESCRIPTION
The sdk test harness specifies that events should be disabled if the event config is omitted. 