### PR TITLE
feat: add sha1 hashing  and base16 encoding routines

### DIFF
--- a/libs/internal/include/launchdarkly/encoding/base_16.hpp
+++ b/libs/internal/include/launchdarkly/encoding/base_16.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <iomanip>
+#include <string>
+
+namespace launchdarkly::encoding {
+
+template <unsigned long N>
+std::string Base16Encode(std::array<unsigned char, N> arr) {
+    std::stringstream output_stream;
+    output_stream << std::hex << std::noshowbase;
+    for (unsigned char byte : arr) {
+        output_stream << std::setw(2) << std::setfill('0')
+                      << static_cast<int>(byte);
+    }
+    return output_stream.str();
+}
+
+}  // namespace launchdarkly::encoding

--- a/libs/internal/include/launchdarkly/encoding/sha_1.hpp
+++ b/libs/internal/include/launchdarkly/encoding/sha_1.hpp
@@ -1,13 +1,10 @@
 #pragma once
-
 #include <array>
 #include <string>
 
 #include <openssl/sha.h>
 
 namespace launchdarkly::encoding {
-
-std::array<unsigned char, SHA256_DIGEST_LENGTH> Sha256String(
+std::array<unsigned char, SHA_DIGEST_LENGTH> Sha1String(
     std::string const& input);
-
-}  // namespace launchdarkly::encoding
+}

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -38,7 +38,8 @@ add_library(${LIBNAME} OBJECT
         serialization/json_rule_clause.cpp
         serialization/json_flag.cpp
         encoding/base_64.cpp
-        encoding/sha_256.cpp)
+        encoding/sha_256.cpp
+        encoding/sha_1.cpp)
 
 add_library(launchdarkly::internal ALIAS ${LIBNAME})
 

--- a/libs/internal/src/encoding/sha_1.cpp
+++ b/libs/internal/src/encoding/sha_1.cpp
@@ -1,0 +1,18 @@
+#include <openssl/sha.h>
+
+#include <launchdarkly/encoding/sha_256.hpp>
+
+namespace launchdarkly::encoding {
+
+std::array<unsigned char, SHA_DIGEST_LENGTH> Sha1String(
+    std::string const& input) {
+    std::array<unsigned char, SHA_DIGEST_LENGTH> hash;
+
+    SHA_CTX sha;
+    SHA1_Init(&sha);
+    SHA1_Update(&sha, input.c_str(), input.size());
+    SHA1_Final(hash.data(), &sha);
+
+    return hash;
+}
+}  // namespace launchdarkly::encoding

--- a/libs/internal/src/encoding/sha_256.cpp
+++ b/libs/internal/src/encoding/sha_256.cpp
@@ -1,24 +1,19 @@
-#include "openssl/sha.h"
+#include <openssl/sha.h>
 
 #include <launchdarkly/encoding/sha_256.hpp>
-
-#include <functional>
-#include <iomanip>
-#include <sstream>
 
 namespace launchdarkly::encoding {
 
 std::array<unsigned char, SHA256_DIGEST_LENGTH> Sha256String(
     std::string const& input) {
-    unsigned char hash[SHA256_DIGEST_LENGTH];
+    std::array<unsigned char, SHA256_DIGEST_LENGTH> hash;
+
     SHA256_CTX sha256;
     SHA256_Init(&sha256);
     SHA256_Update(&sha256, input.c_str(), input.size());
-    SHA256_Final(hash, &sha256);
+    SHA256_Final(hash.data(), &sha256);
 
-    std::array<unsigned char, SHA256_DIGEST_LENGTH> out;
-    std::copy(std::begin(hash), std::end(hash), out.begin());
-    return out;
+    return hash;
 }
 
 }  // namespace launchdarkly::encoding

--- a/libs/internal/tests/sha_1_test.cpp
+++ b/libs/internal/tests/sha_1_test.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include "launchdarkly/encoding/base_16.hpp"
+#include "launchdarkly/encoding/sha_1.hpp"
+
+using namespace launchdarkly::encoding;
+
+TEST(Sha1, CanEncodeString) {
+    // Test vectors from
+    // https://www.di-mgt.com.au/sha_testvectors.html
+    EXPECT_EQ(std::string("da39a3ee5e6b4b0d3255bfef95601890afd80709"),
+              Base16Encode(Sha1String("")));
+
+    EXPECT_EQ(std::string("a9993e364706816aba3e25717850c26c9cd0d89d"),
+              Base16Encode(Sha1String("abc")));
+
+    EXPECT_EQ(std::string("84983e441c3bd26ebaae4aa1f95129e5e54670f1"),
+              Base16Encode(Sha1String(
+                  "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")));
+}

--- a/libs/internal/tests/sha_256_test.cpp
+++ b/libs/internal/tests/sha_256_test.cpp
@@ -1,18 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "launchdarkly/encoding/base_16.hpp"
 #include "launchdarkly/encoding/sha_256.hpp"
 
-using launchdarkly::encoding::Sha256String;
-
-static std::string HexEncode(std::array<unsigned char, 32> arr) {
-    std::stringstream output_stream;
-    output_stream << std::hex << std::noshowbase;
-    for (unsigned char byte : arr) {
-        output_stream << std::setw(2) << std::setfill('0')
-                      << static_cast<int>(byte);
-    }
-    return output_stream.str();
-}
+using namespace launchdarkly::encoding;
 
 TEST(Sha256, CanEncodeString) {
     // Test vectors from
@@ -20,16 +11,16 @@ TEST(Sha256, CanEncodeString) {
     EXPECT_EQ(
         std::string(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
-        HexEncode(Sha256String("")));
+        Base16Encode(Sha256String("")));
 
     EXPECT_EQ(
         std::string(
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
-        HexEncode(Sha256String("abc")));
+        Base16Encode(Sha256String("abc")));
 
     EXPECT_EQ(
         std::string(
             "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
-        HexEncode(Sha256String(
+        Base16Encode(Sha256String(
             "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")));
 }


### PR DESCRIPTION
Adds a new `sha1` hash function, implemented similar to the existing `sha256`. 

I've also extracted the hex encoding routine from sha256's tests into a dedicated header so it can be reused in sha1's tests or elsewhere. 