### PR TITLE
feat: evaluation stack for detecting cyclic references

### DIFF
--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -6,7 +6,8 @@ file(GLOB HEADER_LIST CONFIGURE_DEPENDS
 # Automatic library: static or dynamic based on user config.
 
 add_library(${LIBNAME}
-        ${HEADER_LIST})
+        ${HEADER_LIST}
+        evaluation/detail/evaluation_stack.cpp)
 
 if (MSVC OR (NOT BUILD_SHARED_LIBS))
     target_link_libraries(${LIBNAME}

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
@@ -1,0 +1,31 @@
+#include "evaluation_stack.hpp"
+
+namespace launchdarkly::server_side::evaluation::detail {
+
+Guard::Guard(std::unordered_set<std::string>& set, std::string const& key)
+    : set_(set), key_(key) {
+    set_.insert(key_);
+}
+
+Guard::~Guard() {
+    set_.erase(key_);
+}
+
+Guard EvaluationStack::NoticePrerequisite(std::string const& prerequisite_key) {
+    return {prerequisites_seen_, prerequisite_key};
+}
+
+Guard EvaluationStack::NoticeSegment(std::string const& segment_key) {
+    return {segments_seen_, segment_key};
+}
+
+bool EvaluationStack::SeenPrerequisite(
+    std::string const& prerequisite_key) const {
+    return prerequisites_seen_.count(prerequisite_key) != 0;
+}
+
+bool EvaluationStack::SeenSegment(std::string const& segment_key) const {
+    return segments_seen_.count(segment_key) != 0;
+}
+
+}  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
@@ -11,21 +11,20 @@ Guard::~Guard() {
     set_.erase(key_);
 }
 
-Guard EvaluationStack::NoticePrerequisite(std::string const& prerequisite_key) {
-    return {prerequisites_seen_, prerequisite_key};
+std::optional<Guard> EvaluationStack::NoticePrerequisite(
+    std::string const& prerequisite_key) {
+    if (prerequisites_seen_.count(prerequisite_key) != 0) {
+        return std::nullopt;
+    }
+    return std::make_optional<Guard>(prerequisites_seen_, prerequisite_key);
 }
 
-Guard EvaluationStack::NoticeSegment(std::string const& segment_key) {
-    return {segments_seen_, segment_key};
-}
-
-bool EvaluationStack::SeenPrerequisite(
-    std::string const& prerequisite_key) const {
-    return prerequisites_seen_.count(prerequisite_key) != 0;
-}
-
-bool EvaluationStack::SeenSegment(std::string const& segment_key) const {
-    return segments_seen_.count(segment_key) != 0;
+std::optional<Guard> EvaluationStack::NoticeSegment(
+    std::string const& segment_key) {
+    if (segments_seen_.count(segment_key) != 0) {
+        return std::nullopt;
+    }
+    return std::make_optional<Guard>(segments_seen_, segment_key);
 }
 
 }  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace launchdarkly::server_side::evaluation::detail {
+
+/**
+ * Guard is an object used to track that a segment or flag key has been noticed.
+ * Upon destruction, the key is forgotten.
+ */
+struct Guard {
+    Guard(std::unordered_set<std::string>& set, std::string const& key);
+    ~Guard();
+
+    Guard(Guard const&) = delete;
+    Guard& operator=(Guard const&) = delete;
+
+    Guard(Guard&&) = delete;
+    Guard& operator=(Guard&&) = delete;
+
+   private:
+    std::unordered_set<std::string>& set_;
+    std::string const& key_;
+};
+
+/**
+ * EvaluationStack is used to track which segments and flags have been noticed
+ * during evaluation in order to detect circular references.
+ *
+ * Intended usage is to first call Seen[Segment|Prerequisite] to check if the
+ * segment/flag was already seen during this evaluation.
+ *
+ * If so, this indicates a circular reference. If not, call
+ * Notice[Segment|Prerequisite] to mark it as seen for the duration of the
+ * returned Guard's lifetime.
+ */
+class EvaluationStack {
+   public:
+    EvaluationStack() = default;
+
+    /**
+     * Marks a prerequisite as noticed. The prerequisite will be forgotten when
+     * the returned Guard destructs.
+     *
+     * Must only be called if Seen returns false.
+     *
+     * @param prerequisite_key Key of the prerequisite.
+     * @return Guard object representing the fact that a prerequisite has been
+     * seen for the duration of the returned object's lifetime.
+     */
+    [[nodiscard]] Guard NoticePrerequisite(std::string const& prerequisite_key);
+
+    /**
+     * Marks a segment as noticed. The segment will be forgotten when the
+     * returned Guard destructs.
+     *
+     * Must only be called if Seen returns false.
+     *
+     * @param segment_key Key of the segment.
+     * @return Guard object representing the fact that a segment has been seen
+     * for the duration of the returned object's lifetime.
+     */
+    [[nodiscard]] Guard NoticeSegment(std::string const& segment_key);
+
+    /**
+     * Returns true if the prerequisite has been seen.
+     */
+    bool SeenPrerequisite(std::string const& prerequisite_key) const;
+
+    /**
+     * Returns true if the segment has been seen.
+     */
+    bool SeenSegment(std::string const& segment_key) const;
+
+   private:
+    std::unordered_set<std::string> prerequisites_seen_;
+    std::unordered_set<std::string> segments_seen_;
+};
+
+}  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <unordered_set>
 
@@ -49,7 +50,8 @@ class EvaluationStack {
      * @return Guard object representing the fact that a prerequisite has been
      * seen for the duration of the returned object's lifetime.
      */
-    [[nodiscard]] Guard NoticePrerequisite(std::string const& prerequisite_key);
+    [[nodiscard]] std::optional<Guard> NoticePrerequisite(
+        std::string const& prerequisite_key);
 
     /**
      * Marks a segment as noticed. The segment will be forgotten when the
@@ -61,17 +63,8 @@ class EvaluationStack {
      * @return Guard object representing the fact that a segment has been seen
      * for the duration of the returned object's lifetime.
      */
-    [[nodiscard]] Guard NoticeSegment(std::string const& segment_key);
-
-    /**
-     * Returns true if the prerequisite has been seen.
-     */
-    bool SeenPrerequisite(std::string const& prerequisite_key) const;
-
-    /**
-     * Returns true if the segment has been seen.
-     */
-    bool SeenSegment(std::string const& segment_key) const;
+    [[nodiscard]] std::optional<Guard> NoticeSegment(
+        std::string const& segment_key);
 
    private:
     std::unordered_set<std::string> prerequisites_seen_;

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
@@ -28,40 +28,27 @@ struct Guard {
 /**
  * EvaluationStack is used to track which segments and flags have been noticed
  * during evaluation in order to detect circular references.
- *
- * Intended usage is to first call Seen[Segment|Prerequisite] to check if the
- * segment/flag was already seen during this evaluation.
- *
- * If so, this indicates a circular reference. If not, call
- * Notice[Segment|Prerequisite] to mark it as seen for the duration of the
- * returned Guard's lifetime.
  */
 class EvaluationStack {
    public:
     EvaluationStack() = default;
 
     /**
-     * Marks a prerequisite as noticed. The prerequisite will be forgotten when
-     * the returned Guard destructs.
-     *
-     * Must only be called if Seen returns false.
+     * If the given prerequisite key has not been seen, marks it as seen
+     * and returns a Guard object. Otherwise, returns std::nullopt.
      *
      * @param prerequisite_key Key of the prerequisite.
-     * @return Guard object representing the fact that a prerequisite has been
-     * seen for the duration of the returned object's lifetime.
+     * @return Guard object if not seen before, otherwise std::nullopt.
      */
     [[nodiscard]] std::optional<Guard> NoticePrerequisite(
         std::string const& prerequisite_key);
 
     /**
-     * Marks a segment as noticed. The segment will be forgotten when the
-     * returned Guard destructs.
+     * If the given segment key has not been seen, marks it as seen
+     * and returns a Guard object. Otherwise, returns std::nullopt.
      *
-     * Must only be called if Seen returns false.
-     *
-     * @param segment_key Key of the segment.
-     * @return Guard object representing the fact that a segment has been seen
-     * for the duration of the returned object's lifetime.
+     * @param prerequisite_key Key of the segment.
+     * @return Guard object if not seen before, otherwise std::nullopt.
      */
     [[nodiscard]] std::optional<Guard> NoticeSegment(
         std::string const& segment_key);

--- a/libs/server-sdk/tests/evaluation_stack_test.cpp
+++ b/libs/server-sdk/tests/evaluation_stack_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include "evaluation/detail/evaluation_stack.hpp"
+
+using namespace launchdarkly::server_side::evaluation::detail;
+
+TEST(EvalStackTests, NoticeSegments) {
+    EvaluationStack stack;
+    ASSERT_FALSE(stack.SeenSegment("foo"));
+    {
+        auto guard = stack.NoticeSegment("foo");
+        ASSERT_TRUE(stack.SeenSegment("foo"));
+    }
+    ASSERT_FALSE(stack.SeenSegment("foo"));
+}
+
+TEST(EvalStackTests, NoticePrerequisites) {
+    EvaluationStack stack;
+    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
+    {
+        auto guard = stack.NoticePrerequisite("foo");
+        ASSERT_TRUE(stack.SeenPrerequisite("foo"));
+    }
+    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
+}
+
+TEST(EvalStackTests, SegmentAndPrereqHaveSeparateCaches) {
+    EvaluationStack stack;
+    auto g1 = stack.NoticeSegment("foo");
+    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
+    auto g2 = stack.NoticePrerequisite("bar");
+    ASSERT_FALSE(stack.SeenSegment("bar"));
+}
+
+TEST(EvalStackTests, ManyNoticedKeysAreForgotten) {
+    EvaluationStack stack;
+
+    for (std::size_t i = 0; i < 100; i++) {
+        auto guard = stack.NoticeSegment(std::to_string(i));
+        ASSERT_TRUE(stack.SeenSegment(std::to_string(i)));
+    }
+
+    for (std::size_t i = 0; i < 100; i++) {
+        ASSERT_FALSE(stack.SeenSegment(std::to_string(i)));
+    }
+}

--- a/libs/server-sdk/tests/evaluation_stack_test.cpp
+++ b/libs/server-sdk/tests/evaluation_stack_test.cpp
@@ -8,16 +8,14 @@ TEST(EvalStackTests, SegmentIsNoticed) {
     EvaluationStack stack;
     auto g1 = stack.NoticeSegment("foo");
     ASSERT_TRUE(g1);
-    auto g2 = stack.NoticeSegment("foo");
-    ASSERT_FALSE(g2);
+    ASSERT_FALSE(stack.NoticeSegment("foo"));
 }
 
 TEST(EvalStackTests, PrereqIsNoticed) {
     EvaluationStack stack;
     auto g1 = stack.NoticePrerequisite("foo");
     ASSERT_TRUE(g1);
-    auto g2 = stack.NoticePrerequisite("foo");
-    ASSERT_FALSE(g2);
+    ASSERT_FALSE(stack.NoticePrerequisite("foo"));
 }
 
 TEST(EvalStackTests, NestedScopes) {
@@ -40,18 +38,16 @@ TEST(EvalStackTests, NestedScopes) {
 
 TEST(EvalStackTests, SegmentAndPrereqHaveSeparateCaches) {
     EvaluationStack stack;
-    ASSERT_TRUE(stack.NoticeSegment("foo"));
-    ASSERT_TRUE(stack.NoticePrerequisite("foo"));
+    auto g1 = stack.NoticeSegment("foo");
+    ASSERT_TRUE(g1);
+    auto g2 = stack.NoticePrerequisite("foo");
+    ASSERT_TRUE(g2);
 }
 
-TEST(EvalStackTests, ManyNoticedKeysAreForgotten) {
+TEST(EvalStackTests, ImmediateDestructionOfGuard) {
     EvaluationStack stack;
 
-    for (std::size_t i = 0; i < 100; i++) {
-        ASSERT_TRUE(stack.NoticeSegment(std::to_string(i)));
-    }
-
-    for (std::size_t i = 0; i < 100; i++) {
-        ASSERT_TRUE(stack.NoticeSegment(std::to_string(i)));
-    }
+    ASSERT_TRUE(stack.NoticeSegment("foo"));
+    ASSERT_TRUE(stack.NoticeSegment("foo"));
+    ASSERT_TRUE(stack.NoticeSegment("foo"));
 }

--- a/libs/server-sdk/tests/evaluation_stack_test.cpp
+++ b/libs/server-sdk/tests/evaluation_stack_test.cpp
@@ -4,43 +4,54 @@
 
 using namespace launchdarkly::server_side::evaluation::detail;
 
-TEST(EvalStackTests, NoticeSegments) {
+TEST(EvalStackTests, SegmentIsNoticed) {
     EvaluationStack stack;
-    ASSERT_FALSE(stack.SeenSegment("foo"));
-    {
-        auto guard = stack.NoticeSegment("foo");
-        ASSERT_TRUE(stack.SeenSegment("foo"));
-    }
-    ASSERT_FALSE(stack.SeenSegment("foo"));
+    auto g1 = stack.NoticeSegment("foo");
+    ASSERT_TRUE(g1);
+    auto g2 = stack.NoticeSegment("foo");
+    ASSERT_FALSE(g2);
 }
 
-TEST(EvalStackTests, NoticePrerequisites) {
+TEST(EvalStackTests, PrereqIsNoticed) {
     EvaluationStack stack;
-    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
+    auto g1 = stack.NoticePrerequisite("foo");
+    ASSERT_TRUE(g1);
+    auto g2 = stack.NoticePrerequisite("foo");
+    ASSERT_FALSE(g2);
+}
+
+TEST(EvalStackTests, NestedScopes) {
+    EvaluationStack stack;
     {
-        auto guard = stack.NoticePrerequisite("foo");
-        ASSERT_TRUE(stack.SeenPrerequisite("foo"));
+        auto g1 = stack.NoticeSegment("foo");
+        ASSERT_TRUE(g1);
+        ASSERT_FALSE(stack.NoticeSegment("foo"));
+        {
+            auto g2 = stack.NoticeSegment("bar");
+            ASSERT_TRUE(g2);
+            ASSERT_FALSE(stack.NoticeSegment("bar"));
+            ASSERT_FALSE(stack.NoticeSegment("foo"));
+        }
+        ASSERT_TRUE(stack.NoticeSegment("bar"));
     }
-    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
+    ASSERT_TRUE(stack.NoticeSegment("foo"));
+    ASSERT_TRUE(stack.NoticeSegment("bar"));
 }
 
 TEST(EvalStackTests, SegmentAndPrereqHaveSeparateCaches) {
     EvaluationStack stack;
-    auto g1 = stack.NoticeSegment("foo");
-    ASSERT_FALSE(stack.SeenPrerequisite("foo"));
-    auto g2 = stack.NoticePrerequisite("bar");
-    ASSERT_FALSE(stack.SeenSegment("bar"));
+    ASSERT_TRUE(stack.NoticeSegment("foo"));
+    ASSERT_TRUE(stack.NoticePrerequisite("foo"));
 }
 
 TEST(EvalStackTests, ManyNoticedKeysAreForgotten) {
     EvaluationStack stack;
 
     for (std::size_t i = 0; i < 100; i++) {
-        auto guard = stack.NoticeSegment(std::to_string(i));
-        ASSERT_TRUE(stack.SeenSegment(std::to_string(i)));
+        ASSERT_TRUE(stack.NoticeSegment(std::to_string(i)));
     }
 
     for (std::size_t i = 0; i < 100; i++) {
-        ASSERT_FALSE(stack.SeenSegment(std::to_string(i)));
+        ASSERT_TRUE(stack.NoticeSegment(std::to_string(i)));
     }
 }


### PR DESCRIPTION
Adds a data structure for detecting circular references during evaluation. It is called `EvaluationStack` and uses RAII to notice/forget keys. 

Intended usage is like:
```c++
if (auto guard = stack.SeenPrerequisite("foo")) {
   // Now "foo" has been seen. Can't obtain another guard until this one is destroyed.
   assert_false(stack.SeenPrerequisite("foo"))
}
```