### PR TITLE
fix: enforce minimum polling interval of 5 minutes

### DIFF
--- a/libs/client-sdk/src/data_sources/polling_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/polling_data_source.cpp
@@ -90,8 +90,11 @@ PollingDataSource::PollingDataSource(
         data_source_config.method);
     if (polling_interval_ < polling_config.min_polling_interval) {
         LD_LOG(logger_, LogLevel::kWarn)
-            << "Polling interval specified under minimum, defaulting to 30 "
-               "second polling interval";
+            << "Polling interval too frequent, defaulting to "
+            << std::chrono::duration_cast<std::chrono::seconds>(
+                   polling_config.min_polling_interval)
+                   .count()
+            << " seconds";
 
         polling_interval_ = polling_config.min_polling_interval;
     }

--- a/libs/common/include/launchdarkly/config/shared/defaults.hpp
+++ b/libs/common/include/launchdarkly/config/shared/defaults.hpp
@@ -63,9 +63,8 @@ struct Defaults<ClientSDK> {
     }
 
     static auto PollingConfig() -> shared::built::PollingConfig<ClientSDK> {
-        // Default to 5 minutes;
-        return {std::chrono::seconds{5 * 60}, "/msdk/evalx/contexts",
-                "/msdk/evalx/context", std::chrono::seconds{5 * 60}};
+        return {std::chrono::minutes(5), "/msdk/evalx/contexts",
+                "/msdk/evalx/context", std::chrono::minutes(5)};
     }
 
     static std::size_t MaxCachedContexts() { return 5; }

--- a/libs/common/include/launchdarkly/config/shared/defaults.hpp
+++ b/libs/common/include/launchdarkly/config/shared/defaults.hpp
@@ -65,7 +65,7 @@ struct Defaults<ClientSDK> {
     static auto PollingConfig() -> shared::built::PollingConfig<ClientSDK> {
         // Default to 5 minutes;
         return {std::chrono::seconds{5 * 60}, "/msdk/evalx/contexts",
-                "/msdk/evalx/context", std::chrono::seconds{30}};
+                "/msdk/evalx/context", std::chrono::seconds{5 * 60}};
     }
 
     static std::size_t MaxCachedContexts() { return 5; }


### PR DESCRIPTION
Enforces a minimum client-side polling interval of 5 minutes. The error message has been slightly updated for clarity.