### PR TITLE
feat: add Version method to obtain SDK version

### DIFF
--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -33,11 +33,10 @@ LDClientSDK_New(LDClientConfig config, LDContext context);
 
 /**
  * Returns the version of the SDK.
- * @param sdk SDK. Must not be NULL.
  * @return String representation of the SDK version.
  */
 LD_EXPORT(char const*)
-LDClientSDK_Version(LDClientSDK sdk);
+LDClientSDK_Version(void);
 
 /**
  * Starts the SDK, initiating a connection to LaunchDarkly if not offline.

--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -32,6 +32,14 @@ LD_EXPORT(LDClientSDK)
 LDClientSDK_New(LDClientConfig config, LDContext context);
 
 /**
+ * Returns the version of the SDK.
+ * @param sdk SDK. Must not be NULL.
+ * @return String representation of the SDK version.
+ */
+LD_EXPORT(char const*)
+LDClientSDK_Version(LDClientSDK sdk);
+
+/**
  * Starts the SDK, initiating a connection to LaunchDarkly if not offline.
  *
  * Only one Start call can be in progress at once; calling it

--- a/libs/client-sdk/include/launchdarkly/client_side/client.hpp
+++ b/libs/client-sdk/include/launchdarkly/client_side/client.hpp
@@ -242,12 +242,6 @@ class IClient {
      */
     virtual flag_manager::IFlagNotifier& FlagNotifier() = 0;
 
-    /**
-     * Returns the version of the SDK.
-     * @return String representing version of the SDK.
-     */
-    [[nodiscard]] virtual char const* Version() const = 0;
-
     virtual ~IClient() = default;
     IClient(IClient const& item) = delete;
     IClient(IClient&& item) = delete;
@@ -318,7 +312,11 @@ class Client : public IClient {
 
     flag_manager::IFlagNotifier& FlagNotifier() override;
 
-    [[nodiscard]] char const* Version() const override;
+    /**
+     * Returns the version of the SDK.
+     * @return String representing version of the SDK.
+     */
+    [[nodiscard]] static char const* Version();
 
    private:
     inline static char const* const kVersion =

--- a/libs/client-sdk/include/launchdarkly/client_side/client.hpp
+++ b/libs/client-sdk/include/launchdarkly/client_side/client.hpp
@@ -246,7 +246,7 @@ class IClient {
      * Returns the version of the SDK.
      * @return String representing version of the SDK.
      */
-    virtual char const* Version() const = 0;
+    [[nodiscard]] virtual char const* Version() const = 0;
 
     virtual ~IClient() = default;
     IClient(IClient const& item) = delete;
@@ -318,7 +318,7 @@ class Client : public IClient {
 
     flag_manager::IFlagNotifier& FlagNotifier() override;
 
-    char const* Version() const override;
+    [[nodiscard]] char const* Version() const override;
 
    private:
     inline static char const* const kVersion =

--- a/libs/client-sdk/include/launchdarkly/client_side/client.hpp
+++ b/libs/client-sdk/include/launchdarkly/client_side/client.hpp
@@ -242,6 +242,12 @@ class IClient {
      */
     virtual flag_manager::IFlagNotifier& FlagNotifier() = 0;
 
+    /**
+     * Returns the version of the SDK.
+     * @return String representing version of the SDK.
+     */
+    virtual char const* Version() const = 0;
+
     virtual ~IClient() = default;
     IClient(IClient const& item) = delete;
     IClient(IClient&& item) = delete;
@@ -254,9 +260,6 @@ class IClient {
 
 class Client : public IClient {
    public:
-    inline static char const* const kVersion =
-        "0.1.0";  // {x-release-please-version}
-
     Client(Config config, Context context);
 
     Client(Client&&) = delete;
@@ -315,7 +318,11 @@ class Client : public IClient {
 
     flag_manager::IFlagNotifier& FlagNotifier() override;
 
+    char const* Version() const override;
+
    private:
+    inline static char const* const kVersion =
+        "0.1.0";  // {x-release-please-version}
     std::unique_ptr<IClient> client;
 };
 

--- a/libs/client-sdk/src/bindings/c/sdk.cpp
+++ b/libs/client-sdk/src/bindings/c/sdk.cpp
@@ -58,6 +58,13 @@ LDClientSDK_New(LDClientConfig config, LDContext context) {
     return FROM_SDK(sdk);
 }
 
+LD_EXPORT(char const*)
+LDClientSDK_Version(LDClientSDK sdk) {
+    LD_ASSERT_NOT_NULL(sdk);
+
+    return TO_SDK(sdk)->Version();
+}
+
 LD_EXPORT(bool)
 LDClientSDK_Start(LDClientSDK sdk,
                   unsigned int milliseconds,

--- a/libs/client-sdk/src/bindings/c/sdk.cpp
+++ b/libs/client-sdk/src/bindings/c/sdk.cpp
@@ -59,10 +59,8 @@ LDClientSDK_New(LDClientConfig config, LDContext context) {
 }
 
 LD_EXPORT(char const*)
-LDClientSDK_Version(LDClientSDK sdk) {
-    LD_ASSERT_NOT_NULL(sdk);
-
-    return TO_SDK(sdk)->Version();
+LDClientSDK_Version(void) {
+    return Client::Version();
 }
 
 LD_EXPORT(bool)

--- a/libs/client-sdk/src/client.cpp
+++ b/libs/client-sdk/src/client.cpp
@@ -96,8 +96,8 @@ flag_manager::IFlagNotifier& Client::FlagNotifier() {
     return client->FlagNotifier();
 }
 
-char const* Client::Version() const {
-    return client->Version();
+char const* Client::Version() {
+    return kVersion;
 }
 
 }  // namespace launchdarkly::client_side

--- a/libs/client-sdk/src/client.cpp
+++ b/libs/client-sdk/src/client.cpp
@@ -96,4 +96,8 @@ flag_manager::IFlagNotifier& Client::FlagNotifier() {
     return client->FlagNotifier();
 }
 
+char const* Client::Version() const {
+    return client->Version();
+}
+
 }  // namespace launchdarkly::client_side

--- a/libs/client-sdk/src/client_impl.cpp
+++ b/libs/client-sdk/src/client_impl.cpp
@@ -89,12 +89,11 @@ static std::shared_ptr<IPersistence> MakePersistence(Config const& config) {
     return persistence.implementation;
 }
 
-ClientImpl::ClientImpl(Config config,
-                       Context context,
-                       std::string const& version)
-    : config_(config),
+ClientImpl::ClientImpl(Config config, Context context, std::string version)
+    : version_(std::move(version)),
+      config_(config),
       http_properties_(HttpPropertiesBuilder(config.HttpProperties())
-                           .Header("user-agent", "CPPClient/" + version)
+                           .Header("user-agent", "CPPClient/" + version_)
                            .Header("authorization", config.SdkKey())
                            .Build()),
       logger_(MakeLogger(config.Logging())),
@@ -128,6 +127,10 @@ ClientImpl::ClientImpl(Config config,
         std::chrono::system_clock::now(), context_});
 
     run_thread_ = std::move(std::thread([&]() { ioc_.run(); }));
+}
+
+char const* ClientImpl::Version() const {
+    return version_.c_str();
 }
 
 // Was an attempt made to initialize the data source, and did that attempt

--- a/libs/client-sdk/src/client_impl.cpp
+++ b/libs/client-sdk/src/client_impl.cpp
@@ -89,11 +89,12 @@ static std::shared_ptr<IPersistence> MakePersistence(Config const& config) {
     return persistence.implementation;
 }
 
-ClientImpl::ClientImpl(Config config, Context context, std::string version)
-    : version_(std::move(version)),
-      config_(config),
+ClientImpl::ClientImpl(Config config,
+                       Context context,
+                       std::string const& version)
+    : config_(config),
       http_properties_(HttpPropertiesBuilder(config.HttpProperties())
-                           .Header("user-agent", "CPPClient/" + version_)
+                           .Header("user-agent", "CPPClient/" + version)
                            .Header("authorization", config.SdkKey())
                            .Build()),
       logger_(MakeLogger(config.Logging())),
@@ -127,10 +128,6 @@ ClientImpl::ClientImpl(Config config, Context context, std::string version)
         std::chrono::system_clock::now(), context_});
 
     run_thread_ = std::move(std::thread([&]() { ioc_.run(); }));
-}
-
-char const* ClientImpl::Version() const {
-    return version_.c_str();
 }
 
 // Was an attempt made to initialize the data source, and did that attempt

--- a/libs/client-sdk/src/client_impl.hpp
+++ b/libs/client-sdk/src/client_impl.hpp
@@ -31,12 +31,14 @@
 namespace launchdarkly::client_side {
 class ClientImpl : public IClient {
    public:
-    ClientImpl(Config config, Context context, std::string const& version);
+    ClientImpl(Config config, Context context, std::string version);
 
     ClientImpl(ClientImpl&&) = delete;
     ClientImpl(ClientImpl const&) = delete;
     ClientImpl& operator=(ClientImpl) = delete;
     ClientImpl& operator=(ClientImpl&& other) = delete;
+
+    char const* Version() const override;
 
     bool Initialized() const override;
 
@@ -116,6 +118,7 @@ class ClientImpl : public IClient {
         std::function<bool(data_sources::DataSourceStatus::DataSourceState)>
             predicate);
 
+    std::string version_;
     Config config_;
     Logger logger_;
 

--- a/libs/client-sdk/src/client_impl.hpp
+++ b/libs/client-sdk/src/client_impl.hpp
@@ -31,15 +31,13 @@
 namespace launchdarkly::client_side {
 class ClientImpl : public IClient {
    public:
-    ClientImpl(Config config, Context context, std::string version);
+    ClientImpl(Config config, Context context, std::string const& version);
 
     ClientImpl(ClientImpl&&) = delete;
     ClientImpl(ClientImpl const&) = delete;
     ClientImpl& operator=(ClientImpl) = delete;
     ClientImpl& operator=(ClientImpl&& other) = delete;
-
-    char const* Version() const override;
-
+    
     bool Initialized() const override;
 
     using FlagKey = std::string;
@@ -118,7 +116,6 @@ class ClientImpl : public IClient {
         std::function<bool(data_sources::DataSourceStatus::DataSourceState)>
             predicate);
 
-    std::string version_;
     Config config_;
     Logger logger_;
 

--- a/libs/client-sdk/tests/client_c_bindings_test.cpp
+++ b/libs/client-sdk/tests/client_c_bindings_test.cpp
@@ -18,7 +18,7 @@ TEST(ClientBindings, MinimalInstantiation) {
 
     LDClientSDK sdk = LDClientSDK_New(config, context);
 
-    char const* version = LDClientSDK_Version(sdk);
+    char const* version = LDClientSDK_Version();
     ASSERT_TRUE(version);
     ASSERT_STREQ(version, "0.1.0");  // {x-release-please-version}
 

--- a/libs/client-sdk/tests/client_c_bindings_test.cpp
+++ b/libs/client-sdk/tests/client_c_bindings_test.cpp
@@ -18,5 +18,9 @@ TEST(ClientBindings, MinimalInstantiation) {
 
     LDClientSDK sdk = LDClientSDK_New(config, context);
 
+    char const* version = LDClientSDK_Version(sdk);
+    ASSERT_TRUE(version);
+    ASSERT_STRNE(version, "");
+
     LDClientSDK_Free(sdk);
 }

--- a/libs/client-sdk/tests/client_c_bindings_test.cpp
+++ b/libs/client-sdk/tests/client_c_bindings_test.cpp
@@ -20,7 +20,7 @@ TEST(ClientBindings, MinimalInstantiation) {
 
     char const* version = LDClientSDK_Version(sdk);
     ASSERT_TRUE(version);
-    ASSERT_STRNE(version, "");
+    ASSERT_STREQ(version, "0.1.0");  // {x-release-please-version}
 
     LDClientSDK_Free(sdk);
 }

--- a/libs/client-sdk/tests/client_test.cpp
+++ b/libs/client-sdk/tests/client_test.cpp
@@ -16,7 +16,7 @@ TEST(ClientTest, ClientConstructedWithMinimalConfigAndContext) {
 
     char const* version = client.Version();
     ASSERT_TRUE(version);
-    ASSERT_STRNE(version, "");
+    ASSERT_STREQ(version, "0.1.0");  // {x-release-please-version}
 }
 
 TEST(ClientTest, AllFlagsIsEmpty) {

--- a/libs/client-sdk/tests/client_test.cpp
+++ b/libs/client-sdk/tests/client_test.cpp
@@ -13,6 +13,10 @@ TEST(ClientTest, ClientConstructedWithMinimalConfigAndContext) {
     Context context = ContextBuilder().Kind("cat", "shadow").Build();
 
     Client client(std::move(*config), context);
+
+    char const* version = client.Version();
+    ASSERT_TRUE(version);
+    ASSERT_STRNE(version, "");
 }
 
 TEST(ClientTest, AllFlagsIsEmpty) {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,9 @@
     "libs/client-sdk": {
       "initial-version": "0.1.0",
       "extra-files": [
-        "include/launchdarkly/client_side/client.hpp"
+        "include/launchdarkly/client_side/client.hpp",
+        "tests/client_c_bindings_test.cpp",
+        "tests/client_test.cpp"
       ]
     },
     "libs/server-sent-events": {


### PR DESCRIPTION
Adds a `Version/LDClientSDK_Version`method, which exposes the client's version via function call.

In the previous way, it was a public static class member. This way, we have a bit more encapsulation and can also expose it via C binding.