### PR TITLE
feat: add more EvaluationReason constructors

### DIFF
--- a/libs/common/include/launchdarkly/data/evaluation_reason.hpp
+++ b/libs/common/include/launchdarkly/data/evaluation_reason.hpp
@@ -119,6 +119,37 @@ class EvaluationReason {
 
     explicit EvaluationReason(enum ErrorKind error_kind);
 
+    /**
+     * The flag was off.
+     */
+    static EvaluationReason Off();
+
+    /**
+     * The flag didn't return a variation due to a prerequisite failing.
+     */
+    static EvaluationReason PrerequisiteFailed(std::string prerequisite_key);
+
+    /**
+     * The flag evaluated to a particular variation due to a target match.
+     */
+    static EvaluationReason TargetMatch();
+
+    /**
+     * The flag evaluated to its fallthrough value.
+     * @param in_experiment Whether the flag is part of an experiment.
+     */
+    static EvaluationReason Fallthrough(bool in_experiment);
+
+    /**
+     * The flag evaluated to a particular variation because it matched a rule.
+     * @param rule_index Index of the rule.
+     * @param rule_id ID of the rule.
+     * @param in_experiment Whether the flag is part of an experiment.
+     */
+    static EvaluationReason RuleMatch(std::size_t rule_index,
+                                      std::optional<std::string> rule_id,
+                                      bool in_experiment);
+    
     friend std::ostream& operator<<(std::ostream& out,
                                     EvaluationReason const& reason);
 

--- a/libs/common/src/data/evaluation_reason.cpp
+++ b/libs/common/src/data/evaluation_reason.cpp
@@ -56,6 +56,35 @@ EvaluationReason::EvaluationReason(enum ErrorKind error_kind)
                        false,
                        std::nullopt) {}
 
+EvaluationReason EvaluationReason::Off() {
+    return {Kind::kOff,   std::nullopt, std::nullopt, std::nullopt,
+            std::nullopt, false,        std::nullopt};
+}
+
+EvaluationReason EvaluationReason::PrerequisiteFailed(
+    std::string prerequisite_key) {
+    return {
+        Kind::kPrerequisiteFailed,   std::nullopt, std::nullopt, std::nullopt,
+        std::move(prerequisite_key), false,        std::nullopt};
+}
+
+EvaluationReason EvaluationReason::TargetMatch() {
+    return {Kind::kTargetMatch, std::nullopt, std::nullopt, std::nullopt,
+            std::nullopt,       false,        std::nullopt};
+}
+
+EvaluationReason EvaluationReason::Fallthrough(bool in_experiment) {
+    return {Kind::kFallthrough, std::nullopt,  std::nullopt, std::nullopt,
+            std::nullopt,       in_experiment, std::nullopt};
+}
+
+EvaluationReason EvaluationReason::RuleMatch(std::size_t rule_index,
+                                             std::optional<std::string> rule_id,
+                                             bool in_experiment) {
+    return {Kind::kRuleMatch, std::nullopt,  rule_index,  std::move(rule_id),
+            std::nullopt,     in_experiment, std::nullopt};
+}
+
 std::ostream& operator<<(std::ostream& out, EvaluationReason const& reason) {
     out << "{";
     out << " kind: " << reason.kind_;


### PR DESCRIPTION
This is the first in some attempts to break up the large evaluator PR. 

This commit adds new `EvaluationReason` constructors used within the evaluation engine.