### PR TITLE
chore: add internal lib to CI

### DIFF
--- a/.github/workflows/internal.yml
+++ b/.github/workflows/internal.yml
@@ -1,0 +1,20 @@
+name: libs/internal
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci
+        with:
+          cmake_target: launchdarkly-cpp-internal

--- a/libs/internal/tests/event_processor_test.cpp
+++ b/libs/internal/tests/event_processor_test.cpp
@@ -74,7 +74,9 @@ TEST(EventProcessorTests, ProcessorCompiles) {
 
     ASSERT_TRUE(config);
 
-    events::AsioEventProcessor processor(ioc.get_executor(), *config, logger);
+    events::AsioEventProcessor<client_side::SDK> processor(
+        ioc.get_executor(), config->ServiceEndpoints(), config->Events(),
+        config->HttpProperties(), logger);
     std::thread ioc_thread([&]() { ioc.run(); });
 
     auto context = launchdarkly::ContextBuilder().kind("org", "ld").build();


### PR DESCRIPTION
Adds `libs/internal` to CI; fixes test using constructor of `AsioEventProcessor` to take all necessary config arguments. 