### PR TITLE
feat: timestamp parsing from Values

### DIFF
--- a/cmake/rfc3339_timestamp.cmake
+++ b/cmake/rfc3339_timestamp.cmake
@@ -1,0 +1,31 @@
+FetchContent_Declare(timestamp
+        GIT_REPOSITORY https://github.com/chansen/c-timestamp
+        GIT_TAG "b205c407ae6680d23d74359ac00444b80989792f"
+        )
+
+FetchContent_GetProperties(timestamp)
+if (NOT timestamp_POPULATED)
+    FetchContent_Populate(timestamp)
+endif ()
+
+add_library(timestamp OBJECT
+        ${timestamp_SOURCE_DIR}/timestamp_tm.c
+        ${timestamp_SOURCE_DIR}/timestamp_valid.c
+        ${timestamp_SOURCE_DIR}/timestamp_parse.c
+        )
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties(timestamp PROPERTIES
+            POSITION_INDEPENDENT_CODE 1
+            C_VISIBILITY_PRESET hidden
+            )
+endif ()
+
+target_include_directories(timestamp PUBLIC
+        $<BUILD_INTERFACE:${timestamp_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include/timestamp>
+        )
+install(
+        TARGETS timestamp
+        EXPORT ${PROJECT_NAME}-targets
+)

--- a/libs/server-sdk/CMakeLists.txt
+++ b/libs/server-sdk/CMakeLists.txt
@@ -27,6 +27,9 @@ endif ()
 # Needed to fetch external dependencies. 
 include(FetchContent)
 
+# Needed to parse RFC3339 dates in flag rules.
+include(${CMAKE_FILES}/rfc3339_timestamp.cmake)
+
 # Add main SDK sources.
 add_subdirectory(src)
 

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -6,12 +6,13 @@ file(GLOB HEADER_LIST CONFIGURE_DEPENDS
 # Automatic library: static or dynamic based on user config.
 
 add_library(${LIBNAME}
-        ${HEADER_LIST})
+        ${HEADER_LIST}
+        evaluation/detail/timestamp_operations.cpp)
 
 if (MSVC OR (NOT BUILD_SHARED_LIBS))
     target_link_libraries(${LIBNAME}
             PUBLIC launchdarkly::common
-            PRIVATE Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy)
+            PRIVATE Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy timestamp)
 else ()
     # The default static lib builds, for linux, are positition independent.
     # So they do not link into a shared object without issues. So, when
@@ -20,7 +21,7 @@ else ()
     # macOS shares the same path for simplicity.
     target_link_libraries(${LIBNAME}
             PUBLIC launchdarkly::common
-            PRIVATE Boost::headers launchdarkly::sse launchdarkly::internal foxy)
+            PRIVATE Boost::headers launchdarkly::sse launchdarkly::internal foxy timestamp)
 
     target_sources(${LIBNAME} PRIVATE boost.cpp)
 endif ()

--- a/libs/server-sdk/src/evaluation/detail/timestamp_operations.cpp
+++ b/libs/server-sdk/src/evaluation/detail/timestamp_operations.cpp
@@ -1,0 +1,55 @@
+#include "timestamp_operations.hpp"
+
+#include "timestamp.h"
+
+#include <cmath>
+#include <sstream>
+
+namespace launchdarkly::server_side::evaluation::detail {
+
+std::optional<Timepoint> MillisecondsToTimepoint(double ms);
+
+std::optional<Timepoint> RFC3339ToTimepoint(std::string const& timestamp);
+
+std::optional<Timepoint> ToTimepoint(Value const& value) {
+    if (value.Type() == Value::Type::kNumber) {
+        double const epoch_ms = value.AsDouble();
+        return MillisecondsToTimepoint(epoch_ms);
+    }
+    if (value.Type() == Value::Type::kString) {
+        std::string const& rfc3339_timestamp = value.AsString();
+        return RFC3339ToTimepoint(rfc3339_timestamp);
+    }
+    return std::nullopt;
+}
+
+std::optional<Timepoint> MillisecondsToTimepoint(double ms) {
+    if (ms < 0.0) {
+        return std::nullopt;
+    }
+    if (std::trunc(ms) == ms) {
+        return std::chrono::system_clock::time_point{
+            std::chrono::milliseconds{static_cast<long long>(ms)}};
+    }
+    return std::nullopt;
+}
+
+std::optional<Timepoint> RFC3339ToTimepoint(std::string const& timestamp) {
+    if (timestamp.empty()) {
+        return std::nullopt;
+    }
+
+    timestamp_t ts{};
+    if (timestamp_parse(timestamp.c_str(), timestamp.size(), &ts)) {
+        return std::nullopt;
+    }
+
+    Timepoint epoch{};
+    epoch += std::chrono::seconds{ts.sec};
+    epoch +=
+        std::chrono::floor<Clock::duration>(std::chrono::nanoseconds{ts.nsec});
+
+    return epoch;
+}
+
+}  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/detail/timestamp_operations.hpp
+++ b/libs/server-sdk/src/evaluation/detail/timestamp_operations.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <launchdarkly/value.hpp>
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+namespace launchdarkly::server_side::evaluation::detail {
+
+using Clock = std::chrono::system_clock;
+using Timepoint = Clock::time_point;
+
+[[nodiscard]] std::optional<Timepoint> ToTimepoint(Value const& value);
+
+}  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/tests/CMakeLists.txt
+++ b/libs/server-sdk/tests/CMakeLists.txt
@@ -14,6 +14,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}../")
 
 add_executable(gtest_${LIBNAME}
         ${tests})
-target_link_libraries(gtest_${LIBNAME} launchdarkly::server launchdarkly::internal GTest::gtest_main)
+target_link_libraries(gtest_${LIBNAME} launchdarkly::server launchdarkly::internal GTest::gtest_main timestamp)
 
 gtest_discover_tests(gtest_${LIBNAME})

--- a/libs/server-sdk/tests/timestamp_tests.cpp
+++ b/libs/server-sdk/tests/timestamp_tests.cpp
@@ -1,0 +1,94 @@
+#include "evaluation/detail/timestamp_operations.hpp"
+
+#include <gtest/gtest.h>
+
+#include <unordered_map>
+
+using namespace launchdarkly::server_side::evaluation::detail;
+using namespace std::chrono_literals;
+
+static Timepoint BasicDate() {
+    return std::chrono::system_clock::from_time_t(1577836800);
+}
+
+struct TimestampTest {
+    launchdarkly::Value input;
+    char const* explanation;
+    std::optional<Timepoint> expected;
+};
+
+class TimestampTests : public ::testing::TestWithParam<TimestampTest> {};
+TEST_P(TimestampTests, ExpectedTimestampIsParsed) {
+    auto const& param = GetParam();
+
+    std::optional<Timepoint> result = ToTimepoint(param.input);
+
+    constexpr auto print_tp =
+        [](std::optional<Timepoint> const& expected) -> std::string {
+        if (expected) {
+            return std::to_string(expected.value().time_since_epoch().count());
+        } else {
+            return "(none)";
+        }
+    };
+
+    ASSERT_EQ(result, param.expected)
+        << param.explanation << ": input was " << param.input << ", expected "
+        << print_tp(param.expected) << " but got " << print_tp(result);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ValidTimestamps,
+    TimestampTests,
+    ::testing::ValuesIn({
+        TimestampTest{0.0, "default constructed", Timepoint{}},
+        TimestampTest{1000.0, "1 second", Timepoint{1s}},
+        TimestampTest{1000.0 * 60, "60 seconds", Timepoint{60s}},
+        TimestampTest{1000.0 * 60 * 60, "1 hour", Timepoint{60min}},
+        TimestampTest{"2020-01-01T00:00:00Z", "with Zulu offset", BasicDate()},
+        TimestampTest{"2020-01-01T00:00:00+00:00", "with normal offset",
+                      BasicDate()},
+        TimestampTest{"2020-01-01T01:00:00+01:00", "with 1hr offset",
+                      BasicDate()},
+        TimestampTest{"2020-01-01T01:00:00+01:00",
+                      "with colon-delimited offset", BasicDate()},
+
+        TimestampTest{"2020-01-01T00:00:00.123Z", "with milliseconds",
+                      BasicDate() + 123ms},
+        TimestampTest{"2020-01-01T00:00:00.123+00:00",
+                      "with milliseconds and offset", BasicDate() + 123ms},
+        TimestampTest{"2020-01-01T00:00:00.000123Z", "with microseconds ",
+                      BasicDate() + 123us},
+        TimestampTest{"2020-01-01T00:00:00.000123+00:00",
+                      "with microseconds and offset", BasicDate() + 123us},
+        TimestampTest{"2020-01-01T00:00:00.123456789Z",
+                      "floor nanoseconds with zulu offset",
+                      BasicDate() + 123ms + 456us},
+        TimestampTest{"2020-01-01T01:00:00.123456789+01:00",
+                      "floor nanoseconds with offset",
+                      BasicDate() + 123ms + 456us},
+
+    }));
+
+INSTANTIATE_TEST_SUITE_P(
+    InvalidTimestamps,
+    TimestampTests,
+    ::testing::ValuesIn({
+        TimestampTest{0.1, "not an integer", std::nullopt},
+        TimestampTest{1000.2, "not an integer", std::nullopt},
+        TimestampTest{123456.789, "not an integer", std::nullopt},
+        TimestampTest{-1000.5, "not an integer", std::nullopt},
+        TimestampTest{-1000.0, "negative integer", std::nullopt},
+        TimestampTest{"", "empty string", std::nullopt},
+        TimestampTest{"2020-01-01T00:00:00/foo", "invalid offset",
+                      std::nullopt},
+        TimestampTest{"2020-01-01T00:00:00.0000000001Z",
+                      "more than 9 digits of precision", std::nullopt},
+        TimestampTest{launchdarkly::Value::Null(), "not a number or string",
+                      std::nullopt},
+        TimestampTest{launchdarkly::Value::Array(), "not a number or string",
+                      std::nullopt},
+        TimestampTest{launchdarkly::Value::Object(), "not a number or string",
+                      std::nullopt},
+
+    }));


### PR DESCRIPTION
Adds the ability to parse timestamps from string or numeric `Value`s. 

This uses the same RFC3339 parser from the C Server SDK, so results should be consistent. 