### PR TITLE
feat: add Flag model to SDKDataSet

### DIFF
--- a/libs/internal/include/launchdarkly/data_model/flag.hpp
+++ b/libs/internal/include/launchdarkly/data_model/flag.hpp
@@ -84,6 +84,11 @@ struct Flag {
     bool trackEventsFallthrough;
     std::optional<std::uint64_t> debugEventsUntilDate;
 
+    /**
+     * Returns the flag's version. Satisfies ItemDescriptor template
+     * constraints.
+     * @return Version of this flag.
+     */
     [[nodiscard]] inline std::uint64_t Version() const { return version; }
 };
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/flag.hpp
+++ b/libs/internal/include/launchdarkly/data_model/flag.hpp
@@ -83,5 +83,7 @@ struct Flag {
     bool trackEvents;
     bool trackEventsFallthrough;
     std::optional<std::uint64_t> debugEventsUntilDate;
+
+    [[nodiscard]] inline std::uint64_t Version() const { return version; }
 };
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -15,9 +15,8 @@ namespace launchdarkly::data_model {
 struct SDKDataSet {
     using FlagKey = std::string;
     using SegmentKey = std::string;
-    std::optional<std::unordered_map<FlagKey, ItemDescriptor<Flag>>> flags;
-    std::optional<std::unordered_map<SegmentKey, ItemDescriptor<Segment>>>
-        segments;
+    std::unordered_map<FlagKey, ItemDescriptor<Flag>> flags;
+    std::unordered_map<SegmentKey, ItemDescriptor<Segment>> segments;
 };
 
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
+++ b/libs/internal/include/launchdarkly/data_model/sdk_data_set.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <launchdarkly/data_model/flag.hpp>
 #include <launchdarkly/data_model/item_descriptor.hpp>
 #include <launchdarkly/data_model/segment.hpp>
 
@@ -14,7 +15,7 @@ namespace launchdarkly::data_model {
 struct SDKDataSet {
     using FlagKey = std::string;
     using SegmentKey = std::string;
-    // std::unordered_map<FlagKey, ItemDescriptor<Flag>> flags;
+    std::optional<std::unordered_map<FlagKey, ItemDescriptor<Flag>>> flags;
     std::optional<std::unordered_map<SegmentKey, ItemDescriptor<Segment>>>
         segments;
 };

--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -48,6 +48,12 @@ struct Segment {
 
     // TODO(cwaldren): make Kind a real type that is deserialized, so we can
     // make empty string an error.
+
+    /**
+     * Returns the segment's version. Satisfies ItemDescriptor template
+     * constraints.
+     * @return Version of this segment.
+     */
     [[nodiscard]] inline std::uint64_t Version() const { return version; }
 };
 }  // namespace launchdarkly::data_model

--- a/libs/internal/src/serialization/json_sdk_data_set.cpp
+++ b/libs/internal/src/serialization/json_sdk_data_set.cpp
@@ -1,5 +1,6 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/json.hpp>
+#include <launchdarkly/serialization/json_flag.hpp>
 #include <launchdarkly/serialization/json_item_descriptor.hpp>
 #include <launchdarkly/serialization/json_sdk_data_set.hpp>
 #include <launchdarkly/serialization/json_segment.hpp>
@@ -19,6 +20,7 @@ tl::expected<std::optional<data_model::SDKDataSet>, JsonError> tag_invoke(
 
     data_model::SDKDataSet data_set;
 
+    PARSE_CONDITIONAL_FIELD(data_set.flags, obj, "flags");
     PARSE_CONDITIONAL_FIELD(data_set.segments, obj, "segments");
 
     return data_set;

--- a/libs/internal/src/serialization/json_sdk_data_set.cpp
+++ b/libs/internal/src/serialization/json_sdk_data_set.cpp
@@ -20,8 +20,8 @@ tl::expected<std::optional<data_model::SDKDataSet>, JsonError> tag_invoke(
 
     data_model::SDKDataSet data_set;
 
-    PARSE_CONDITIONAL_FIELD(data_set.flags, obj, "flags");
-    PARSE_CONDITIONAL_FIELD(data_set.segments, obj, "segments");
+    PARSE_FIELD(data_set.flags, obj, "flags");
+    PARSE_FIELD(data_set.segments, obj, "segments");
 
     return data_set;
 }

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -14,6 +14,7 @@ TEST(SDKDataSetTests, DeserializesEmptyDataSet) {
             boost::json::parse("{}"));
     ASSERT_TRUE(result);
     ASSERT_FALSE(result->segments);
+    ASSERT_FALSE(result->flags);
 }
 
 TEST(SDKDataSetTests, ErrorOnInvalidSchema) {
@@ -31,6 +32,17 @@ TEST(SDKDataSetTests, DeserializesZeroSegments) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->segments);
     ASSERT_TRUE(result->segments->empty());
+    ASSERT_FALSE(result->flags);
+}
+
+TEST(SDKDataSetTests, DeserializesZeroFlags) {
+    auto result =
+        boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
+            boost::json::parse(R"({"flags":{}})"));
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result->flags);
+    ASSERT_TRUE(result->flags->empty());
+    ASSERT_FALSE(result->segments);
 }
 
 TEST(SegmentTests, DeserializesMinimumValid) {

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -13,8 +13,8 @@ TEST(SDKDataSetTests, DeserializesEmptyDataSet) {
         boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
             boost::json::parse("{}"));
     ASSERT_TRUE(result);
-    ASSERT_FALSE(result->segments);
-    ASSERT_FALSE(result->flags);
+    ASSERT_TRUE(result->segments.empty());
+    ASSERT_TRUE(result->flags.empty());
 }
 
 TEST(SDKDataSetTests, ErrorOnInvalidSchema) {
@@ -30,9 +30,7 @@ TEST(SDKDataSetTests, DeserializesZeroSegments) {
         boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
             boost::json::parse(R"({"segments":{}})"));
     ASSERT_TRUE(result);
-    ASSERT_TRUE(result->segments);
-    ASSERT_TRUE(result->segments->empty());
-    ASSERT_FALSE(result->flags);
+    ASSERT_TRUE(result->segments.empty());
 }
 
 TEST(SDKDataSetTests, DeserializesZeroFlags) {
@@ -40,9 +38,7 @@ TEST(SDKDataSetTests, DeserializesZeroFlags) {
         boost::json::value_to<tl::expected<data_model::SDKDataSet, JsonError>>(
             boost::json::parse(R"({"flags":{}})"));
     ASSERT_TRUE(result);
-    ASSERT_TRUE(result->flags);
-    ASSERT_TRUE(result->flags->empty());
-    ASSERT_FALSE(result->segments);
+    ASSERT_TRUE(result->flags.empty());
 }
 
 TEST(SegmentTests, DeserializesMinimumValid) {


### PR DESCRIPTION
Adds in missing `Flag` model to the top-level `SDKDataSet`.

I've also changed both the flag/segment fields to use `PARSE_FIELD`, so we can get an empty `unordered_map` if they are missing. 