### PR TITLE
feat: context bucketing logic

### DIFF
--- a/libs/common/include/launchdarkly/context.hpp
+++ b/libs/common/include/launchdarkly/context.hpp
@@ -57,8 +57,9 @@ class Context final {
      * @param ref The reference to the desired attribute.
      * @return The attribute Value or a Value representing null.
      */
-    Value const& Get(std::string const& kind,
-                     launchdarkly::AttributeReference const& ref);
+    [[nodiscard]] Value const& Get(
+        std::string const& kind,
+        launchdarkly::AttributeReference const& ref) const;
 
     /**
      * Check if a context is valid.

--- a/libs/common/include/launchdarkly/detail/c_binding_helpers.hpp
+++ b/libs/common/include/launchdarkly/detail/c_binding_helpers.hpp
@@ -1,10 +1,11 @@
 #include <launchdarkly/bindings/c/status.h>
-#include <cassert>
-#include <functional>
 #include <launchdarkly/error.hpp>
-#include <optional>
 
 #include <tl/expected.hpp>
+
+#include <cassert>
+#include <functional>
+#include <optional>
 
 namespace launchdarkly {
 template <typename T, typename = void>

--- a/libs/common/src/context.cpp
+++ b/libs/common/src/context.cpp
@@ -40,7 +40,7 @@ Context::Context(std::map<std::string, launchdarkly::Attributes> attributes)
 }
 
 Value const& Context::Get(std::string const& kind,
-                          AttributeReference const& ref) {
+                          AttributeReference const& ref) const {
     auto found = attributes_.find(kind);
     if (found != attributes_.end()) {
         return found->second.Get(ref);
@@ -64,7 +64,7 @@ std::string Context::make_canonical_key() {
     if (kinds_to_keys_.size() == 1) {
         if (auto iterator = kinds_to_keys_.find("user");
             iterator != kinds_to_keys_.end()) {
-            return std::string(iterator->second);
+            return iterator->second;
         }
     }
     std::stringstream stream;

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -9,7 +9,9 @@ add_library(${LIBNAME}
         ${HEADER_LIST}
         evaluation/detail/evaluation_stack.cpp
         evaluation/detail/semver_operations.cpp
-        evaluation/detail/timestamp_operations.cpp)
+        evaluation/detail/timestamp_operations.cpp
+        evaluation/evaluation_error.cpp
+        evaluation/bucketing.cpp)
 
 if (MSVC OR (NOT BUILD_SHARED_LIBS))
     target_link_libraries(${LIBNAME}

--- a/libs/server-sdk/src/evaluation/bucketing.cpp
+++ b/libs/server-sdk/src/evaluation/bucketing.cpp
@@ -77,6 +77,8 @@ AttributeReference const& Key() {
 }
 
 std::optional<float> ContextHash(Value const& value, BucketPrefix prefix) {
+    using namespace launchdarkly::encoding;
+
     std::optional<std::string> id = BucketValue(value);
     if (!id) {
         return std::nullopt;
@@ -86,16 +88,15 @@ std::optional<float> ContextHash(Value const& value, BucketPrefix prefix) {
     input << prefix << "." << *id;
 
     std::array<unsigned char, SHA_DIGEST_LENGTH> const sha1hash =
-        launchdarkly::encoding::Sha1String(input.str());
+        Sha1String(input.str());
 
-    std::string const sha1hash_hexed =
-        launchdarkly::encoding::Base16Encode(sha1hash);
+    std::string const sha1hash_hexed = Base16Encode(sha1hash);
 
     std::string const sha1hash_hexed_first_15 = sha1hash_hexed.substr(0, 15);
 
     try {
         unsigned long long as_number =
-            std::stoull(sha1hash_hexed_first_15.data(), nullptr, 16);
+            std::stoull(sha1hash_hexed_first_15.data(), nullptr, /* base */ 16);
 
         double as_double = static_cast<double>(as_number);
         return as_double / kBucketScale;

--- a/libs/server-sdk/src/evaluation/bucketing.cpp
+++ b/libs/server-sdk/src/evaluation/bucketing.cpp
@@ -1,0 +1,128 @@
+#include "bucketing.hpp"
+
+#include <launchdarkly/detail/c_binding_helpers.hpp>
+#include <launchdarkly/encoding/base_16.hpp>
+#include <launchdarkly/encoding/sha_1.hpp>
+
+#include <string_view>
+
+namespace launchdarkly::server_side::evaluation {
+
+constexpr std::int64_t kBucketScaleInt = 0x0FFFFFFFFFFFFFFF;
+
+static_assert(kBucketScaleInt < std::numeric_limits<double>::max(),
+              "Bucket scale is too large to be represented as a double");
+constexpr double kBucketScaleDouble = static_cast<double>(kBucketScaleInt);
+
+BucketPrefix::BucketPrefix(Seed seed) : prefix_(seed) {}
+
+BucketPrefix::BucketPrefix(std::string key, std::string salt)
+    : prefix_(KeyAndSalt{key, salt}) {}
+
+void BucketPrefix::Update(std::string* input) const {
+    return std::visit(
+        [&](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, KeyAndSalt>) {
+                input->append(arg.key);
+                input->push_back('.');
+                input->append(arg.salt);
+            } else if constexpr (std::is_same_v<T, Seed>) {
+                input->append(std::to_string(arg));
+            }
+        },
+        prefix_);
+}
+
+tl::expected<std::pair<ContextHashValue, RolloutKindPresence>, Error> Bucket(
+    Context const& context,
+    AttributeReference const& by_attr,
+    BucketPrefix const& prefix,
+    bool is_experiment,
+    std::string const& context_kind) {
+    AttributeReference ref =
+        is_experiment ? AttributeReference("key") : std::move(by_attr);
+
+    if (!ref.Valid()) {
+        return tl::make_unexpected(Error::kInvalidAttributeReference);
+    }
+
+    Value value = context.Get(context_kind, ref);
+
+    bool is_bucketable = value.Type() == Value::Type::kNumber ||
+                         value.Type() == Value::Type::kString;
+
+    if (is_bucketable) {
+        return std::make_pair(
+            ComputeBucket(value, prefix, is_experiment).value_or(0.0),
+            RolloutKindPresence::kPresent);
+    }
+
+    auto rollout_context_found =
+        std::count(context.Kinds().begin(), context.Kinds().end(),
+                   context_kind) > 0
+            ? RolloutKindPresence::kPresent
+            : RolloutKindPresence::kAbsent;
+
+    return std::make_pair(0.0, rollout_context_found);
+}
+
+std::optional<float> ComputeBucket(Value const& value,
+                                   BucketPrefix prefix,
+                                   bool is_experiment) {
+    LD_ASSERT(value.Type() == Value::Type::kNumber ||
+              value.Type() == Value::Type::kString);
+
+    std::optional<std::string> id = BucketValue(value);
+    if (!id) {
+        return std::nullopt;
+    }
+
+    std::string input;
+    prefix.Update(&input);
+    input.push_back('.');
+    input.append(*id);
+
+    std::array<unsigned char, SHA_DIGEST_LENGTH> const sha1hash =
+        launchdarkly::encoding::Sha1String(input);
+
+    std::string const sha1hash_hexed =
+        launchdarkly::encoding::Base16Encode(sha1hash);
+
+    std::string const sha1hash_hexed_first_15 = sha1hash_hexed.substr(0, 15);
+
+    try {
+        unsigned long long as_number =
+            std::stoull(sha1hash_hexed_first_15.data(), nullptr, 16);
+
+        double as_double = static_cast<double>(as_number);
+        return as_double / kBucketScaleDouble;
+
+    } catch (std::invalid_argument) {
+        return std::nullopt;
+    } catch (std::out_of_range) {
+        return std::nullopt;
+    }
+}
+
+inline bool IsIntegral(double f) {
+    return std::trunc(f) == f;
+}
+
+std::optional<std::string> BucketValue(Value const& value) {
+    switch (value.Type()) {
+        case Value::Type::kString:
+            return value.AsString();
+        case Value::Type::kNumber: {
+            if (IsIntegral(value.AsDouble())) {
+                return std::to_string(value.AsInt());
+            } else {
+                return std::nullopt;
+            }
+        }
+        default:
+            return std::nullopt;
+    }
+}
+
+}  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/bucketing.cpp
+++ b/libs/server-sdk/src/evaluation/bucketing.cpp
@@ -4,44 +4,48 @@
 #include <launchdarkly/encoding/base_16.hpp>
 #include <launchdarkly/encoding/sha_1.hpp>
 
+#include <sstream>
 #include <string_view>
 
 namespace launchdarkly::server_side::evaluation {
 
-constexpr std::int64_t kBucketScaleInt = 0x0FFFFFFFFFFFFFFF;
+double const kBucketScale = static_cast<double>(0x0FFFFFFFFFFFFFFF);
 
-static_assert(kBucketScaleInt < std::numeric_limits<double>::max(),
-              "Bucket scale is too large to be represented as a double");
-constexpr double kBucketScaleDouble = static_cast<double>(kBucketScaleInt);
+AttributeReference const& Key();
+
+std::optional<ContextHashValue> ContextHash(Value const& value,
+                                            BucketPrefix prefix);
+
+std::optional<std::string> BucketValue(Value const& value);
+
+bool IsIntegral(double f);
 
 BucketPrefix::BucketPrefix(Seed seed) : prefix_(seed) {}
 
 BucketPrefix::BucketPrefix(std::string key, std::string salt)
     : prefix_(KeyAndSalt{key, salt}) {}
 
-void BucketPrefix::Update(std::string* input) const {
-    return std::visit(
+std::ostream& operator<<(std::ostream& os, BucketPrefix const& prefix) {
+    std::visit(
         [&](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, KeyAndSalt>) {
-                input->append(arg.key);
-                input->push_back('.');
-                input->append(arg.salt);
-            } else if constexpr (std::is_same_v<T, Seed>) {
-                input->append(std::to_string(arg));
+            if constexpr (std::is_same_v<T, BucketPrefix::KeyAndSalt>) {
+                os << arg.key << "." << arg.salt;
+            } else if constexpr (std::is_same_v<T, BucketPrefix::Seed>) {
+                os << arg;
             }
         },
-        prefix_);
+        prefix.prefix_);
+    return os;
 }
 
-tl::expected<std::pair<ContextHashValue, RolloutKindPresence>, Error> Bucket(
+tl::expected<std::pair<ContextHashValue, RolloutKindLookup>, Error> Bucket(
     Context const& context,
     AttributeReference const& by_attr,
     BucketPrefix const& prefix,
     bool is_experiment,
     std::string const& context_kind) {
-    AttributeReference ref =
-        is_experiment ? AttributeReference("key") : std::move(by_attr);
+    AttributeReference const& ref = is_experiment ? Key() : by_attr;
 
     if (!ref.Valid()) {
         return tl::make_unexpected(Error::kInvalidAttributeReference);
@@ -53,38 +57,36 @@ tl::expected<std::pair<ContextHashValue, RolloutKindPresence>, Error> Bucket(
                          value.Type() == Value::Type::kString;
 
     if (is_bucketable) {
-        return std::make_pair(
-            ComputeBucket(value, prefix, is_experiment).value_or(0.0),
-            RolloutKindPresence::kPresent);
+        return std::make_pair(ContextHash(value, prefix).value_or(0.0),
+                              RolloutKindLookup::kPresent);
     }
 
     auto rollout_context_found =
         std::count(context.Kinds().begin(), context.Kinds().end(),
-                   context_kind) > 0
-            ? RolloutKindPresence::kPresent
-            : RolloutKindPresence::kAbsent;
+                   context_kind) > 0;
 
-    return std::make_pair(0.0, rollout_context_found);
+    return std::make_pair(0.0, rollout_context_found
+                                   ? RolloutKindLookup::kPresent
+                                   : RolloutKindLookup::kAbsent);
 }
 
-std::optional<float> ComputeBucket(Value const& value,
-                                   BucketPrefix prefix,
-                                   bool is_experiment) {
-    LD_ASSERT(value.Type() == Value::Type::kNumber ||
-              value.Type() == Value::Type::kString);
+AttributeReference const& Key() {
+    static AttributeReference const key{"key"};
+    LD_ASSERT(key.Valid());
+    return key;
+}
 
+std::optional<float> ContextHash(Value const& value, BucketPrefix prefix) {
     std::optional<std::string> id = BucketValue(value);
     if (!id) {
         return std::nullopt;
     }
 
-    std::string input;
-    prefix.Update(&input);
-    input.push_back('.');
-    input.append(*id);
+    std::stringstream input;
+    input << prefix << "." << *id;
 
     std::array<unsigned char, SHA_DIGEST_LENGTH> const sha1hash =
-        launchdarkly::encoding::Sha1String(input);
+        launchdarkly::encoding::Sha1String(input.str());
 
     std::string const sha1hash_hexed =
         launchdarkly::encoding::Base16Encode(sha1hash);
@@ -96,17 +98,13 @@ std::optional<float> ComputeBucket(Value const& value,
             std::stoull(sha1hash_hexed_first_15.data(), nullptr, 16);
 
         double as_double = static_cast<double>(as_number);
-        return as_double / kBucketScaleDouble;
+        return as_double / kBucketScale;
 
     } catch (std::invalid_argument) {
         return std::nullopt;
     } catch (std::out_of_range) {
         return std::nullopt;
     }
-}
-
-inline bool IsIntegral(double f) {
-    return std::trunc(f) == f;
 }
 
 std::optional<std::string> BucketValue(Value const& value) {
@@ -116,13 +114,16 @@ std::optional<std::string> BucketValue(Value const& value) {
         case Value::Type::kNumber: {
             if (IsIntegral(value.AsDouble())) {
                 return std::to_string(value.AsInt());
-            } else {
-                return std::nullopt;
             }
+            return std::nullopt;
         }
         default:
             return std::nullopt;
     }
+}
+
+bool IsIntegral(double f) {
+    return std::trunc(f) == f;
 }
 
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/bucketing.hpp
+++ b/libs/server-sdk/src/evaluation/bucketing.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "evaluation_error.hpp"
+
+#include <launchdarkly/attribute_reference.hpp>
+#include <launchdarkly/context.hpp>
+#include <launchdarkly/data_model/flag.hpp>
+
+#include <tl/expected.hpp>
+
+#include <limits>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace launchdarkly::server_side::evaluation {
+
+enum RolloutKindPresence {
+    /* The rollout's contextKind was found in the current evaluation context. */
+    kPresent,
+    /* The rollout's contextKind was not found in the current evaluation
+     * context. */
+    kAbsent
+};
+
+class BucketPrefix {
+   public:
+    struct KeyAndSalt {
+        std::string key;
+        std::string salt;
+    };
+
+    using Seed = std::int64_t;
+
+    BucketPrefix(Seed seed);
+    BucketPrefix(std::string key, std::string salt);
+
+    void Update(std::string* input) const;
+
+   private:
+    std::variant<KeyAndSalt, Seed> prefix_;
+};
+
+struct BucketResult {
+    std::size_t variation_index;
+    bool in_experiment;
+
+    BucketResult(
+        data_model::Flag::Rollout::WeightedVariation weighted_variation,
+        bool is_experiment)
+        : variation_index(weighted_variation.variation),
+          in_experiment(is_experiment && !weighted_variation.untracked) {}
+
+    BucketResult(data_model::Flag::Variation variation, bool in_experiment)
+        : variation_index(variation), in_experiment(in_experiment) {}
+
+    BucketResult(data_model::Flag::Variation variation)
+        : variation_index(variation), in_experiment(false) {}
+};
+
+std::optional<float> ComputeBucket(Value const& value,
+                                   BucketPrefix prefix,
+                                   bool is_experiment);
+
+std::optional<std::string> BucketValue(Value const& value);
+
+using ContextHashValue = float;
+
+tl::expected<std::pair<ContextHashValue, RolloutKindPresence>, Error> Bucket(
+    Context const& context,
+    AttributeReference const& by_attr,
+    BucketPrefix const& prefix,
+    bool is_experiment,
+    std::string const& context_kind);
+
+}  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/bucketing.hpp
+++ b/libs/server-sdk/src/evaluation/bucketing.hpp
@@ -10,19 +10,26 @@
 
 #include <limits>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <variant>
 
 namespace launchdarkly::server_side::evaluation {
 
-enum RolloutKindPresence {
-    /* The rollout's contextKind was found in the current evaluation context. */
+enum RolloutKindLookup {
+    /* The rollout's context kind was found in the supplied evaluation context.
+     */
     kPresent,
-    /* The rollout's contextKind was not found in the current evaluation
+    /* The rollout's context kind was not found in the supplied evaluation
      * context. */
     kAbsent
 };
 
+/**
+ * Bucketing is performed by hashing an input string. This string
+ * may be comprised of a seed (if the flag rule has a seed) or a combined
+ * key/salt pair.
+ */
 class BucketPrefix {
    public:
     struct KeyAndSalt {
@@ -32,41 +39,43 @@ class BucketPrefix {
 
     using Seed = std::int64_t;
 
-    BucketPrefix(Seed seed);
+    /**
+     * Constructs a BucketPrefix from a seed value.
+     * @param seed Value of the seed.
+     */
+    explicit BucketPrefix(Seed seed);
+
+    /**
+     * Constructs a BucketPrefix from a key and salt.
+     * @param key Key to use.
+     * @param salt Salt to use.
+     */
     BucketPrefix(std::string key, std::string salt);
 
-    void Update(std::string* input) const;
+    friend std::ostream& operator<<(std::ostream& os,
+                                    BucketPrefix const& prefix);
 
    private:
     std::variant<KeyAndSalt, Seed> prefix_;
 };
 
-struct BucketResult {
-    std::size_t variation_index;
-    bool in_experiment;
-
-    BucketResult(
-        data_model::Flag::Rollout::WeightedVariation weighted_variation,
-        bool is_experiment)
-        : variation_index(weighted_variation.variation),
-          in_experiment(is_experiment && !weighted_variation.untracked) {}
-
-    BucketResult(data_model::Flag::Variation variation, bool in_experiment)
-        : variation_index(variation), in_experiment(in_experiment) {}
-
-    BucketResult(data_model::Flag::Variation variation)
-        : variation_index(variation), in_experiment(false) {}
-};
-
-std::optional<float> ComputeBucket(Value const& value,
-                                   BucketPrefix prefix,
-                                   bool is_experiment);
-
-std::optional<std::string> BucketValue(Value const& value);
-
 using ContextHashValue = float;
 
-tl::expected<std::pair<ContextHashValue, RolloutKindPresence>, Error> Bucket(
+/**
+ * Computes the context hash value for an attribute in the given context
+ * identified by the given attribute reference. The hash value is
+ * augmented with the supplied bucket prefix.
+ *
+ * @param context Context to query.
+ * @param by_attr Identifier of the attribute to hash. If is_experiment is true,
+ * then "key" will be used regardless of by_attr's value.
+ * @param prefix Prefix to use when hashing.
+ * @param is_experiment Whether this rollout is an experiment.
+ * @param context_kind Which kind to inspect in the context.
+ * @return A context hash value and indication of whether or not context_kind
+ * was found in the context.
+ */
+tl::expected<std::pair<ContextHashValue, RolloutKindLookup>, Error> Bucket(
     Context const& context,
     AttributeReference const& by_attr,
     BucketPrefix const& prefix,

--- a/libs/server-sdk/src/evaluation/evaluation_error.cpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.cpp
@@ -1,0 +1,21 @@
+#include "evaluation_error.hpp"
+
+namespace launchdarkly::server_side::evaluation {
+
+std::ostream& operator<<(std::ostream& out, Error const& err) {
+    switch (err) {
+        case Error::kCyclicReference:
+            return out << "cyclicReference";
+        case Error::kBigSegmentEncountered:
+            return out << "bigSegmentEncountered";
+        case Error::kInvalidAttributeReference:
+            return out << "invalidAttributeReference";
+        case Error::kRolloutMissingVariations:
+            return out << "rolloutMissingVariations";
+        case Error::kUnknownOperator:
+            return out << "unknownOperator";
+        default:
+            return out << "unknownError";
+    }
+}
+}  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/evaluation_error.cpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.cpp
@@ -5,17 +5,24 @@ namespace launchdarkly::server_side::evaluation {
 std::ostream& operator<<(std::ostream& out, Error const& err) {
     switch (err) {
         case Error::kCyclicReference:
-            return out << "cyclicReference";
+            out << "CYCLIC_REFERENCE";
+            break;
         case Error::kBigSegmentEncountered:
-            return out << "bigSegmentEncountered";
+            out << "BIG_SEGMENT_ENCOUNTERED";
+            break;
         case Error::kInvalidAttributeReference:
-            return out << "invalidAttributeReference";
+            out << "INVALID_ATTRIBUTE_REFERENCE";
+            break;
         case Error::kRolloutMissingVariations:
-            return out << "rolloutMissingVariations";
-        case Error::kUnknownOperator:
-            return out << "unknownOperator";
+            out << "ROLLOUT_MISSING_VARIATIONS";
+            break;
+        case Error::kUnrecognizedOperator:
+            out << "UNRECOGNIZED_OPERATOR";
+            break;
         default:
-            return out << "unknownError";
+            out << "UNKNOWN_ERROR";
+            break;
     }
+    return out;
 }
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/evaluation_error.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.hpp
@@ -15,7 +15,7 @@ enum class Error {
     /* A rollout was missing variations. */
     kRolloutMissingVariations,
     /* An operator was supplied that isn't recognized by this SDK. */
-    kUnknownOperator,
+    kUnrecognizedOperator,
 };
 
 std::ostream& operator<<(std::ostream& out, Error const& arr);

--- a/libs/server-sdk/src/evaluation/evaluation_error.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <ostream>
+
+namespace launchdarkly::server_side::evaluation {
+
+enum class Error {
+    /* A cyclic reference was detected within flags or segments. */
+    kCyclicReference,
+    /* A big segment was encountered; big segments are not supported in this
+     * SDK. */
+    kBigSegmentEncountered,
+    /* Encountered an invalid attribute reference. */
+    kInvalidAttributeReference,
+    /* A rollout was missing variations. */
+    kRolloutMissingVariations,
+    /* An operator was supplied that isn't recognized by this SDK. */
+    kUnknownOperator,
+};
+
+std::ostream& operator<<(std::ostream& out, Error const& arr);
+
+}  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/tests/bucketing_tests.cpp
+++ b/libs/server-sdk/tests/bucketing_tests.cpp
@@ -1,0 +1,134 @@
+#include "evaluation/bucketing.hpp"
+
+#include <gtest/gtest.h>
+#include <launchdarkly/context_builder.hpp>
+
+using namespace launchdarkly;
+using namespace launchdarkly::server_side::evaluation;
+
+/**
+ * Note: These tests are meant to be exact duplicates of tests
+ * in other SDKs. Do not change any of the values unless they
+ * are also changed in other SDKs. These are not traditional behavioral
+ * tests so much as consistency tests to guarantee that the implementation
+ * is identical across SDKs.
+ *
+ * Tests in this file may derive from BucketingConsistencyTests to gain access
+ * to shared constants.
+ */
+class BucketingConsistencyTests : public ::testing::Test {
+   public:
+    // Bucket results must be no more than this distance from the expected
+    // value.
+    double const kBucketTolerance = 0.0000001;
+    const std::string kHashKey = "hashKey";
+    const std::string kSalt = "saltyA";
+};
+
+TEST_F(BucketingConsistencyTests, BucketContextByKey) {
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+
+    auto tests =
+        std::vector<std::pair<std::string, double>>{{"userKeyA", 0.42157587},
+                                                    {"userKeyB", 0.6708485},
+                                                    {"userKeyC", 0.10343106}};
+
+    for (auto [key, bucket] : tests) {
+        auto context = ContextBuilder().Kind("user", key).Build();
+        auto result = Bucket(context, "key", kPrefix, false, "user");
+        ASSERT_TRUE(result)
+            << key << " should be bucketed but got " << result.error();
+
+        ASSERT_NEAR(result->first, bucket, kBucketTolerance);
+    }
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByKeyWithSeed) {
+    auto const kPrefix = BucketPrefix::Seed(61);
+
+    auto tests =
+        std::vector<std::pair<std::string, double>>{{"userKeyA", 0.09801207},
+                                                    {"userKeyB", 0.14483777},
+                                                    {"userKeyC", 0.9242641}};
+
+    for (auto [key, bucket] : tests) {
+        auto context = ContextBuilder().Kind("user", key).Build();
+        auto result = Bucket(context, "key", kPrefix, false, "user");
+        ASSERT_TRUE(result)
+            << key << " should be bucketed but got " << result.error();
+
+        ASSERT_NEAR(result->first, bucket, kBucketTolerance);
+
+        auto result_diff_seed =
+            Bucket(context, "key", BucketPrefix::Seed(60), false, "user");
+        ASSERT_TRUE(result_diff_seed) << key << " should be bucketed but got "
+                                      << result_diff_seed.error();
+
+        ASSERT_NE(result_diff_seed->first, result->first);
+    }
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByInvalidReference) {
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    auto const kInvalidRef = AttributeReference();
+    ASSERT_FALSE(kInvalidRef.Valid());
+
+    auto context = ContextBuilder().Kind("user", "userKeyA").Build();
+    auto result = Bucket(context, kInvalidRef, kPrefix, false, "user");
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kInvalidAttributeReference);
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByIntAttribute) {
+    auto const kUserKey = "userKeyD";
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+
+    auto context =
+        ContextBuilder().Kind("user", kUserKey).Set("intAttr", 33'333).Build();
+    auto result = Bucket(context, "intAttr", kPrefix, false, "user");
+    ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
+                        << result.error();
+    ASSERT_NEAR(result->first, 0.54771423, kBucketTolerance);
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByStringifiedIntAttribute) {
+    auto const kUserKey = "userKeyD";
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+
+    auto context = ContextBuilder()
+                       .Kind("user", kUserKey)
+                       .Set("stringAttr", "33333")
+                       .Build();
+    auto result = Bucket(context, "stringAttr", kPrefix, false, "user");
+    ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
+                        << result.error();
+    ASSERT_NEAR(result->first, 0.54771423, kBucketTolerance);
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByFloatAttributeNotAllowed) {
+    auto const kUserKey = "userKeyE";
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+
+    auto context = ContextBuilder()
+                       .Kind("user", kUserKey)
+                       .Set("floatAttr", 999.999)
+                       .Build();
+    auto result = Bucket(context, "floatAttr", kPrefix, false, "user");
+    ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
+                        << result.error();
+    ASSERT_NEAR(result->first, 0.0, kBucketTolerance);
+}
+
+TEST_F(BucketingConsistencyTests, BucketContextByFloatAttributeThatIsInteger) {
+    auto const kUserKey = "userKeyE";
+    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+
+    auto context = ContextBuilder()
+                       .Kind("user", kUserKey)
+                       .Set("floatAttr", 33333.0)
+                       .Build();
+    auto result = Bucket(context, "floatAttr", kPrefix, false, "user");
+    ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
+                        << result.error();
+    ASSERT_NEAR(result->first, 0.54771423, kBucketTolerance);
+}

--- a/libs/server-sdk/tests/bucketing_tests.cpp
+++ b/libs/server-sdk/tests/bucketing_tests.cpp
@@ -26,7 +26,7 @@ class BucketingConsistencyTests : public ::testing::Test {
 };
 
 TEST_F(BucketingConsistencyTests, BucketContextByKey) {
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    const BucketPrefix kPrefix{kHashKey, kSalt};
 
     auto tests =
         std::vector<std::pair<std::string, double>>{{"userKeyA", 0.42157587},
@@ -44,7 +44,7 @@ TEST_F(BucketingConsistencyTests, BucketContextByKey) {
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByKeyWithSeed) {
-    auto const kPrefix = BucketPrefix::Seed(61);
+    const BucketPrefix kPrefix{61};
 
     auto tests =
         std::vector<std::pair<std::string, double>>{{"userKeyA", 0.09801207},
@@ -59,41 +59,45 @@ TEST_F(BucketingConsistencyTests, BucketContextByKeyWithSeed) {
 
         ASSERT_NEAR(result->first, bucket, kBucketTolerance);
 
-        auto result_diff_seed =
-            Bucket(context, "key", BucketPrefix::Seed(60), false, "user");
-        ASSERT_TRUE(result_diff_seed) << key << " should be bucketed but got "
-                                      << result_diff_seed.error();
+        auto result_different_seed =
+            Bucket(context, "key", BucketPrefix{60}, false, "user");
+        ASSERT_TRUE(result_different_seed)
+            << key << " should be bucketed but got "
+            << result_different_seed.error();
 
-        ASSERT_NE(result_diff_seed->first, result->first);
+        ASSERT_NE(result_different_seed->first, result->first);
     }
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByInvalidReference) {
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
-    auto const kInvalidRef = AttributeReference();
+    const BucketPrefix kPrefix{kHashKey, kSalt};
+    const AttributeReference kInvalidRef;
+
     ASSERT_FALSE(kInvalidRef.Valid());
 
     auto context = ContextBuilder().Kind("user", "userKeyA").Build();
     auto result = Bucket(context, kInvalidRef, kPrefix, false, "user");
+
     ASSERT_FALSE(result);
     ASSERT_EQ(result.error(), Error::kInvalidAttributeReference);
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByIntAttribute) {
-    auto const kUserKey = "userKeyD";
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    const std::string kUserKey = "userKeyD";
+    const BucketPrefix kPrefix{kHashKey, kSalt};
 
     auto context =
         ContextBuilder().Kind("user", kUserKey).Set("intAttr", 33'333).Build();
     auto result = Bucket(context, "intAttr", kPrefix, false, "user");
+
     ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
                         << result.error();
     ASSERT_NEAR(result->first, 0.54771423, kBucketTolerance);
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByStringifiedIntAttribute) {
-    auto const kUserKey = "userKeyD";
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    const std::string kUserKey = "userKeyD";
+    const BucketPrefix kPrefix{kHashKey, kSalt};
 
     auto context = ContextBuilder()
                        .Kind("user", kUserKey)
@@ -106,28 +110,30 @@ TEST_F(BucketingConsistencyTests, BucketContextByStringifiedIntAttribute) {
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByFloatAttributeNotAllowed) {
-    auto const kUserKey = "userKeyE";
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    const std::string kUserKey = "userKeyE";
+    const BucketPrefix kPrefix{kHashKey, kSalt};
 
     auto context = ContextBuilder()
                        .Kind("user", kUserKey)
                        .Set("floatAttr", 999.999)
                        .Build();
     auto result = Bucket(context, "floatAttr", kPrefix, false, "user");
+
     ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
                         << result.error();
     ASSERT_NEAR(result->first, 0.0, kBucketTolerance);
 }
 
 TEST_F(BucketingConsistencyTests, BucketContextByFloatAttributeThatIsInteger) {
-    auto const kUserKey = "userKeyE";
-    auto const kPrefix = BucketPrefix(kHashKey, kSalt);
+    const std::string kUserKey = "userKeyE";
+    const BucketPrefix kPrefix{kHashKey, kSalt};
 
     auto context = ContextBuilder()
                        .Kind("user", kUserKey)
                        .Set("floatAttr", 33333.0)
                        .Build();
     auto result = Bucket(context, "floatAttr", kPrefix, false, "user");
+    
     ASSERT_TRUE(result) << kUserKey << " should be bucketed but got "
                         << result.error();
     ASSERT_NEAR(result->first, 0.54771423, kBucketTolerance);


### PR DESCRIPTION
Adds bucketing logic to be used in evaluation engine. 

Buckets are computed based on a hash value comprised of context attributes and prefixes derived from flag rules. 