### PR TITLE
feat: deserialize segments

### DIFF
--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -2,6 +2,7 @@
 
 #include <launchdarkly/encoding/base_64.hpp>
 #include <launchdarkly/serialization/json_evaluation_result.hpp>
+#include <launchdarkly/serialization/json_item_descriptor.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
 #include <boost/json.hpp>

--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -3,6 +3,7 @@
 #include <launchdarkly/encoding/base_64.hpp>
 #include <launchdarkly/serialization/json_evaluation_result.hpp>
 #include <launchdarkly/serialization/json_item_descriptor.hpp>
+#include <launchdarkly/serialization/json_primitives.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
 #include <boost/json.hpp>
@@ -77,6 +78,17 @@ DataSourceEventHandler::DataSourceEventHandler(
       logger_(logger),
       status_manager_(status_manager) {}
 
+std::unordered_map<std::string, ItemDescriptor> remove_nulls(
+    std::unordered_map<std::string, std::optional<ItemDescriptor>> map) {
+    std::unordered_map<std::string, ItemDescriptor> result;
+    for (auto [key, value] : map) {
+        if (value.has_value()) {
+            result.emplace(key, std::move(value.value()));
+        }
+    }
+    return result;
+}
+
 DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
     std::string const& type,
     std::string const& data) {
@@ -90,12 +102,19 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
                 kErrorParsingPut);
             return DataSourceEventHandler::MessageStatus::kInvalidMessage;
         }
-        auto res = boost::json::value_to<tl::expected<
-            std::unordered_map<std::string, ItemDescriptor>, JsonError>>(
-            parsed);
+        auto res = boost::json::value_to<
+            tl::expected<std::optional<std::unordered_map<
+                             std::string, std::optional<ItemDescriptor>>>,
+                         JsonError>>(parsed);
 
         if (res.has_value()) {
-            handler_.Init(context_, res.value());
+            // If the map was null or omitted, treat it like an empty data set.
+            auto map = res.value().value_or(
+                std::unordered_map<std::string,
+                                   std::optional<ItemDescriptor>>{});
+            // If any map value is null or omitted, remove it.
+            auto filtered = remove_nulls(std::move(map));
+            handler_.Init(context_, std::move(filtered));
             status_manager_.SetState(DataSourceStatus::DataSourceState::kValid);
             return DataSourceEventHandler::MessageStatus::kMessageHandled;
         }

--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -34,13 +34,14 @@ static tl::expected<DataSourceEventHandler::PatchData, JsonError> tag_invoke(
         auto const& obj = json_value.as_object();
         auto const* key_iter = obj.find("key");
         auto key = ValueAsOpt<std::string>(key_iter, obj.end());
-        auto result =
-            boost::json::value_to<tl::expected<EvaluationResult, JsonError>>(
-                json_value);
+        auto result = boost::json::value_to<
+            tl::expected<std::optional<EvaluationResult>, JsonError>>(
+            json_value);
 
-        if (result.has_value() && key.has_value()) {
+        if (result.has_value() && result.value().has_value() &&
+            key.has_value()) {
             return DataSourceEventHandler::PatchData{key.value(),
-                                                     result.value()};
+                                                     result.value().value()};
         }
     }
     return tl::unexpected(JsonError::kSchemaFailure);

--- a/libs/client-sdk/src/data_sources/data_source_update_sink.hpp
+++ b/libs/client-sdk/src/data_sources/data_source_update_sink.hpp
@@ -9,11 +9,11 @@
 #include <launchdarkly/config/shared/built/service_endpoints.hpp>
 #include <launchdarkly/context.hpp>
 #include <launchdarkly/data/evaluation_result.hpp>
-#include <launchdarkly/data_kinds/item_descriptor.hpp>
+#include <launchdarkly/data_model/item_descriptor.hpp>
 
 namespace launchdarkly::client_side {
 
-using ItemDescriptor = data_kinds::ItemDescriptor<EvaluationResult>;
+using ItemDescriptor = data_model::ItemDescriptor<EvaluationResult>;
 
 /**
  * Interface for handling updates from LaunchDarkly.

--- a/libs/client-sdk/src/flag_manager/flag_persistence.cpp
+++ b/libs/client-sdk/src/flag_manager/flag_persistence.cpp
@@ -4,6 +4,7 @@
 #include <launchdarkly/encoding/sha_256.hpp>
 
 #include <launchdarkly/serialization/json_evaluation_result.hpp>
+#include <launchdarkly/serialization/json_item_descriptor.hpp>
 
 #include <utility>
 

--- a/libs/client-sdk/tests/data_source_event_handler_test.cpp
+++ b/libs/client-sdk/tests/data_source_event_handler_test.cpp
@@ -90,7 +90,7 @@ TEST(StreamingDataHandlerTests, BadSchemaPut) {
         ContextBuilder().Kind("user", "user-key").Build(), test_handler, logger,
         status_manager);
 
-    auto res = stream_handler.HandleMessage("put", "{\"potato\": {}}");
+    auto res = stream_handler.HandleMessage("put", "{\"potato\": 3}");
 
     EXPECT_EQ(DataSourceEventHandler::MessageStatus::kInvalidMessage, res);
     EXPECT_EQ(0, test_handler.count_);

--- a/libs/common/include/launchdarkly/attribute_reference.hpp
+++ b/libs/common/include/launchdarkly/attribute_reference.hpp
@@ -15,8 +15,9 @@ namespace launchdarkly {
  * launchdarkly::Context::Get, or to identify an attribute or nested value that
  * should be considered private
  * with launchdarkly::AttributesBuilder<BuilderReturn, BuildType>::SetPrivate or
- * launchdarkly::AttributesBuilder<BuilderReturn, BuildType>::AddPrivateAttribute
- * (the SDK configuration can also have a list of private attribute references).
+ * launchdarkly::AttributesBuilder<BuilderReturn,
+ * BuildType>::AddPrivateAttribute (the SDK configuration can also have a list
+ * of private attribute references).
  *
  *  This is represented as a separate type, rather than just a string, so that
  * validation and parsing can be done ahead of time if an attribute reference
@@ -122,6 +123,11 @@ class AttributeReference {
      * @param ref_str The string to make an attribute reference from.
      */
     AttributeReference(char const* ref_str);
+
+    /**
+     * Default constructs an invalid attribute reference.
+     */
+    explicit AttributeReference();
 
     bool operator==(AttributeReference const& other) const {
         return components_ == other.components_;

--- a/libs/common/src/attribute_reference.cpp
+++ b/libs/common/src/attribute_reference.cpp
@@ -226,6 +226,8 @@ AttributeReference::AttributeReference(std::string ref_str)
 AttributeReference::AttributeReference(char const* ref_str)
     : AttributeReference(std::string(ref_str)) {}
 
+AttributeReference::AttributeReference() : AttributeReference("") {}
+
 std::string AttributeReference::PathToStringReference(
     std::vector<std::string_view> path) {
     // Approximate size to reduce resizes.

--- a/libs/internal/include/launchdarkly/data_model/item_descriptor.hpp
+++ b/libs/internal/include/launchdarkly/data_model/item_descriptor.hpp
@@ -61,48 +61,4 @@ template <typename T>
 ItemDescriptor<T>::ItemDescriptor(T item)
     : version(item.Version()), item(std::move(item)) {}
 
-template <typename T>
-tl::expected<std::unordered_map<std::string, ItemDescriptor<T>>, JsonError>
-tag_invoke(boost::json::value_to_tag<
-               tl::expected<std::unordered_map<std::string, ItemDescriptor<T>>,
-                            JsonError>> const& unused,
-           boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-
-    if (!json_value.is_object()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
-    }
-    auto const& obj = json_value.as_object();
-    std::unordered_map<std::string, ItemDescriptor<T>> descriptors;
-    for (auto const& pair : obj) {
-        auto eval_result =
-            boost::json::value_to<tl::expected<T, JsonError>>(pair.value());
-        if (!eval_result.has_value()) {
-            return tl::unexpected(JsonError::kSchemaFailure);
-        }
-        descriptors.emplace(pair.key(),
-                            ItemDescriptor<T>(std::move(eval_result.value())));
-    }
-    return descriptors;
-}
-
-template <typename T>
-void tag_invoke(
-    boost::json::value_from_tag const& unused,
-    boost::json::value& json_value,
-    std::unordered_map<std::string, std::shared_ptr<ItemDescriptor<T>>> const&
-        all_flags) {
-    boost::ignore_unused(unused);
-
-    auto& obj = json_value.emplace_object();
-    for (auto descriptor : all_flags) {
-        // Only serialize non-deleted items..
-        if (descriptor.second->item) {
-            auto eval_result_json =
-                boost::json::value_from(*descriptor.second->item);
-            obj.emplace(descriptor.first, eval_result_json);
-        }
-    }
-}
-
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/item_descriptor.hpp
+++ b/libs/internal/include/launchdarkly/data_model/item_descriptor.hpp
@@ -8,7 +8,7 @@
 #include <tl/expected.hpp>
 #include <unordered_map>
 
-namespace launchdarkly::data_kinds {
+namespace launchdarkly::data_model {
 /**
  * An item descriptor is an abstraction that allows for Flag data to be
  * handled using the same type in both a put or a patch.
@@ -105,4 +105,4 @@ void tag_invoke(
     }
 }
 
-}  // namespace launchdarkly::data_kinds
+}  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <boost/json/value.hpp>
+#include <launchdarkly/data_model/item_descriptor.hpp>
+#include <launchdarkly/data_model/segment.hpp>
+#include <tl/expected.hpp>
+#include <unordered_map>
+
+namespace launchdarkly::data_model {
+
+struct SDKDataSet {
+    using FlagKey = std::string;
+    using SegmentKey = std::string;
+    // std::unordered_map<FlagKey, ItemDescriptor<Flag>> flags;
+    std::unordered_map<SegmentKey, ItemDescriptor<Segment>> segments;
+};
+
+tl::expected<SDKDataSet, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<SDKDataSet, JsonError>> const&
+        unused,
+    boost::json::value const& json_value);
+
+}  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -13,7 +13,8 @@ struct SDKDataSet {
     using FlagKey = std::string;
     using SegmentKey = std::string;
     // std::unordered_map<FlagKey, ItemDescriptor<Flag>> flags;
-    std::optional<std::unordered_map<SegmentKey, ItemDescriptor<Segment>>>
+    std::optional<
+        std::unordered_map<SegmentKey, std::optional<ItemDescriptor<Segment>>>>
         segments;
 };
 

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -3,6 +3,7 @@
 #include <boost/json/value.hpp>
 #include <launchdarkly/data_model/item_descriptor.hpp>
 #include <launchdarkly/data_model/segment.hpp>
+#include <optional>
 #include <tl/expected.hpp>
 #include <unordered_map>
 
@@ -12,7 +13,8 @@ struct SDKDataSet {
     using FlagKey = std::string;
     using SegmentKey = std::string;
     // std::unordered_map<FlagKey, ItemDescriptor<Flag>> flags;
-    std::unordered_map<SegmentKey, ItemDescriptor<Segment>> segments;
+    std::optional<std::unordered_map<SegmentKey, ItemDescriptor<Segment>>>
+        segments;
 };
 
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -15,9 +15,4 @@ struct SDKDataSet {
     std::unordered_map<SegmentKey, ItemDescriptor<Segment>> segments;
 };
 
-tl::expected<SDKDataSet, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<SDKDataSet, JsonError>> const&
-        unused,
-    boost::json::value const& json_value);
-
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -17,9 +17,9 @@ struct Segment {
         std::vector<std::string> values;
     };
     struct Clause {
-        AttributeReference attribute;
+        // AttributeReference attribute;
         std::string op;
-        std::vector<Value> values;
+        // std::vector<Value> values;
 
         std::optional<bool> negate;
         std::optional<std::string> contextKind;
@@ -32,7 +32,7 @@ struct Segment {
         std::optional<std::string> rolloutContextKind;
     };
     std::string key;
-    std::size_t version;
+    std::uint64_t version;
 
     std::optional<std::vector<std::string>> included;
     std::optional<std::vector<std::string>> excluded;
@@ -42,6 +42,8 @@ struct Segment {
     std::optional<std::string> salt;
     std::optional<bool> unbounded;
     std::optional<std::string> unboundedContextKind;
-    std::optional<std::size_t> generation;
+    std::optional<std::uint64_t> generation;
+
+    [[nodiscard]] inline std::uint64_t Version() const { return version; }
 };
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -47,7 +47,7 @@ struct Segment {
         std::vector<Clause> clauses;
         std::optional<std::string> id;
         std::optional<std::uint64_t> weight;
-        std::optional<std::string> bucketBy;
+        std::optional<AttributeReference> bucketBy;
         std::optional<std::string> rolloutContextKind;
     };
     std::string key;

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -17,9 +17,28 @@ struct Segment {
         std::vector<std::string> values;
     };
     struct Clause {
-        // AttributeReference attribute;
-        std::string op;
-        // std::vector<Value> values;
+        enum class Op {
+            kUnrecognized,
+            kIn,
+            kStartsWith,
+            kEndsWith,
+            kMatches,
+            kContains,
+            kLessThan,
+            kLessThanOrEqual,
+            kGreaterThan,
+            kGreaterThanOrEqual,
+            kBefore,
+            kAfter,
+            kSemVerEqual,
+            kSemVerLessThan,
+            kSemVerGreaterThan,
+            kSegmentMatch
+        };
+
+        AttributeReference attribute;
+        Op op;
+        std::vector<Value> values;
 
         std::optional<bool> negate;
         std::optional<std::string> contextKind;

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <boost/json/value.hpp>
+#include <launchdarkly/attribute_reference.hpp>
+#include <launchdarkly/value.hpp>
+#include <optional>
+#include <string>
+#include <tl/expected.hpp>
+#include <unordered_map>
+#include <vector>
+
+namespace launchdarkly::data_model {
+
+struct Segment {
+    struct Target {
+        std::string contextKind;
+        std::vector<std::string> values;
+    };
+    struct Clause {
+        AttributeReference attribute;
+        std::string op;
+        std::vector<Value> values;
+
+        std::optional<bool> negate;
+        std::optional<std::string> contextKind;
+    };
+    struct Rule {
+        std::vector<Clause> clauses;
+        std::optional<std::string> id;
+        std::optional<std::uint64_t> weight;
+        std::optional<std::string> bucketBy;
+        std::optional<std::string> rolloutContextKind;
+    };
+    std::string key;
+    std::size_t version;
+
+    std::optional<std::vector<std::string>> included;
+    std::optional<std::vector<std::string>> excluded;
+    std::optional<std::vector<Target>> includedContexts;
+    std::optional<std::vector<Target>> excludedContexts;
+    std::optional<std::vector<Rule>> rules;
+    std::optional<std::string> salt;
+    std::optional<bool> unbounded;
+    std::optional<std::string> unboundedContextKind;
+    std::optional<std::size_t> generation;
+};
+}  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -18,7 +18,8 @@ struct Segment {
     };
     struct Clause {
         enum class Op {
-            kUnrecognized,
+            kOmitted,      /* represents empty string */
+            kUnrecognized, /* didn't match any known operators */
             kIn,
             kStartsWith,
             kEndsWith,
@@ -36,7 +37,7 @@ struct Segment {
             kSegmentMatch
         };
 
-        AttributeReference attribute;
+        std::optional<AttributeReference> attribute;
         Op op;
         std::vector<Value> values;
 

--- a/libs/internal/include/launchdarkly/serialization/json_evaluation_result.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_evaluation_result.hpp
@@ -18,6 +18,11 @@ tl::expected<EvaluationResult, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value);
 
+tl::expected<std::optional<EvaluationResult>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<EvaluationResult>, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
 void tag_invoke(boost::json::value_from_tag const& unused,
                 boost::json::value& json_value,
                 EvaluationResult const& evaluation_result);

--- a/libs/internal/include/launchdarkly/serialization/json_evaluation_result.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_evaluation_result.hpp
@@ -8,15 +8,6 @@
 #include "json_errors.hpp"
 
 namespace launchdarkly {
-/**
- * Method used by boost::json for converting a boost::json::value into a
- * launchdarkly::EvaluationResult.
- * @return A EvaluationResult representation of the boost::json::value.
- */
-tl::expected<EvaluationResult, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<EvaluationResult, JsonError>> const&
-        unused,
-    boost::json::value const& json_value);
 
 tl::expected<std::optional<EvaluationResult>, JsonError> tag_invoke(
     boost::json::value_to_tag<

--- a/libs/internal/include/launchdarkly/serialization/json_item_descriptor.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_item_descriptor.hpp
@@ -27,7 +27,7 @@ tag_invoke(boost::json::value_to_tag<tl::expected<
         auto eval_result =
             boost::json::value_to<tl::expected<T, JsonError>>(pair.value());
         if (!eval_result.has_value()) {
-            return tl::unexpected(JsonError::kSchemaFailure);
+            return tl::unexpected(eval_result.error());
         }
         descriptors.emplace(pair.key(), data_model::ItemDescriptor<T>(
                                             std::move(eval_result.value())));

--- a/libs/internal/include/launchdarkly/serialization/json_item_descriptor.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_item_descriptor.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <tl/expected.hpp>
+
+#include <boost/json.hpp>
+
+#include <launchdarkly/data_model/item_descriptor.hpp>
+#include "json_errors.hpp"
+
+namespace launchdarkly {
+
+template <typename T>
+tl::expected<std::unordered_map<std::string, data_model::ItemDescriptor<T>>,
+             JsonError>
+tag_invoke(boost::json::value_to_tag<tl::expected<
+               std::unordered_map<std::string, data_model::ItemDescriptor<T>>,
+               JsonError>> const& unused,
+           boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    if (!json_value.is_object()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    auto const& obj = json_value.as_object();
+    std::unordered_map<std::string, data_model::ItemDescriptor<T>> descriptors;
+    for (auto const& pair : obj) {
+        auto eval_result =
+            boost::json::value_to<tl::expected<T, JsonError>>(pair.value());
+        if (!eval_result.has_value()) {
+            return tl::unexpected(JsonError::kSchemaFailure);
+        }
+        descriptors.emplace(pair.key(), data_model::ItemDescriptor<T>(
+                                            std::move(eval_result.value())));
+    }
+    return descriptors;
+}
+
+template <typename T>
+void tag_invoke(
+    boost::json::value_from_tag const& unused,
+    boost::json::value& json_value,
+    std::unordered_map<std::string,
+                       std::shared_ptr<data_model::ItemDescriptor<T>>> const&
+        all_flags) {
+    boost::ignore_unused(unused);
+
+    auto& obj = json_value.emplace_object();
+    for (auto descriptor : all_flags) {
+        // Only serialize non-deleted items..
+        if (descriptor.second->item) {
+            auto eval_result_json =
+                boost::json::value_from(*descriptor.second->item);
+            obj.emplace(descriptor.first, eval_result_json);
+        }
+    }
+}
+}  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/json.hpp>
+#include <tl/expected.hpp>
+#include "json_errors.hpp"
+
+namespace launchdarkly {
+
+template <typename T>
+tl::expected<std::vector<T>, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::vector<T>, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    if (!json_value.is_array()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    auto const& arr = json_value.as_array();
+    std::vector<T> items;
+    items.reserve(arr.size());
+    for (auto const& item : arr) {
+        auto eval_result =
+            boost::json::value_to<tl::expected<T, JsonError>>(item);
+        if (!eval_result.has_value()) {
+            return tl::unexpected(eval_result.error());
+        }
+        items.emplace_back(std::move(eval_result.value()));
+    }
+    return items;
+}
+
+tl::expected<bool, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+tl::expected<std::uint64_t, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::uint64_t, JsonError>> const&
+        unused,
+    boost::json::value const& json_value);
+
+tl::expected<std::string, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::string, JsonError>> const&
+        unused,
+    boost::json::value const& json_value);
+}  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
@@ -40,27 +40,9 @@ tl::expected<std::optional<std::vector<T>>, JsonError> tag_invoke(
     return items;
 }
 
-template <typename T>
-tl::expected<std::vector<T>, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::vector<T>, JsonError>> const&
-        unused,
-    boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-    auto maybe_val = boost::json::value_to<
-        tl::expected<std::optional<std::vector<T>>, JsonError>>(json_value);
-    if (!maybe_val.has_value()) {
-        return tl::unexpected(maybe_val.error());
-    }
-    return maybe_val.value().value_or(std::vector<T>{});
-}
-
 tl::expected<std::optional<bool>, JsonError> tag_invoke(
     boost::json::value_to_tag<
         tl::expected<std::optional<bool>, JsonError>> const& unused,
-    boost::json::value const& json_value);
-
-tl::expected<bool, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
     boost::json::value const& json_value);
 
 tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
@@ -68,19 +50,9 @@ tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
         tl::expected<std::optional<std::uint64_t>, JsonError>> const& unused,
     boost::json::value const& json_value);
 
-tl::expected<std::uint64_t, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::uint64_t, JsonError>> const&
-        unused,
-    boost::json::value const& json_value);
-
 tl::expected<std::optional<std::string>, JsonError> tag_invoke(
     boost::json::value_to_tag<
         tl::expected<std::optional<std::string>, JsonError>> const& unused,
-    boost::json::value const& json_value);
-
-tl::expected<std::string, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::string, JsonError>> const&
-        unused,
     boost::json::value const& json_value);
 
 template <typename K, typename V>
@@ -113,20 +85,27 @@ tl::expected<std::optional<std::unordered_map<K, V>>, JsonError> tag_invoke(
     return descriptors;
 }
 
-template <typename K, typename V>
-tl::expected<std::unordered_map<K, V>, JsonError> tag_invoke(
-    boost::json::value_to_tag<
-        tl::expected<std::unordered_map<K, V>, JsonError>> const& unused,
+/**
+ * Convenience implementation that deserializes a T via the tag_invoke overload
+ * for std::optional<T>.
+ *
+ * If that overload returns std::nullopt, this returns
+ * a default-constructed T.
+ *
+ * Json errors are propagated.
+ */
+template <typename T>
+tl::expected<T, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<T, JsonError>> const& unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
-    auto maybe_val = boost::json::value_to<
-        tl::expected<std::optional<std::unordered_map<K, V>>, JsonError>>(
-        json_value);
+    auto maybe_val =
+        boost::json::value_to<tl::expected<std::optional<T>, JsonError>>(
+            json_value);
     if (!maybe_val.has_value()) {
         return tl::unexpected(maybe_val.error());
     }
-    auto const& val = maybe_val.value();
-    return val.value_or(std::unordered_map<K, V>{});
+    return maybe_val.value().value_or(T{});
 }
 
 }  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
@@ -8,15 +8,24 @@
 namespace launchdarkly {
 
 template <typename T>
-tl::expected<std::vector<T>, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::vector<T>, JsonError>> const&
-        unused,
+tl::expected<std::optional<std::vector<T>>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::vector<T>>, JsonError>> const& unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
+
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
 
     if (!json_value.is_array()) {
         return tl::unexpected(JsonError::kSchemaFailure);
     }
+
+    if (json_value.as_array().empty()) {
+        return std::nullopt;
+    }
+
     auto const& arr = json_value.as_array();
     std::vector<T> items;
     items.reserve(arr.size());
@@ -31,8 +40,32 @@ tl::expected<std::vector<T>, JsonError> tag_invoke(
     return items;
 }
 
+template <typename T>
+tl::expected<std::vector<T>, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::vector<T>, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    auto maybe_val = boost::json::value_to<
+        tl::expected<std::optional<std::vector<T>>, JsonError>>(json_value);
+    if (!maybe_val.has_value()) {
+        return tl::unexpected(maybe_val.error());
+    }
+    return maybe_val.value().value_or(std::vector<T>{});
+}
+
+tl::expected<std::optional<bool>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<bool>, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
 tl::expected<bool, JsonError> tag_invoke(
     boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::uint64_t>, JsonError>> const& unused,
     boost::json::value const& json_value);
 
 tl::expected<std::uint64_t, JsonError> tag_invoke(
@@ -40,8 +73,60 @@ tl::expected<std::uint64_t, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value);
 
+tl::expected<std::optional<std::string>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::string>, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
 tl::expected<std::string, JsonError> tag_invoke(
     boost::json::value_to_tag<tl::expected<std::string, JsonError>> const&
         unused,
     boost::json::value const& json_value);
+
+template <typename K, typename V>
+tl::expected<std::optional<std::unordered_map<K, V>>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::unordered_map<K, V>>, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
+    if (!json_value.is_object()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    if (json_value.as_object().empty()) {
+        return std::nullopt;
+    }
+    auto const& obj = json_value.as_object();
+    std::unordered_map<K, V> descriptors;
+    for (auto const& pair : obj) {
+        auto eval_result =
+            boost::json::value_to<tl::expected<V, JsonError>>(pair.value());
+        if (!eval_result.has_value()) {
+            return tl::unexpected(eval_result.error());
+        }
+        descriptors.emplace(pair.key(), eval_result.value());
+    }
+    return descriptors;
+}
+
+template <typename K, typename V>
+tl::expected<std::unordered_map<K, V>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::unordered_map<K, V>, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    auto maybe_val = boost::json::value_to<
+        tl::expected<std::optional<std::unordered_map<K, V>>, JsonError>>(
+        json_value);
+    if (!maybe_val.has_value()) {
+        return tl::unexpected(maybe_val.error());
+    }
+    auto const& val = maybe_val.value();
+    return val.value_or(std::unordered_map<K, V>{});
+}
+
 }  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_sdk_data_set.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <launchdarkly/data_model/sdk_data_set.hpp>
+
+namespace launchdarkly {
+tl::expected<data_model::SDKDataSet, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::SDKDataSet, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+}

--- a/libs/internal/include/launchdarkly/serialization/json_segment.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_segment.hpp
@@ -14,4 +14,19 @@ tl::expected<data_model::Segment::Target, JsonError> tag_invoke(
         tl::expected<data_model::Segment::Target, JsonError>> const& unused,
     boost::json::value const& json_value);
 
+tl::expected<data_model::Segment::Rule, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Rule, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+tl::expected<data_model::Segment::Clause, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Clause, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+tl::expected<data_model::Segment::Clause::Op, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Clause::Op, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
 }  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_segment.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_segment.hpp
@@ -4,9 +4,9 @@
 #include <launchdarkly/serialization/json_errors.hpp>
 
 namespace launchdarkly {
-tl::expected<data_model::Segment, JsonError> tag_invoke(
-    boost::json::value_to_tag<
-        tl::expected<data_model::Segment, JsonError>> const& unused,
+tl::expected<std::optional<data_model::Segment>, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::optional<data_model::Segment>,
+                                           JsonError>> const& unused,
     boost::json::value const& json_value);
 
 tl::expected<data_model::Segment::Target, JsonError> tag_invoke(
@@ -23,6 +23,12 @@ tl::expected<data_model::Segment::Clause, JsonError> tag_invoke(
     boost::json::value_to_tag<
         tl::expected<data_model::Segment::Clause, JsonError>> const& unused,
     boost::json::value const& json_value);
+
+tl::expected<std::optional<data_model::Segment::Clause::Op>, JsonError>
+tag_invoke(boost::json::value_to_tag<
+               tl::expected<std::optional<data_model::Segment::Clause::Op>,
+                            JsonError>> const& unused,
+           boost::json::value const& json_value);
 
 tl::expected<data_model::Segment::Clause::Op, JsonError> tag_invoke(
     boost::json::value_to_tag<

--- a/libs/internal/include/launchdarkly/serialization/json_segment.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_segment.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <launchdarkly/data_model/segment.hpp>
+#include <launchdarkly/serialization/json_errors.hpp>
+
+namespace launchdarkly {
+tl::expected<data_model::Segment, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+tl::expected<data_model::Segment::Target, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Target, JsonError>> const& unused,
+    boost::json::value const& json_value);
+
+}  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_value.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_value.hpp
@@ -2,7 +2,9 @@
 
 #include <boost/json.hpp>
 
+#include <launchdarkly/serialization/json_errors.hpp>
 #include <launchdarkly/value.hpp>
+#include <tl/expected.hpp>
 
 namespace launchdarkly {
 /**
@@ -12,6 +14,10 @@ namespace launchdarkly {
  */
 Value tag_invoke(boost::json::value_to_tag<Value> const&,
                  boost::json::value const&);
+
+tl::expected<Value, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<Value, JsonError>> const&,
+    boost::json::value const&);
 
 /**
  * Method used by boost::json for converting a launchdarkly::Value into a

--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -72,14 +72,8 @@ tl::expected<std::optional<T>, JsonError> ParseOptionalField(
     if (it == obj.end()) {
         return std::nullopt;
     }
-    if (it->value().is_null()) {
-        return std::nullopt;
-    }
-    auto val = boost::json::value_to<tl::expected<T, JsonError>>(it->value());
-    if (!val) {
-        return tl::make_unexpected(val.error());
-    }
-    return std::make_optional(val.value());
+    return boost::json::value_to<tl::expected<std::optional<T>, JsonError>>(
+        it->value());
 }
 
 template <typename T>
@@ -100,16 +94,9 @@ tl::expected<T, JsonError> ParseRequiredField(boost::json::object const& obj,
                                               std::string const& field_name) {
     auto const& it = obj.find(field_name);
     if (it == obj.end()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
+        return tl::make_unexpected(JsonError::kSchemaFailure);
     }
-    if (it->value().is_null()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
-    }
-    auto val = boost::json::value_to<tl::expected<T, JsonError>>(it->value());
-    if (!val) {
-        return tl::make_unexpected(val.error());
-    }
-    return val.value();
+    return boost::json::value_to<tl::expected<T, JsonError>>(it->value());
 }
 
 template <typename T>

--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -1,9 +1,32 @@
 #pragma once
 
 #include <boost/json.hpp>
+#include <launchdarkly/serialization/json_errors.hpp>
+#include <launchdarkly/serialization/json_primitives.hpp>
+#include <tl/expected.hpp>
+
+#define PARSE_OPTIONAL_FIELD(field, obj, key)                            \
+    do {                                                                 \
+        if (auto error = ParseOptionalFieldOutParam(obj, key, &field)) { \
+            return tl::make_unexpected(error.value());                   \
+        }                                                                \
+    } while (0)
+
+#define PARSE_REQUIRED_FIELD(field, obj, key)                            \
+    do {                                                                 \
+        if (auto error = ParseRequiredFieldOutParam(obj, key, &field)) { \
+            return tl::make_unexpected(error.value());                   \
+        }                                                                \
+    } while (0)
+
+#define REQUIRE_OBJECT(value)                                      \
+    do {                                                           \
+        if (!json_value.is_object()) {                             \
+            return tl::make_unexpected(JsonError::kSchemaFailure); \
+        }                                                          \
+    } while (0)
 
 namespace launchdarkly {
-
 template <typename Type>
 std::optional<Type> ValueAsOpt(boost::json::object::const_iterator iterator,
                                boost::json::object::const_iterator end) {
@@ -34,9 +57,82 @@ std::optional<OutType> MapOpt(std::optional<InType> opt,
     return std::nullopt;
 }
 
+template <typename T>
+tl::expected<std::optional<T>, JsonError> ParseOptionalField(
+    boost::json::object const& obj,
+    std::string const& field_name) {
+    auto const& it = obj.find(field_name);
+    if (it == obj.end()) {
+        return std::nullopt;
+    }
+    if (it->value().is_null()) {
+        return std::nullopt;
+    }
+    auto val = boost::json::value_to<tl::expected<T, JsonError>>(it->value());
+    if (!val) {
+        return tl::make_unexpected(val.error());
+    }
+    return std::make_optional(val.value());
+}
+
+template <typename T>
+std::optional<JsonError> ParseOptionalFieldOutParam(
+    boost::json::object const& obj,
+    std::string const& field_name,
+    std::optional<T>* out_value) {
+    auto maybe_opt_val = ParseOptionalField<T>(obj, field_name);
+    if (!maybe_opt_val) {
+        return maybe_opt_val.error();
+    }
+    *out_value = std::move(maybe_opt_val.value());
+    return std::nullopt;
+}
+
+template <typename T>
+tl::expected<T, JsonError> ParseRequiredField(boost::json::object const& obj,
+                                              std::string const& field_name) {
+    auto const& it = obj.find(field_name);
+    if (it == obj.end()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    if (it->value().is_null()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    auto val = boost::json::value_to<tl::expected<T, JsonError>>(it->value());
+    if (!val) {
+        return tl::make_unexpected(val.error());
+    }
+    return val.value();
+}
+
+template <typename T>
+std::optional<JsonError> ParseRequiredFieldOutParam(
+    boost::json::object const& obj,
+    std::string const& field_name,
+    T* out_value) {
+    auto maybe_val = ParseRequiredField<T>(obj, field_name);
+    if (!maybe_val) {
+        return maybe_val.error();
+    }
+    *out_value = std::move(maybe_val.value());
+    return std::nullopt;
+}
+
 template <>
 std::optional<uint64_t> ValueAsOpt(boost::json::object::const_iterator iterator,
                                    boost::json::object::const_iterator end);
+
+template <>
+std::optional<bool> ValueAsOpt(boost::json::object::const_iterator iterator,
+                               boost::json::object::const_iterator end);
+
+// Returns std::nullopt if:
+// - The iterator value is not an array
+// - ANY element of the array is not a string
+template <>
+std::optional<std::vector<std::string>> ValueAsOpt(
+    boost::json::object::const_iterator iterator,
+    boost::json::object::const_iterator end);
 
 template <>
 std::optional<std::string> ValueAsOpt(

--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -26,6 +26,13 @@
         }                                                          \
     } while (0)
 
+#define REQUIRE_STRING(value)                                      \
+    do {                                                           \
+        if (!json_value.is_string()) {                             \
+            return tl::make_unexpected(JsonError::kSchemaFailure); \
+        }                                                          \
+    } while (0)
+
 namespace launchdarkly {
 template <typename Type>
 std::optional<Type> ValueAsOpt(boost::json::object::const_iterator iterator,

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -31,9 +31,9 @@ add_library(${LIBNAME} OBJECT
         serialization/json_value.cpp
         serialization/value_mapping.cpp
         serialization/json_evaluation_result.cpp
+        serialization/json_sdk_data_set.cpp
         encoding/base_64.cpp
-        encoding/sha_256.cpp
-        data_model/sdk_data_set.cpp)
+        encoding/sha_256.cpp)
 
 add_library(launchdarkly::internal ALIAS ${LIBNAME})
 

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(${LIBNAME} OBJECT
         serialization/value_mapping.cpp
         serialization/json_evaluation_result.cpp
         encoding/base_64.cpp
-        encoding/sha_256.cpp)
+        encoding/sha_256.cpp
+        data_model/sdk_data_set.cpp)
 
 add_library(launchdarkly::internal ALIAS ${LIBNAME})
 

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(${LIBNAME} OBJECT
         serialization/value_mapping.cpp
         serialization/json_evaluation_result.cpp
         serialization/json_sdk_data_set.cpp
+        serialization/json_segment.cpp
+        serialization/json_primitives.cpp
         encoding/base_64.cpp
         encoding/sha_256.cpp)
 

--- a/libs/internal/src/data_model/sdk_data_set.cpp
+++ b/libs/internal/src/data_model/sdk_data_set.cpp
@@ -1,3 +1,0 @@
-#include <launchdarkly/data_model/sdk_data_set.hpp>
-
-namespace launchdarkly::data_model {}

--- a/libs/internal/src/data_model/sdk_data_set.cpp
+++ b/libs/internal/src/data_model/sdk_data_set.cpp
@@ -1,0 +1,3 @@
+#include <launchdarkly/data_model/sdk_data_set.hpp>
+
+namespace launchdarkly::data_model {}

--- a/libs/internal/src/serialization/json_evaluation_result.cpp
+++ b/libs/internal/src/serialization/json_evaluation_result.cpp
@@ -6,22 +6,6 @@
 #include <boost/core/ignore_unused.hpp>
 
 namespace launchdarkly {
-tl::expected<EvaluationResult, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<EvaluationResult, JsonError>> const&
-        unused,
-    boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-    auto maybe_result = boost::json::value_to<
-        tl::expected<std::optional<EvaluationResult>, JsonError>>(json_value);
-    if (!maybe_result) {
-        return tl::unexpected(maybe_result.error());
-    }
-    auto const& result = maybe_result.value();
-    if (!result.has_value()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
-    }
-    return *result;
-}
 
 tl::expected<std::optional<EvaluationResult>, JsonError> tag_invoke(
     boost::json::value_to_tag<

--- a/libs/internal/src/serialization/json_evaluation_result.cpp
+++ b/libs/internal/src/serialization/json_evaluation_result.cpp
@@ -11,87 +11,106 @@ tl::expected<EvaluationResult, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
-    if (json_value.is_object()) {
-        auto& json_obj = json_value.as_object();
+    auto maybe_result = boost::json::value_to<
+        tl::expected<std::optional<EvaluationResult>, JsonError>>(json_value);
+    if (!maybe_result) {
+        return tl::unexpected(maybe_result.error());
+    }
+    auto const& result = maybe_result.value();
+    if (!result.has_value()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    return *result;
+}
 
-        auto* version_iter = json_obj.find("version");
-        auto version_opt = ValueAsOpt<uint64_t>(version_iter, json_obj.end());
-        if (!version_opt.has_value()) {
-            return tl::unexpected(JsonError::kSchemaFailure);
-        }
-        auto version = version_opt.value();
+tl::expected<std::optional<EvaluationResult>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<EvaluationResult>, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
+    if (!json_value.is_object()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    if (json_value.as_object().empty()) {
+        return std::nullopt;
+    }
+    auto const& json_obj = json_value.as_object();
 
-        auto* flag_version_iter = json_obj.find("flagVersion");
-        auto flag_version =
-            ValueAsOpt<uint64_t>(flag_version_iter, json_obj.end());
+    auto* version_iter = json_obj.find("version");
+    auto version_opt = ValueAsOpt<uint64_t>(version_iter, json_obj.end());
+    if (!version_opt.has_value()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    auto version = version_opt.value();
 
-        auto* track_events_iter = json_obj.find("trackEvents");
-        auto track_events =
-            ValueOrDefault(track_events_iter, json_obj.end(), false);
+    auto* flag_version_iter = json_obj.find("flagVersion");
+    auto flag_version = ValueAsOpt<uint64_t>(flag_version_iter, json_obj.end());
 
-        auto* track_reason_iter = json_obj.find("trackReason");
-        auto track_reason =
-            ValueOrDefault(track_reason_iter, json_obj.end(), false);
+    auto* track_events_iter = json_obj.find("trackEvents");
+    auto track_events =
+        ValueOrDefault(track_events_iter, json_obj.end(), false);
 
-        auto* debug_events_until_date_iter =
-            json_obj.find("debugEventsUntilDate");
+    auto* track_reason_iter = json_obj.find("trackReason");
+    auto track_reason =
+        ValueOrDefault(track_reason_iter, json_obj.end(), false);
 
-        auto debug_events_until_date =
-            MapOpt<std::chrono::time_point<std::chrono::system_clock>,
-                   uint64_t>(ValueAsOpt<uint64_t>(debug_events_until_date_iter,
-                                                  json_obj.end()),
-                             [](auto value) {
-                                 return std::chrono::system_clock::time_point{
-                                     std::chrono::milliseconds{value}};
-                             });
+    auto* debug_events_until_date_iter = json_obj.find("debugEventsUntilDate");
 
-        // Evaluation detail is directly de-serialized inline here.
-        // This is because the shape of the evaluation detail is different
-        // when deserializing FlagMeta. Primarily `variation` not
-        // `variationIndex`.
+    auto debug_events_until_date =
+        MapOpt<std::chrono::time_point<std::chrono::system_clock>, uint64_t>(
+            ValueAsOpt<uint64_t>(debug_events_until_date_iter, json_obj.end()),
+            [](auto value) {
+                return std::chrono::system_clock::time_point{
+                    std::chrono::milliseconds{value}};
+            });
 
-        auto* value_iter = json_obj.find("value");
-        if (value_iter == json_obj.end()) {
-            return tl::unexpected(JsonError::kSchemaFailure);
-        }
-        auto value = boost::json::value_to<Value>(value_iter->value());
+    // Evaluation detail is directly de-serialized inline here.
+    // This is because the shape of the evaluation detail is different
+    // when deserializing FlagMeta. Primarily `variation` not
+    // `variationIndex`.
 
-        auto* variation_iter = json_obj.find("variation");
-        auto variation = ValueAsOpt<uint64_t>(variation_iter, json_obj.end());
+    auto* value_iter = json_obj.find("value");
+    if (value_iter == json_obj.end()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    auto value = boost::json::value_to<Value>(value_iter->value());
 
-        auto* reason_iter = json_obj.find("reason");
+    auto* variation_iter = json_obj.find("variation");
+    auto variation = ValueAsOpt<uint64_t>(variation_iter, json_obj.end());
 
-        // There is a reason.
-        if (reason_iter != json_obj.end() && !reason_iter->value().is_null()) {
-            auto reason = boost::json::value_to<
-                tl::expected<EvaluationReason, JsonError>>(
+    auto* reason_iter = json_obj.find("reason");
+
+    // There is a reason.
+    if (reason_iter != json_obj.end() && !reason_iter->value().is_null()) {
+        auto reason =
+            boost::json::value_to<tl::expected<EvaluationReason, JsonError>>(
                 reason_iter->value());
 
-            if (reason.has_value()) {
-                return EvaluationResult{
-                    version,
-                    flag_version,
-                    track_events,
-                    track_reason,
-                    debug_events_until_date,
-                    EvaluationDetailInternal(
-                        value, variation, std::make_optional(reason.value()))};
-            }
-            // We could not parse the reason.
-            return tl::unexpected(JsonError::kSchemaFailure);
+        if (reason.has_value()) {
+            return EvaluationResult{
+                version,
+                flag_version,
+                track_events,
+                track_reason,
+                debug_events_until_date,
+                EvaluationDetailInternal(value, variation,
+                                         std::make_optional(reason.value()))};
         }
-
-        // There was no reason.
-        return EvaluationResult{
-            version,
-            flag_version,
-            track_events,
-            track_reason,
-            debug_events_until_date,
-            EvaluationDetailInternal(value, variation, std::nullopt)};
+        // We could not parse the reason.
+        return tl::unexpected(JsonError::kSchemaFailure);
     }
 
-    return tl::unexpected(JsonError::kSchemaFailure);
+    // There was no reason.
+    return EvaluationResult{
+        version,
+        flag_version,
+        track_events,
+        track_reason,
+        debug_events_until_date,
+        EvaluationDetailInternal(value, variation, std::nullopt)};
 }
 
 void tag_invoke(boost::json::value_from_tag const& unused,

--- a/libs/internal/src/serialization/json_primitives.cpp
+++ b/libs/internal/src/serialization/json_primitives.cpp
@@ -1,0 +1,40 @@
+#include <launchdarkly/serialization/json_primitives.hpp>
+
+namespace launchdarkly {
+tl::expected<bool, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    if (!json_value.is_bool()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    return json_value.as_bool();
+}
+
+tl::expected<std::uint64_t, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::uint64_t, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    if (!json_value.is_number()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    return json_value.to_number<uint64_t>();
+}
+
+tl::expected<std::string, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<std::string, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    
+    if (!json_value.is_string()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    if (json_value.as_string().empty()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    return std::string(json_value.as_string());
+}
+}  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_primitives.cpp
+++ b/libs/internal/src/serialization/json_primitives.cpp
@@ -1,15 +1,48 @@
 #include <launchdarkly/serialization/json_primitives.hpp>
 
 namespace launchdarkly {
+tl::expected<std::optional<bool>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<bool>, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
+    if (!json_value.is_bool()) {
+        return tl::unexpected(JsonError::kSchemaFailure);
+    }
+    if (!json_value.as_bool()) {
+        return std::nullopt;
+    }
+    return json_value.as_bool();
+}
+
 tl::expected<bool, JsonError> tag_invoke(
     boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
+    auto maybe_val =
+        boost::json::value_to<tl::expected<std::optional<bool>, JsonError>>(
+            json_value);
+    if (!maybe_val.has_value()) {
+        return tl::unexpected(maybe_val.error());
+    }
+    return maybe_val.value().value_or(false);
+}
 
-    if (!json_value.is_bool()) {
+tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::uint64_t>, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
+    if (!json_value.is_number()) {
         return tl::unexpected(JsonError::kSchemaFailure);
     }
-    return json_value.as_bool();
+    return json_value.to_number<uint64_t>();
 }
 
 tl::expected<std::uint64_t, JsonError> tag_invoke(
@@ -17,10 +50,29 @@ tl::expected<std::uint64_t, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
-    if (!json_value.is_number()) {
+    auto maybe_val = boost::json::value_to<
+        tl::expected<std::optional<std::uint64_t>, JsonError>>(json_value);
+    if (!maybe_val.has_value()) {
+        return tl::unexpected(maybe_val.error());
+    }
+    return maybe_val.value().value_or(0);
+}
+
+tl::expected<std::optional<std::string>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<std::string>, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+    if (json_value.is_null()) {
+        return std::nullopt;
+    }
+    if (!json_value.is_string()) {
         return tl::unexpected(JsonError::kSchemaFailure);
     }
-    return json_value.to_number<uint64_t>();
+    if (json_value.as_string().empty()) {
+        return std::nullopt;
+    }
+    return std::string(json_value.as_string());
 }
 
 tl::expected<std::string, JsonError> tag_invoke(
@@ -28,13 +80,11 @@ tl::expected<std::string, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
-    
-    if (!json_value.is_string()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
+    auto maybe_val = boost::json::value_to<
+        tl::expected<std::optional<std::string>, JsonError>>(json_value);
+    if (!maybe_val.has_value()) {
+        return tl::unexpected(maybe_val.error());
     }
-    if (json_value.as_string().empty()) {
-        return tl::unexpected(JsonError::kSchemaFailure);
-    }
-    return std::string(json_value.as_string());
+    return maybe_val.value().value_or("");
 }
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_primitives.cpp
+++ b/libs/internal/src/serialization/json_primitives.cpp
@@ -18,19 +18,6 @@ tl::expected<std::optional<bool>, JsonError> tag_invoke(
     return json_value.as_bool();
 }
 
-tl::expected<bool, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<bool, JsonError>> const& unused,
-    boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-    auto maybe_val =
-        boost::json::value_to<tl::expected<std::optional<bool>, JsonError>>(
-            json_value);
-    if (!maybe_val.has_value()) {
-        return tl::unexpected(maybe_val.error());
-    }
-    return maybe_val.value().value_or(false);
-}
-
 tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
     boost::json::value_to_tag<
         tl::expected<std::optional<std::uint64_t>, JsonError>> const& unused,
@@ -43,19 +30,6 @@ tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
         return tl::unexpected(JsonError::kSchemaFailure);
     }
     return json_value.to_number<uint64_t>();
-}
-
-tl::expected<std::uint64_t, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::uint64_t, JsonError>> const&
-        unused,
-    boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-    auto maybe_val = boost::json::value_to<
-        tl::expected<std::optional<std::uint64_t>, JsonError>>(json_value);
-    if (!maybe_val.has_value()) {
-        return tl::unexpected(maybe_val.error());
-    }
-    return maybe_val.value().value_or(0);
 }
 
 tl::expected<std::optional<std::string>, JsonError> tag_invoke(
@@ -75,16 +49,4 @@ tl::expected<std::optional<std::string>, JsonError> tag_invoke(
     return std::string(json_value.as_string());
 }
 
-tl::expected<std::string, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<std::string, JsonError>> const&
-        unused,
-    boost::json::value const& json_value) {
-    boost::ignore_unused(unused);
-    auto maybe_val = boost::json::value_to<
-        tl::expected<std::optional<std::string>, JsonError>>(json_value);
-    if (!maybe_val.has_value()) {
-        return tl::unexpected(maybe_val.error());
-    }
-    return maybe_val.value().value_or("");
-}
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_sdk_data_set.cpp
+++ b/libs/internal/src/serialization/json_sdk_data_set.cpp
@@ -1,0 +1,12 @@
+#include <launchdarkly/serialization/json_sdk_data_set.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+
+namespace launchdarkly {
+tl::expected<data_model::SDKDataSet, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::SDKDataSet, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+}
+}  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_sdk_data_set.cpp
+++ b/libs/internal/src/serialization/json_sdk_data_set.cpp
@@ -1,6 +1,9 @@
-#include <launchdarkly/serialization/json_sdk_data_set.hpp>
-
 #include <boost/core/ignore_unused.hpp>
+#include <launchdarkly/serialization/json_item_descriptor.hpp>
+#include <launchdarkly/serialization/json_sdk_data_set.hpp>
+#include <launchdarkly/serialization/json_segment.hpp>
+#include <launchdarkly/serialization/value_mapping.hpp>
+#include <tl/expected.hpp>
 
 namespace launchdarkly {
 tl::expected<data_model::SDKDataSet, JsonError> tag_invoke(
@@ -8,5 +11,15 @@ tl::expected<data_model::SDKDataSet, JsonError> tag_invoke(
         tl::expected<data_model::SDKDataSet, JsonError>> const& unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
+
+    REQUIRE_OBJECT(json_value);
+
+    auto const& obj = json_value.as_object();
+
+    data_model::SDKDataSet data_set;
+
+    PARSE_OPTIONAL_FIELD(data_set.segments, obj, "segments");
+
+    return data_set;
 }
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_segment.cpp
+++ b/libs/internal/src/serialization/json_segment.cpp
@@ -1,5 +1,7 @@
 #include <boost/core/ignore_unused.hpp>
+#include <launchdarkly/serialization/json_primitives.hpp>
 #include <launchdarkly/serialization/json_segment.hpp>
+#include <launchdarkly/serialization/json_value.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
 namespace launchdarkly {
@@ -20,6 +22,104 @@ tl::expected<data_model::Segment::Target, JsonError> tag_invoke(
     PARSE_REQUIRED_FIELD(target.values, obj, "values");
 
     return target;
+}
+
+tl::expected<data_model::Segment::Rule, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Rule, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_OBJECT(json_value);
+    auto const& obj = json_value.as_object();
+
+    data_model::Segment::Rule rule;
+
+    PARSE_REQUIRED_FIELD(rule.clauses, obj, "clauses");
+
+    PARSE_OPTIONAL_FIELD(rule.weight, obj, "weight");
+    PARSE_OPTIONAL_FIELD(rule.bucketBy, obj, "bucketBy");
+    PARSE_OPTIONAL_FIELD(rule.id, obj, "id");
+    PARSE_OPTIONAL_FIELD(rule.rolloutContextKind, obj, "rolloutContextKind");
+
+    return rule;
+}
+
+tl::expected<data_model::Segment::Clause, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Clause, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_OBJECT(json_value);
+    auto const& obj = json_value.as_object();
+
+    data_model::Segment::Clause clause;
+
+    PARSE_OPTIONAL_FIELD(clause.contextKind, obj, "contextKind");
+
+    std::string literal_or_ref;
+
+    PARSE_REQUIRED_FIELD(literal_or_ref, obj, "attribute");
+
+    if (clause.contextKind) {
+        clause.attribute =
+            AttributeReference::FromReferenceStr(std::move(literal_or_ref));
+    } else {
+        clause.attribute =
+            AttributeReference::FromLiteralStr(std::move(literal_or_ref));
+    }
+
+    PARSE_REQUIRED_FIELD(clause.op, obj, "op");
+    PARSE_REQUIRED_FIELD(clause.values, obj, "values");
+    PARSE_OPTIONAL_FIELD(clause.negate, obj, "negate");
+
+    return clause;
+}
+
+tl::expected<data_model::Segment::Clause::Op, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Clause::Op, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_STRING(json_value);
+
+    auto const& str = json_value.as_string();
+
+    if (str == "in") {
+        return data_model::Segment::Clause::Op::kIn;
+    } else if (str == "endsWith") {
+        return data_model::Segment::Clause::Op::kEndsWith;
+    } else if (str == "startsWith") {
+        return data_model::Segment::Clause::Op::kStartsWith;
+    } else if (str == "matches") {
+        return data_model::Segment::Clause::Op::kMatches;
+    } else if (str == "contains") {
+        return data_model::Segment::Clause::Op::kContains;
+    } else if (str == "lessThan") {
+        return data_model::Segment::Clause::Op::kLessThan;
+    } else if (str == "lessThanOrEqual") {
+        return data_model::Segment::Clause::Op::kLessThanOrEqual;
+    } else if (str == "greaterThan") {
+        return data_model::Segment::Clause::Op::kGreaterThan;
+    } else if (str == "greaterThanOrEqual") {
+        return data_model::Segment::Clause::Op::kGreaterThanOrEqual;
+    } else if (str == "before") {
+        return data_model::Segment::Clause::Op::kBefore;
+    } else if (str == "after") {
+        return data_model::Segment::Clause::Op::kAfter;
+    } else if (str == "semVerEqual") {
+        return data_model::Segment::Clause::Op::kSemVerEqual;
+    } else if (str == "semVerLessThan") {
+        return data_model::Segment::Clause::Op::kSemVerLessThan;
+    } else if (str == "semVerGreaterThan") {
+        return data_model::Segment::Clause::Op::kSemVerGreaterThan;
+    } else if (str == "segmentMatch") {
+        return data_model::Segment::Clause::Op::kSegmentMatch;
+    } else {
+        return data_model::Segment::Clause::Op::kUnrecognized;
+    }
 }
 
 tl::expected<data_model::Segment, JsonError> tag_invoke(
@@ -46,6 +146,8 @@ tl::expected<data_model::Segment, JsonError> tag_invoke(
 
     PARSE_OPTIONAL_FIELD(segment.includedContexts, obj, "includedContexts");
     PARSE_OPTIONAL_FIELD(segment.excludedContexts, obj, "excludedContexts");
+
+    PARSE_OPTIONAL_FIELD(segment.rules, obj, "rules");
 
     return segment;
 }

--- a/libs/internal/src/serialization/json_segment.cpp
+++ b/libs/internal/src/serialization/json_segment.cpp
@@ -35,6 +35,7 @@ tl::expected<data_model::Segment::Rule, JsonError> tag_invoke(
     data_model::Segment::Rule rule;
 
     PARSE_REQUIRED_FIELD(rule.clauses, obj, "clauses");
+
     PARSE_OPTIONAL_FIELD(rule.rolloutContextKind, obj, "rolloutContextKind");
     PARSE_OPTIONAL_FIELD(rule.weight, obj, "weight");
     PARSE_OPTIONAL_FIELD(rule.id, obj, "id");

--- a/libs/internal/src/serialization/json_segment.cpp
+++ b/libs/internal/src/serialization/json_segment.cpp
@@ -1,0 +1,52 @@
+#include <boost/core/ignore_unused.hpp>
+#include <launchdarkly/serialization/json_segment.hpp>
+#include <launchdarkly/serialization/value_mapping.hpp>
+
+namespace launchdarkly {
+
+tl::expected<data_model::Segment::Target, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment::Target, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_OBJECT(json_value);
+
+    auto const& obj = json_value.as_object();
+
+    data_model::Segment::Target target;
+
+    PARSE_REQUIRED_FIELD(target.contextKind, obj, "contextKind");
+    PARSE_REQUIRED_FIELD(target.values, obj, "values");
+
+    return target;
+}
+
+tl::expected<data_model::Segment, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<data_model::Segment, JsonError>> const& unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_OBJECT(json_value);
+
+    auto const& obj = json_value.as_object();
+
+    data_model::Segment segment;
+
+    PARSE_REQUIRED_FIELD(segment.key, obj, "key");
+    PARSE_REQUIRED_FIELD(segment.version, obj, "version");
+
+    PARSE_OPTIONAL_FIELD(segment.excluded, obj, "excluded");
+    PARSE_OPTIONAL_FIELD(segment.included, obj, "included");
+
+    PARSE_OPTIONAL_FIELD(segment.generation, obj, "generation");
+    PARSE_OPTIONAL_FIELD(segment.salt, obj, "salt");
+    PARSE_OPTIONAL_FIELD(segment.unbounded, obj, "unbounded");
+
+    PARSE_OPTIONAL_FIELD(segment.includedContexts, obj, "includedContexts");
+    PARSE_OPTIONAL_FIELD(segment.excludedContexts, obj, "excludedContexts");
+
+    return segment;
+}
+}  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_value.cpp
+++ b/libs/internal/src/serialization/json_value.cpp
@@ -83,5 +83,11 @@ void tag_invoke(boost::json::value_from_tag const&,
     }
 }
 
+tl::expected<Value, JsonError> tag_invoke(
+    boost::json::value_to_tag<tl::expected<Value, JsonError>> const& tag,
+    boost::json::value const& json_value) {
+    return boost::json::value_to<Value>(json_value);
+}
+
 // NOLINTEND modernize-return-braced-init-list
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/value_mapping.cpp
+++ b/libs/internal/src/serialization/value_mapping.cpp
@@ -22,6 +22,32 @@ std::optional<std::string> ValueAsOpt(
 }
 
 template <>
+std::optional<bool> ValueAsOpt(boost::json::object::const_iterator iterator,
+                               boost::json::object::const_iterator end) {
+    if (iterator != end && iterator->value().is_bool()) {
+        return iterator->value().as_bool();
+    }
+    return std::nullopt;
+}
+
+template <>
+std::optional<std::vector<std::string>> ValueAsOpt(
+    boost::json::object::const_iterator iterator,
+    boost::json::object::const_iterator end) {
+    if (iterator != end && iterator->value().is_array()) {
+        std::vector<std::string> result;
+        for (auto const& item : iterator->value().as_array()) {
+            if (!item.is_string()) {
+                return std::nullopt;
+            }
+            result.emplace_back(item.as_string());
+        }
+        return result;
+    }
+    return std::nullopt;
+}
+
+template <>
 bool ValueOrDefault(boost::json::object::const_iterator iterator,
                     boost::json::object::const_iterator end,
                     bool default_value) {

--- a/libs/internal/src/serialization/value_mapping.cpp
+++ b/libs/internal/src/serialization/value_mapping.cpp
@@ -22,15 +22,6 @@ std::optional<std::string> ValueAsOpt(
 }
 
 template <>
-std::optional<bool> ValueAsOpt(boost::json::object::const_iterator iterator,
-                               boost::json::object::const_iterator end) {
-    if (iterator != end && iterator->value().is_bool()) {
-        return iterator->value().as_bool();
-    }
-    return std::nullopt;
-}
-
-template <>
 std::optional<std::vector<std::string>> ValueAsOpt(
     boost::json::object::const_iterator iterator,
     boost::json::object::const_iterator end) {

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <launchdarkly/serialization/json_sdk_data_set.hpp>
+#include <launchdarkly/serialization/json_segment.hpp>
 
 using namespace launchdarkly;
 
@@ -28,20 +29,110 @@ TEST(SDKDataSetTests, DeserializesZeroSegments) {
     ASSERT_TRUE(result->segments->empty());
 }
 
-TEST(SDKDataSetTests, DeserializesMinimumValidSegment) {
+TEST(SegmentTests, DeserializesMinimumValid) {
     auto result =
-        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
-            boost::json::parse(
-                R"({"segments":{"foo":{"key":"foo", "version": 42}}})"));
+        boost::json::value_to<tl::expected<data_model::Segment, JsonError>>(
+            boost::json::parse(R"({"key":"foo", "version": 42})"));
     ASSERT_TRUE(result);
-    ASSERT_EQ(result->segments->size(), 1);
 
-    auto it = result->segments->find("foo");
-    ASSERT_TRUE(it != result->segments->end());
+    ASSERT_EQ(result->version, 42);
+    ASSERT_EQ(result->key, "foo");
+}
 
-    ASSERT_EQ(it->second.version, 42);
-    ASSERT_TRUE(it->second.item);
+TEST(SegmentTests, TolerantOfUnrecognizedFields) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::Segment, JsonError>>(
+            boost::json::parse(
+                R"({"key":"foo", "version": 42, "somethingRandom" : true})"));
+    ASSERT_TRUE(result);
+}
 
-    ASSERT_EQ(it->second.item->key, "foo");
-    ASSERT_EQ(it->second.item->version, 42);
+TEST(RuleTests, DeserializesMinimumValid) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Rule, JsonError>>(boost::json::parse(
+        R"({"clauses": [{"attribute": "", "op": "in", "values": []}]})"));
+    ASSERT_TRUE(result);
+
+    auto const& clauses = result->clauses;
+    ASSERT_EQ(clauses.size(), 1);
+
+    auto const& clause = clauses.at(0);
+    ASSERT_EQ(clause.op, data_model::Segment::Clause::Op::kIn);
+}
+
+TEST(RuleTests, TolerantOfUnrecognizedFields) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Rule, JsonError>>(boost::json::parse(
+        R"({"somethingRandom": true, "clauses": [{"attribute": "", "op": "in", "values": []}]})"));
+
+    ASSERT_TRUE(result);
+}
+
+TEST(ClauseTests, DeserializesMinimumValid) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(
+        boost::json::parse(R"({"attribute": "", "op": "in", "values": []})"));
+    ASSERT_TRUE(result);
+
+    ASSERT_EQ(result->op, data_model::Segment::Clause::Op::kIn);
+    ASSERT_TRUE(result->values.empty());
+    ASSERT_FALSE(result->attribute.Valid());
+}
+
+TEST(ClauseTests, TolerantOfUnrecognizedFields) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(boost::json::parse(
+        R"({"somethingRandom": true, "attribute": "", "op": "in", "values": []})"));
+    ASSERT_TRUE(result);
+}
+
+TEST(ClauseTests, TolerantOfEmptyAttribute) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(
+        boost::json::parse(R"({"attribute": "", "op": "in", "values": []})"));
+    ASSERT_TRUE(result);
+    ASSERT_FALSE(result->attribute.Valid());
+}
+
+TEST(ClauseTests, TolerantOfUnrecognizedOperator) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(
+        boost::json::parse(
+            R"({"attribute": "", "op": "notAnActualOperator", "values": []})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->op, data_model::Segment::Clause::Op::kUnrecognized);
+}
+
+TEST(ClauseTests, DeserializesSimpleAttributeReference) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(boost::json::parse(
+        R"({"attribute": "foo", "op": "in", "values": [], "contextKind" : "user"})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->attribute, AttributeReference("foo"));
+}
+
+TEST(ClauseTests, DeserializesPointerAttributeReference) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(boost::json::parse(
+        R"({"attribute": "/foo/bar", "op": "in", "values": [], "contextKind" : "user"})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->attribute, AttributeReference("/foo/bar"));
+}
+
+TEST(ClauseTests, DeserializesEscapedReference) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(boost::json::parse(
+        R"({"attribute": "/~1foo~1bar", "op": "in", "values": [], "contextKind" : "user"})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->attribute, AttributeReference("/~1foo~1bar"));
+}
+
+TEST(ClauseTests, DeserializesLiteralAttributeReference) {
+    auto result = boost::json::value_to<
+        tl::expected<data_model::Segment::Clause, JsonError>>(
+        boost::json::parse(
+            R"({"attribute": "/foo/bar", "op": "in", "values": []})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->attribute,
+              AttributeReference::FromLiteralStr("/foo/bar"));
 }

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include <launchdarkly/serialization/json_sdk_data_set.hpp>
+
+using namespace launchdarkly;
+
+TEST(SDKDataSetTests, DeserializesEmptyDataSet) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
+            boost::json::parse("{}"));
+    ASSERT_TRUE(result);
+    ASSERT_FALSE(result->segments);
+}
+
+TEST(SDKDataSetTests, ErrorOnInvalidSchema) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
+            boost::json::parse("[]"));
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), JsonError::kSchemaFailure);
+}
+
+TEST(SDKDataSetTests, DeserializesZeroSegments) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
+            boost::json::parse(R"({"segments":{}})"));
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result->segments->empty());
+}
+
+TEST(SDKDataSetTests, DeserializesMinimumValidSegment) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
+            boost::json::parse(
+                R"({"segments":{"foo":{"key":"foo", "version": 42}}})"));
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->segments->size(), 1);
+
+    auto it = result->segments->find("foo");
+    ASSERT_TRUE(it != result->segments->end());
+
+    ASSERT_EQ(it->second.version, 42);
+    ASSERT_TRUE(it->second.item);
+
+    ASSERT_EQ(it->second.item->key, "foo");
+    ASSERT_EQ(it->second.item->version, 42);
+}

--- a/libs/internal/tests/evaluation_result_test.cpp
+++ b/libs/internal/tests/evaluation_result_test.cpp
@@ -15,54 +15,49 @@ using launchdarkly::JsonError;
 using launchdarkly::Value;
 
 TEST(EvaluationResultTests, FromJsonAllFields) {
-    auto evaluation_result =
-        boost::json::value_to<tl::expected<EvaluationResult, JsonError>>(
-            boost::json::parse("{"
-                               "\"version\": 12,"
-                               "\"flagVersion\": 24,"
-                               "\"trackEvents\": true,"
-                               "\"trackReason\": true,"
-                               "\"debugEventsUntilDate\": 1680555761,"
-                               "\"value\": {\"item\": 42},"
-                               "\"variation\": 84,"
-                               "\"reason\": {"
-                               "\"kind\":\"OFF\","
-                               "\"errorKind\":\"MALFORMED_FLAG\","
-                               "\"ruleIndex\":12,"
-                               "\"ruleId\":\"RULE_ID\","
-                               "\"prerequisiteKey\":\"PREREQ_KEY\","
-                               "\"inExperiment\":true,"
-                               "\"bigSegmentStatus\":\"STORE_ERROR\""
-                               "}"
-                               "}"));
+    auto evaluation_result = boost::json::value_to<
+        tl::expected<std::optional<EvaluationResult>, JsonError>>(
+        boost::json::parse("{"
+                           "\"version\": 12,"
+                           "\"flagVersion\": 24,"
+                           "\"trackEvents\": true,"
+                           "\"trackReason\": true,"
+                           "\"debugEventsUntilDate\": 1680555761,"
+                           "\"value\": {\"item\": 42},"
+                           "\"variation\": 84,"
+                           "\"reason\": {"
+                           "\"kind\":\"OFF\","
+                           "\"errorKind\":\"MALFORMED_FLAG\","
+                           "\"ruleIndex\":12,"
+                           "\"ruleId\":\"RULE_ID\","
+                           "\"prerequisiteKey\":\"PREREQ_KEY\","
+                           "\"inExperiment\":true,"
+                           "\"bigSegmentStatus\":\"STORE_ERROR\""
+                           "}"
+                           "}"));
 
     EXPECT_TRUE(evaluation_result.has_value());
-    EXPECT_EQ(12, evaluation_result.value().Version());
-    EXPECT_EQ(24, evaluation_result.value().FlagVersion());
-    EXPECT_TRUE(evaluation_result.value().TrackEvents());
-    EXPECT_TRUE(evaluation_result.value().TrackReason());
+    auto const& val = evaluation_result.value();
+    EXPECT_TRUE(val.has_value());
+
+    EXPECT_EQ(12, val->Version());
+    EXPECT_EQ(24, val->FlagVersion());
+    EXPECT_TRUE(val->TrackEvents());
+    EXPECT_TRUE(val->TrackReason());
     EXPECT_EQ(std::chrono::system_clock::time_point{std::chrono::milliseconds{
                   1680555761}},
-              evaluation_result.value().DebugEventsUntilDate());
-    EXPECT_EQ(
-        42,
-        evaluation_result.value().Detail().Value().AsObject()["item"].AsInt());
-    EXPECT_EQ(84, evaluation_result.value().Detail().VariationIndex());
+              val->DebugEventsUntilDate());
+    EXPECT_EQ(42, val->Detail().Value().AsObject()["item"].AsInt());
+    EXPECT_EQ(84, val->Detail().VariationIndex());
     EXPECT_EQ(EvaluationReason::Kind::kOff,
-              evaluation_result.value().Detail().Reason()->get().Kind());
+              val->Detail().Reason()->get().Kind());
     EXPECT_EQ(EvaluationReason::ErrorKind::kMalformedFlag,
-              evaluation_result.value().Detail().Reason()->get().ErrorKind());
-    EXPECT_EQ(12,
-              evaluation_result.value().Detail().Reason()->get().RuleIndex());
-    EXPECT_EQ("RULE_ID",
-              evaluation_result.value().Detail().Reason()->get().RuleId());
-    EXPECT_EQ(
-        "PREREQ_KEY",
-        evaluation_result.value().Detail().Reason()->get().PrerequisiteKey());
-    EXPECT_EQ("STORE_ERROR",
-        evaluation_result.value().Detail().Reason()->get().BigSegmentStatus());
-    EXPECT_TRUE(
-        evaluation_result.value().Detail().Reason()->get().InExperiment());
+              val->Detail().Reason()->get().ErrorKind());
+    EXPECT_EQ(12, val->Detail().Reason()->get().RuleIndex());
+    EXPECT_EQ("RULE_ID", val->Detail().Reason()->get().RuleId());
+    EXPECT_EQ("PREREQ_KEY", val->Detail().Reason()->get().PrerequisiteKey());
+    EXPECT_EQ("STORE_ERROR", val->Detail().Reason()->get().BigSegmentStatus());
+    EXPECT_TRUE(val->Detail().Reason()->get().InExperiment());
 }
 
 TEST(EvaluationResultTests, ToJsonAllFields) {
@@ -91,29 +86,27 @@ TEST(EvaluationResultTests, ToJsonAllFields) {
 }
 
 TEST(EvaluationResultTests, FromJsonMinimalFields) {
-    auto evaluation_result =
-        boost::json::value_to<tl::expected<EvaluationResult, JsonError>>(
-            boost::json::parse("{"
-                               "\"version\": 12,"
-                               "\"value\": {\"item\": 42}"
-                               "}"));
+    auto evaluation_result = boost::json::value_to<
+        tl::expected<std::optional<EvaluationResult>, JsonError>>(
+        boost::json::parse("{"
+                           "\"version\": 12,"
+                           "\"value\": {\"item\": 42}"
+                           "}"));
 
-    EXPECT_EQ(12, evaluation_result.value().Version());
-    EXPECT_EQ(std::nullopt, evaluation_result.value().FlagVersion());
-    EXPECT_FALSE(evaluation_result.value().TrackEvents());
-    EXPECT_FALSE(evaluation_result.value().TrackReason());
-    EXPECT_EQ(std::nullopt, evaluation_result.value().DebugEventsUntilDate());
-    EXPECT_EQ(
-        42,
-        evaluation_result.value().Detail().Value().AsObject()["item"].AsInt());
-    EXPECT_EQ(std::nullopt,
-              evaluation_result.value().Detail().VariationIndex());
-    EXPECT_EQ(std::nullopt, evaluation_result.value().Detail().Reason());
+    auto const& value = evaluation_result.value();
+    EXPECT_EQ(12, value->Version());
+    EXPECT_EQ(std::nullopt, value->FlagVersion());
+    EXPECT_FALSE(value->TrackEvents());
+    EXPECT_FALSE(value->TrackReason());
+    EXPECT_EQ(std::nullopt, value->DebugEventsUntilDate());
+    EXPECT_EQ(42, value->Detail().Value().AsObject()["item"].AsInt());
+    EXPECT_EQ(std::nullopt, value->Detail().VariationIndex());
+    EXPECT_EQ(std::nullopt, value->Detail().Reason());
 }
 
 TEST(EvaluationResultTests, FromMapOfResults) {
-    auto results = boost::json::value_to<
-        std::map<std::string, tl::expected<EvaluationResult, JsonError>>>(
+    auto results = boost::json::value_to<std::map<
+        std::string, tl::expected<std::optional<EvaluationResult>, JsonError>>>(
         boost::json::parse("{"
                            "\"flagA\":{"
                            "\"version\": 12,"
@@ -124,26 +117,26 @@ TEST(EvaluationResultTests, FromMapOfResults) {
                            "\"value\": false"
                            "}"
                            "}"));
-
-    EXPECT_TRUE(results.at("flagA").value().Detail().Value().AsBool());
-    EXPECT_FALSE(results.at("flagB").value().Detail().Value().AsBool());
+    EXPECT_TRUE(results.at("flagA").value().value().Detail().Value().AsBool());
+    EXPECT_FALSE(results.at("flagB").value().value().Detail().Value().AsBool());
 }
 
 TEST(EvaluationResultTests, NoResultFieldsJson) {
-    auto results =
-        boost::json::value_to<tl::expected<EvaluationResult, JsonError>>(
-            boost::json::parse("{}"));
+    auto results = boost::json::value_to<
+        tl::expected<std::optional<EvaluationResult>, JsonError>>(
+        boost::json::parse("{}"));
 
-    EXPECT_FALSE(results.has_value());
-    EXPECT_EQ(JsonError::kSchemaFailure, results.error());
+    EXPECT_TRUE(results);
+    auto const& val = results.value();
+    EXPECT_FALSE(val);
 }
 
 TEST(EvaluationResultTests, VersionWrongTypeJson) {
-    auto results =
-        boost::json::value_to<tl::expected<EvaluationResult, JsonError>>(
-            boost::json::parse("{\"version\": \"apple\"}"));
+    auto results = boost::json::value_to<
+        tl::expected<std::optional<EvaluationResult>, JsonError>>(
+        boost::json::parse("{\"version\": \"apple\"}"));
 
-    EXPECT_FALSE(results.has_value());
+    EXPECT_FALSE(results);
     EXPECT_EQ(JsonError::kSchemaFailure, results.error());
 }
 


### PR DESCRIPTION
This PR extends our existing deserialization/serialization technique from the client-side SDK to the server-side SDK data model. 

Specifically, it adds deserialization for the segment structure. I've also introduced some helpers to make the logic less repetitive, and centralize some decisions (like what to do if a JSON field isn't present, or is null.)

As background, the `tag_invoke` functions present in this PR are what allows the `boost::json` library to recursively deserialize complex structures. 

Here, I've added a couple new `tag_invokes` for bool, string, vector, etc. The special part is that they deserialize into `expected<type, error>` rather than the primitive directly; this allows us to return an error if the deserialization failed. 