### PR TITLE
fix: ensure x-launchdarkly-tags is sent in event requests

### DIFF
--- a/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
+++ b/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -106,14 +107,14 @@ class HttpPropertiesBuilder {
         std::map<std::string, std::string> base_headers);
 
     /**
-     * Set a custom header value.
-     *
-     * Calling Headers will replace any previously set values.
-     * @param key The key for the header.
-     * @param value The header value.
+     * Set an optional header value. If the value is std::nullopt, any existing
+     * header by that name is removed.
+     * @param name The name of the header.
+     * @param value The optional header value.
      * @return A reference to this builder.
      */
-    HttpPropertiesBuilder& Header(std::string key, std::string value);
+    HttpPropertiesBuilder& Header(std::string key,
+                                  std::optional<std::string> value);
 
     /**
      * Build a set of HttpProperties.

--- a/libs/common/src/config/http_properties_builder.cpp
+++ b/libs/common/src/config/http_properties_builder.cpp
@@ -72,8 +72,12 @@ HttpPropertiesBuilder<SDK>& HttpPropertiesBuilder<SDK>::Headers(
 template <typename SDK>
 HttpPropertiesBuilder<SDK>& HttpPropertiesBuilder<SDK>::Header(
     std::string key,
-    std::string value) {
-    base_headers_.insert_or_assign(key, value);
+    std::optional<std::string> value) {
+    if (value) {
+        base_headers_.insert_or_assign(key, *value);
+    } else {
+        base_headers_.erase(key);
+    }
     return *this;
 }
 


### PR DESCRIPTION
Moves application tag into HTTP Config, so it can propagate to data sources + event sender. 