### PR TITLE
fix: Fix compilation with boost 1.82.

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: |
         choco install boost-msvc-14.3 -y
-        echo "BOOST_ROOT=C:\local\boost_1_81_0" >> $GITHUB_OUTPUT
+        echo "BOOST_ROOT=C:\local\boost_1_82_0" >> $GITHUB_OUTPUT
 
     - name: Install boost using homebrew
       id: brew-action
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         brew install boost
-        echo "BOOST_ROOT=$(boost --prefix boost@1.81)" >> $GITHUB_OUTPUT
+        echo "BOOST_ROOT=$(boost --prefix boost@1.82)" >> $GITHUB_OUTPUT
 
     - name: Determine root
       id: determine-root

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,7 +39,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost@1.81
+        brew install boost
         echo "BOOST_ROOT=$(boost --prefix boost@1.81)" >> $GITHUB_OUTPUT
 
     - name: Determine root

--- a/contract-tests/sdk-contract-tests/src/client_entity.cpp
+++ b/contract-tests/sdk-contract-tests/src/client_entity.cpp
@@ -1,5 +1,6 @@
 #include "client_entity.hpp"
 #include <boost/json.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <launchdarkly/context_builder.hpp>
 #include <launchdarkly/serialization/json_context.hpp>

--- a/contract-tests/sdk-contract-tests/src/client_entity.cpp
+++ b/contract-tests/sdk-contract-tests/src/client_entity.cpp
@@ -1,6 +1,7 @@
 #include "client_entity.hpp"
-#include <boost/json.hpp>
+
 #include <boost/core/ignore_unused.hpp>
+#include <boost/json.hpp>
 
 #include <launchdarkly/context_builder.hpp>
 #include <launchdarkly/serialization/json_context.hpp>

--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -7,6 +7,8 @@
 
 #include <boost/json.hpp>
 #include <unordered_map>
+#include <boost/core/ignore_unused.hpp>
+
 #include <utility>
 
 #include "tl/expected.hpp"

--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -5,9 +5,9 @@
 #include <launchdarkly/serialization/json_evaluation_result.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/json.hpp>
 #include <unordered_map>
-#include <boost/core/ignore_unused.hpp>
 
 #include <utility>
 
@@ -146,7 +146,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             boost::json::parse(data));
         if (res.has_value()) {
             handler_.Upsert(context_, res.value().key,
-                             ItemDescriptor(res.value().version));
+                            ItemDescriptor(res.value().version));
             return DataSourceEventHandler::MessageStatus::kMessageHandled;
         }
         LD_LOG(logger_, LogLevel::kError) << kErrorDeleteInvalid;

--- a/libs/internal/include/launchdarkly/network/asio_requester.hpp
+++ b/libs/internal/include/launchdarkly/network/asio_requester.hpp
@@ -8,6 +8,7 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/version.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include "foxy/client_session.hpp"
 

--- a/libs/internal/include/launchdarkly/network/asio_requester.hpp
+++ b/libs/internal/include/launchdarkly/network/asio_requester.hpp
@@ -149,8 +149,8 @@ class FoxyClient
           response_timeout_(response_timeout),
           handler_(std::move(handler)),
           session_(exec,
-                   launchdarkly::foxy::session_opts{ToOptRef(ssl_context_.get()),
-                                      connect_timeout_}),
+                   launchdarkly::foxy::session_opts{
+                       ToOptRef(ssl_context_.get()), connect_timeout_}),
           resp_() {}
 
     void Run() {

--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/json.hpp>
 
 namespace launchdarkly {

--- a/libs/internal/src/events/asio_event_processor.cpp
+++ b/libs/internal/src/events/asio_event_processor.cpp
@@ -1,9 +1,9 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/http.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/core/ignore_unused.hpp>
 
 #include <launchdarkly/config/shared/builders/http_properties_builder.hpp>
 #include <launchdarkly/config/shared/sdks.hpp>

--- a/libs/internal/src/events/asio_event_processor.cpp
+++ b/libs/internal/src/events/asio_event_processor.cpp
@@ -3,6 +3,7 @@
 #include <boost/beast/http.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <launchdarkly/config/shared/builders/http_properties_builder.hpp>
 #include <launchdarkly/config/shared/sdks.hpp>

--- a/libs/internal/src/serialization/json_attributes.cpp
+++ b/libs/internal/src/serialization/json_attributes.cpp
@@ -1,6 +1,8 @@
 #include <launchdarkly/serialization/json_attributes.hpp>
 #include <launchdarkly/serialization/json_value.hpp>
 
+#include <boost/core/ignore_unused.hpp>
+
 namespace launchdarkly {
 void tag_invoke(boost::json::value_from_tag const& unused,
                 boost::json::value& json_value,

--- a/libs/internal/src/serialization/json_context.cpp
+++ b/libs/internal/src/serialization/json_context.cpp
@@ -5,6 +5,8 @@
 
 #include <optional>
 
+#include <boost/core/ignore_unused.hpp>
+
 namespace launchdarkly {
 void tag_invoke(boost::json::value_from_tag const&,
                 boost::json::value& json_value,

--- a/libs/internal/src/serialization/json_evaluation_reason.cpp
+++ b/libs/internal/src/serialization/json_evaluation_reason.cpp
@@ -1,6 +1,8 @@
 #include <launchdarkly/serialization/json_evaluation_reason.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <sstream>
 
 namespace launchdarkly {

--- a/libs/internal/src/serialization/json_evaluation_reason.cpp
+++ b/libs/internal/src/serialization/json_evaluation_reason.cpp
@@ -63,8 +63,8 @@ void tag_invoke(boost::json::value_from_tag const& unused,
 }
 
 tl::expected<enum EvaluationReason::ErrorKind, JsonError> tag_invoke(
-    boost::json::value_to_tag<
-        tl::expected<enum EvaluationReason::ErrorKind, JsonError>> const& unused,
+    boost::json::value_to_tag<tl::expected<enum EvaluationReason::ErrorKind,
+                                           JsonError>> const& unused,
     boost::json::value const& json_value) {
     if (!json_value.is_string()) {
         return tl::unexpected(JsonError::kSchemaFailure);

--- a/libs/server-sent-events/src/client.cpp
+++ b/libs/server-sent-events/src/client.cpp
@@ -2,6 +2,7 @@
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/use_future.hpp>
+
 #include <foxy/client_session.hpp>
 #include <launchdarkly/sse/client.hpp>
 
@@ -13,8 +14,11 @@
 #include <boost/beast/ssl/ssl_stream.hpp>
 #include <boost/beast/version.hpp>
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
+
 #include <chrono>
 #include <iostream>
 #include <memory>

--- a/libs/server-sent-events/src/parser.hpp
+++ b/libs/server-sent-events/src/parser.hpp
@@ -7,6 +7,7 @@
 #include <boost/beast/http/fields.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/type_traits.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <deque>
 #include <iostream>


### PR DESCRIPTION
This PR fixes compilation using boost 1.82.

It also fixes the CI issues from boost 1.81 being removed from brew, and floated with chocolatey.

Further changes, in another PR, will be needed to improve boost dependency robustness.