### PR TITLE
chore: fix msvc compiler warnings related to strcasecmp

### DIFF
--- a/libs/internal/include/launchdarkly/network/http_requester.hpp
+++ b/libs/internal/include/launchdarkly/network/http_requester.hpp
@@ -13,18 +13,11 @@
 
 #include <launchdarkly/config/shared/built/http_properties.hpp>
 
-#ifdef _MSC_VER
-// MSVC doesn't support strcasecmp.
-#define strcasecmp _stricmp
-#endif
-
 namespace launchdarkly::network {
 
 struct CaseInsensitiveComparator {
     bool operator()(std::string const& lhs,
-                    std::string const& rhs) const noexcept {
-        return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
-    }
+                    std::string const& rhs) const noexcept;
 };
 
 class HttpResult {
@@ -157,7 +150,3 @@ std::optional<std::string> AppendUrl(std::optional<std::string> url_in,
                                      std::string const& to_append);
 
 }  // namespace launchdarkly::network
-
-#ifdef _MSC_VER
-#undef strcasecmp _stricmp
-#endif

--- a/libs/internal/src/network/http_requester.cpp
+++ b/libs/internal/src/network/http_requester.cpp
@@ -1,11 +1,23 @@
 #include <boost/url.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <optional>
 #include <utility>
 
 #include <launchdarkly/network/http_requester.hpp>
 
 namespace launchdarkly::network {
+
+bool CaseInsensitiveComparator::operator()(
+    std::string const& lhs,
+    std::string const& rhs) const noexcept {
+#ifdef _MSC_VER
+    return _stricmp(lhs.c_str(), rhs.c_str()) < 0;
+#else
+    return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
+#endif
+}
 
 HttpResult::StatusCode HttpResult::Status() const {
     return status_;

--- a/libs/internal/src/network/http_requester.cpp
+++ b/libs/internal/src/network/http_requester.cpp
@@ -1,7 +1,6 @@
 #include <boost/url.hpp>
 
-#include <algorithm>
-#include <cctype>
+#include <cstring>
 #include <optional>
 #include <utility>
 


### PR DESCRIPTION
If we don't define the symbol, we don't need to undefine it. 