### PR TITLE
fix: rename C iterator bindings to follow new/free pattern

### DIFF
--- a/libs/common/include/launchdarkly/bindings/c/value.h
+++ b/libs/common/include/launchdarkly/bindings/c/value.h
@@ -185,9 +185,9 @@ LD_EXPORT(unsigned int) LDValue_Count(LDValue val);
  *
  * @param value Target LDValue. Must not be NULL.
  * @return Iterator, or NULL if not an array-type. The iterator
- * must should be destroyed with LDValue_DestroyArrayIter.
+ * must should be destroyed with LDValue_ArrayIter_Free.
  */
-LD_EXPORT(LDValue_ArrayIter) LDValue_CreateArrayIter(LDValue val);
+LD_EXPORT(LDValue_ArrayIter) LDValue_ArrayIter_New(LDValue val);
 
 /**
  * Move the array-type iterator to the next item. Should only be done for an
@@ -219,7 +219,7 @@ LD_EXPORT(LDValue) LDValue_ArrayIter_Value(LDValue_ArrayIter iter);
  * Destroy an array iterator.
  * @param iter The iterator to destroy.
  */
-LD_EXPORT(void) LDValue_DestroyArrayIter(LDValue_ArrayIter iter);
+LD_EXPORT(void) LDValue_ArrayIter_Free(LDValue_ArrayIter iter);
 
 /**
  * Obtain iterator over an object-type LDValue, otherwise NULL.
@@ -228,9 +228,9 @@ LD_EXPORT(void) LDValue_DestroyArrayIter(LDValue_ArrayIter iter);
  *
  * @param value Target LDValue. Must not be NULL.
  * @return Iterator, or NULL if not an object-type. The iterator
- * must should be destroyed with LDValue_DestroyObjectIter.
+ * must should be destroyed with LDValue_ObjectIter_Free.
  */
-LD_EXPORT(LDValue_ObjectIter) LDValue_CreateObjectIter(LDValue val);
+LD_EXPORT(LDValue_ObjectIter) LDValue_ObjectIter_New(LDValue val);
 
 /**
  * Move the object-type iterator to the next item. Should only be done for an
@@ -272,7 +272,7 @@ LD_EXPORT(char const*) LDValue_ObjectIter_Key(LDValue_ObjectIter iter);
  * Destroy an object iterator.
  * @param iter The iterator to destroy.
  */
-LD_EXPORT(void) LDValue_DestroyObjectIter(LDValue_ObjectIter iter);
+LD_EXPORT(void) LDValue_ObjectIter_Free(LDValue_ObjectIter iter);
 
 #ifdef __cplusplus
 }

--- a/libs/common/src/bindings/c/value.cpp
+++ b/libs/common/src/bindings/c/value.cpp
@@ -94,7 +94,7 @@ LD_EXPORT(unsigned int) LDValue_Count(LDValue val) {
     }
 }
 
-LD_EXPORT(LDValue_ArrayIter) LDValue_CreateArrayIter(LDValue val) {
+LD_EXPORT(LDValue_ArrayIter) LDValue_ArrayIter_New(LDValue val) {
     LD_ASSERT_NOT_NULL(val);
 
     if (AS_VALUE(val)->IsArray()) {
@@ -126,13 +126,13 @@ LD_EXPORT(LDValue) LDValue_ArrayIter_Value(LDValue_ArrayIter iter) {
     return AS_LDVALUE(const_cast<Value*>(&(*val_iter->iter)));
 }
 
-LD_EXPORT(void) LDValue_DestroyArrayIter(LDValue_ArrayIter iter) {
+LD_EXPORT(void) LDValue_ArrayIter_Free(LDValue_ArrayIter iter) {
     LD_ASSERT_NOT_NULL(iter);
 
     delete AS_ARR_ITER(iter);
 }
 
-LD_EXPORT(LDValue_ObjectIter) LDValue_CreateObjectIter(LDValue val) {
+LD_EXPORT(LDValue_ObjectIter) LDValue_ObjectIter_New(LDValue val) {
     LD_ASSERT_NOT_NULL(val);
 
     if (AS_VALUE(val)->IsObject()) {
@@ -171,7 +171,7 @@ LD_EXPORT(char const*) LDValue_ObjectIter_Key(LDValue_ObjectIter iter) {
     return val_iter->iter->first.c_str();
 }
 
-LD_EXPORT(void) LDValue_DestroyObjectIter(LDValue_ObjectIter iter) {
+LD_EXPORT(void) LDValue_ObjectIter_Free(LDValue_ObjectIter iter) {
     LD_ASSERT_NOT_NULL(iter);
 
     delete AS_OBJ_ITER(iter);

--- a/libs/common/tests/bindings/value_test.cpp
+++ b/libs/common/tests/bindings/value_test.cpp
@@ -75,7 +75,7 @@ TEST(ValueCBindingTests, CanCreateArray) {
 
     EXPECT_EQ(LDValueType_Array, LDValue_Type(val_ptr));
 
-    auto* iter = LDValue_CreateArrayIter(val_ptr);
+    auto* iter = LDValue_ArrayIter_New(val_ptr);
 
     auto index = 0;
     while (!LDValue_ArrayIter_End(iter)) {
@@ -102,7 +102,7 @@ TEST(ValueCBindingTests, CanCreateArray) {
         index++;
     }
 
-    LDValue_DestroyArrayIter(iter);
+    LDValue_ArrayIter_Free(iter);
 
     // Should have iterated 4 items.
     EXPECT_EQ(4, index);
@@ -128,7 +128,7 @@ TEST(ValueCBindingTests, CanCreateObject) {
 
     EXPECT_EQ(LDValueType_Object, LDValue_Type(val_ptr));
 
-    auto* iter = LDValue_CreateObjectIter(val_ptr);
+    auto* iter = LDValue_ObjectIter_New(val_ptr);
 
     auto index = 0;
     while (!LDValue_ObjectIter_End(iter)) {
@@ -159,7 +159,7 @@ TEST(ValueCBindingTests, CanCreateObject) {
         LDValue_ObjectIter_Next(iter);
     }
 
-    LDValue_DestroyObjectIter(iter);
+    LDValue_ObjectIter_Free(iter);
 
     // Should have iterated 4 items.
     EXPECT_EQ(4, index);


### PR DESCRIPTION
Renames create/destroy object/array iterators to use new/free naming. 