### PR TITLE
fix: update required Boost version to 1.81 for Boost.URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,30 @@
 This repository contains LaunchDarkly SDK packages which are written in C++.
 This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 
-This repository contains beta software and should not be considered ready for production use while this message is visible.
+This repository contains beta software and should not be considered ready for production use while this message is
+visible.
 
 ## Packages
 
-| Readme                                       | issues                                      | tests                                                    | docs                     |
-|----------------------------------------------|---------------------------------------------|----------------------------------------------------------|--------------------------|
-| [libs/client-sdk](libs/client-sdk/README.md) | [C++ Client SDK][package-cpp-client-issues] | [![Actions Status][cpp-client-ci-badge]][cpp-client-ci]  |[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/cpp-sdks/libs/client-sdk/docs/html/)
+| Readme                                       | issues                                      | tests                                                   | docs                                                                                                                                                                           |
+|----------------------------------------------|---------------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [libs/client-sdk](libs/client-sdk/README.md) | [C++ Client SDK][package-cpp-client-issues] | [![Actions Status][cpp-client-ci-badge]][cpp-client-ci] | [![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/cpp-sdks/libs/client-sdk/docs/html/) 
 
-| Shared packages                                              | issues                                            | tests                                                                 |
-|--------------------------------------------------------------|---------------------------------------------------|-----------------------------------------------------------------------|
-| [libs/common](libs/common/README.md)                         | [Common][package-shared-common-issues]            | [![Actions Status][shared-common-ci-badge]][shared-common-ci]         |
+| Shared packages                                              | issues                                            | tests                                                                |
+|--------------------------------------------------------------|---------------------------------------------------|----------------------------------------------------------------------|
+| [libs/common](libs/common/README.md)                         | [Common][package-shared-common-issues]            | [![Actions Status][shared-common-ci-badge]][shared-common-ci]        |
 | [libs/server-sent-events](libs/server-sent-events/README.md) | [Common Server][package-shared-sdk-server-issues] | [![Actions Status][shared-sse-ci-badge-badge]][shared-sdk-server-ci] |
 
 ## Organization
 
- | Directory | Description |
- |----------|--------------|
- | .github  | Contains CI and release process workflows and actions.
- | apps     | Contains example and test applications.
- | cmake    | Contains cmake files for importing and configuring external libraries.
- | libs     | Contains library implementations. This includes libraries shared within the project as well as SDK libraries like the client-sdk.
- | scripts  | Contains scripts used in the release process.
- | vendor   | Contains third party source which is directly integrated into the project. Generally third party source is included through CMake using FetchContent, but some libraries require modification specific to this repository.
+| Directory | Description                                                                                                                                                                                                                |
+ |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| .github   | Contains CI and release process workflows and actions.                                                                                                                                                                     
+| apps      | Contains example and test applications.                                                                                                                                                                                    
+| cmake     | Contains cmake files for importing and configuring external libraries.                                                                                                                                                     
+| libs      | Contains library implementations. This includes libraries shared within the project as well as SDK libraries like the client-sdk.                                                                                          
+| scripts   | Contains scripts used in the release process.                                                                                                                                                                              
+| vendor    | Contains third party source which is directly integrated into the project. Generally third party source is included through CMake using FetchContent, but some libraries require modification specific to this repository. 
 
 ## Build Requirements
 
@@ -34,7 +35,7 @@ This repository contains beta software and should not be considered ready for pr
 1. C++17 and above
 1. CMake 3.19 or higher
 1. Ninja (if using the included build scripts)
-1. Boost version 1.80 or higher.
+1. Boost version 1.81 or higher
 1. OpenSSL
 
 Additional dependencies are fetched via CMake. For details see the `cmake` folder.
@@ -89,17 +90,26 @@ our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contri
       updates
 
 [//]: # 'libs/common'
+
 [shared-common-ci-badge]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/common.yml/badge.svg
+
 [shared-common-ci]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/common.yml
+
 [package-shared-common-issues]: https://github.com/launchdarkly/cpp-sdks/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+shared%2Fcommon%22+
 
 [//]: # 'libs/server-sent-events'
+
 [shared-sse-ci-badge-badge]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/sse.yml/badge.svg
+
 [shared-sdk-server-ci]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/sse.yml
+
 [package-shared-sdk-server-issues]: https://github.com/launchdarkly/cpp-sdks/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+shared%2Fsse%22+
 
 
 [//]: # 'libs/client-sdk'
+
 [cpp-client-ci-badge]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/client.yml/badge.svg
+
 [cpp-client-ci]: https://github.com/launchdarkly/cpp-sdks/actions/workflows/client.yml
+
 [package-cpp-client-issues]: https://github.com/launchdarkly/cpp-sdks/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fclient%22+


### PR DESCRIPTION
We use Boost.URL, which was [introduced](https://www.boost.org/users/history/version_1_81_0.html) in 1.81.

Potentially we could switch to foxy's built-in URL library if we wanted to relax the boost requirement, although 1.81 came out in December 2022 so it's not exactly bleeding edge.