### PR TITLE
feat: add comparison operators to Value

### DIFF
--- a/libs/common/include/launchdarkly/value.hpp
+++ b/libs/common/include/launchdarkly/value.hpp
@@ -428,4 +428,24 @@ bool operator!=(Value::Array const& lhs, Value::Array const& rhs);
 bool operator==(Value::Object const& lhs, Value::Object const& rhs);
 bool operator!=(Value::Object const& lhs, Value::Object const& rhs);
 
+/* Returns true if both values are numbers and lhs < rhs. Returns false if
+ * either value is not a number.
+ */
+bool operator<(Value const& lhs, Value const& rhs);
+
+/* Returns true if both values are numbers and lhs > rhs. Returns false if
+ * either value is not a number.
+ */
+bool operator>(Value const& lhs, Value const& rhs);
+
+/* Returns true if both values are numbers and lhs <= rhs. Returns false if
+ * either value is not a number.
+ */
+bool operator<=(Value const& lhs, Value const& rhs);
+
+/* Returns true if both values are numbers and lhs >= rhs. Returns false if
+ * either value is not a number.
+ */
+bool operator>=(Value const& lhs, Value const& rhs);
+
 }  // namespace launchdarkly

--- a/libs/common/src/value.cpp
+++ b/libs/common/src/value.cpp
@@ -264,4 +264,23 @@ bool operator!=(Value::Object const& lhs, Value::Object const& rhs) {
     return !(lhs == rhs);
 }
 
+inline bool BothNumbers(Value const& lhs, Value const& rhs) {
+    return lhs.IsNumber() && rhs.IsNumber();
+}
+
+bool operator<(Value const& lhs, Value const& rhs) {
+    return BothNumbers(lhs, rhs) && lhs.AsDouble() < rhs.AsDouble();
+}
+
+bool operator>(Value const& lhs, Value const& rhs) {
+    return BothNumbers(lhs, rhs) && rhs < lhs;
+}
+
+bool operator<=(Value const& lhs, Value const& rhs) {
+    return BothNumbers(lhs, rhs) && !(lhs > rhs);
+}
+
+bool operator>=(Value const& lhs, Value const& rhs) {
+    return BothNumbers(lhs, rhs) && !(lhs < rhs);
+}
 }  // namespace launchdarkly


### PR DESCRIPTION
Adds `<`, `>`, `<=`, and `>=` to `Value`. These are used within rule match logic in the evaluation engine.

They don't attempt to do any special lexical comparisons or anything like that - non-numbers always return false. 