### PR TITLE
feat: add ContextKind type to data model

### DIFF
--- a/libs/internal/include/launchdarkly/data_model/context_aware_reference.hpp
+++ b/libs/internal/include/launchdarkly/data_model/context_aware_reference.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <launchdarkly/attribute_reference.hpp>
+#include <launchdarkly/data_model/context_kind.hpp>
+
 #include <string>
 
 namespace launchdarkly::data_model {
@@ -46,12 +48,12 @@ struct ContextAwareReference<
         std::is_same<char const* const,
                      decltype(FieldNames::kReferenceFieldName)>::value>::type> {
     using fields = FieldNames;
-    std::string contextKind;
+    ContextKind contextKind;
     AttributeReference reference;
 };
 
 #define DEFINE_CONTEXT_KIND_FIELD(name) \
-    std::string name;                   \
+    ContextKind name;                   \
     constexpr static const char* kContextFieldName = #name;
 
 #define DEFINE_ATTRIBUTE_REFERENCE_FIELD(name) \

--- a/libs/internal/include/launchdarkly/data_model/context_aware_reference.hpp
+++ b/libs/internal/include/launchdarkly/data_model/context_aware_reference.hpp
@@ -52,6 +52,7 @@ struct ContextAwareReference<
     AttributeReference reference;
 };
 
+// NOLINTBEGIN cppcoreguidelines-macro-usage
 #define DEFINE_CONTEXT_KIND_FIELD(name) \
     ContextKind name;                   \
     constexpr static const char* kContextFieldName = #name;
@@ -59,5 +60,6 @@ struct ContextAwareReference<
 #define DEFINE_ATTRIBUTE_REFERENCE_FIELD(name) \
     AttributeReference name;                   \
     constexpr static const char* kReferenceFieldName = #name;
+// NOLINTEND cppcoreguidelines-macro-usage
 
 }  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/context_kind.hpp
+++ b/libs/internal/include/launchdarkly/data_model/context_kind.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <boost/serialization/strong_typedef.hpp>
+
+#include <string>
+
+namespace launchdarkly::data_model {
+
+BOOST_STRONG_TYPEDEF(std::string, ContextKind);
+
+}  // namespace launchdarkly::data_model

--- a/libs/internal/include/launchdarkly/data_model/flag.hpp
+++ b/libs/internal/include/launchdarkly/data_model/flag.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <launchdarkly/data_model/context_aware_reference.hpp>
+#include <launchdarkly/data_model/context_kind.hpp>
 #include <launchdarkly/data_model/rule_clause.hpp>
 #include <launchdarkly/value.hpp>
 
@@ -15,8 +16,6 @@
 namespace launchdarkly::data_model {
 
 struct Flag {
-    using ContextKind = std::string;
-
     struct Rollout {
         enum class Kind {
             kUnrecognized = 0,

--- a/libs/internal/include/launchdarkly/serialization/json_context_aware_reference.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_context_aware_reference.hpp
@@ -2,6 +2,7 @@
 
 #include <launchdarkly/attribute_reference.hpp>
 #include <launchdarkly/data_model/context_aware_reference.hpp>
+#include <launchdarkly/serialization/json_context_kind.hpp>
 #include <launchdarkly/serialization/json_errors.hpp>
 #include <launchdarkly/serialization/value_mapping.hpp>
 
@@ -25,14 +26,9 @@ tl::expected<data_model::ContextAwareReference<Fields>, JsonError> tag_invoke(
 
     auto const& obj = json_value.as_object();
 
-    std::optional<std::string> kind;
+    std::optional<data_model::ContextKind> kind;
 
     PARSE_CONDITIONAL_FIELD(kind, obj, Type::fields::kContextFieldName);
-
-    if (kind && *kind == "") {
-        // Empty string is not a valid kind.
-        return tl::make_unexpected(JsonError::kSchemaFailure);
-    }
 
     std::string attr_ref_or_name;
     PARSE_FIELD_DEFAULT(attr_ref_or_name, obj,
@@ -43,7 +39,8 @@ tl::expected<data_model::ContextAwareReference<Fields>, JsonError> tag_invoke(
                     AttributeReference::FromReferenceStr(attr_ref_or_name)};
     }
 
-    return Type{"user", AttributeReference::FromLiteralStr(attr_ref_or_name)};
+    return Type{data_model::ContextKind("user"),
+                AttributeReference::FromLiteralStr(attr_ref_or_name)};
 }
 
 }  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/json_context_kind.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_context_kind.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <launchdarkly/data_model/context_kind.hpp>
+#include <launchdarkly/serialization/json_errors.hpp>
+
+#include <boost/json.hpp>
+#include <tl/expected.hpp>
+
+#include <optional>
+
+namespace launchdarkly {
+
+tl::expected<std::optional<data_model::ContextKind>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<data_model::ContextKind>, JsonError>> const&
+        unused,
+    boost::json::value const& json_value);
+
+}  // namespace launchdarkly

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(${LIBNAME} OBJECT
         serialization/json_primitives.cpp
         serialization/json_rule_clause.cpp
         serialization/json_flag.cpp
+        serialization/json_context_kind.cpp
         encoding/base_64.cpp
         encoding/sha_256.cpp
         signals/boost_signal_connection.cpp)

--- a/libs/internal/src/serialization/json_context_kind.cpp
+++ b/libs/internal/src/serialization/json_context_kind.cpp
@@ -1,0 +1,24 @@
+#include <launchdarkly/serialization/json_context_kind.hpp>
+#include <launchdarkly/serialization/value_mapping.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+
+namespace launchdarkly {
+tl::expected<std::optional<data_model::ContextKind>, JsonError> tag_invoke(
+    boost::json::value_to_tag<
+        tl::expected<std::optional<data_model::ContextKind>, JsonError>> const&
+        unused,
+    boost::json::value const& json_value) {
+    boost::ignore_unused(unused);
+
+    REQUIRE_STRING(json_value);
+    auto const& str = json_value.as_string();
+
+    if (str.empty()) {
+        /* Empty string is not a valid context kind. */
+        return tl::make_unexpected(JsonError::kSchemaFailure);
+    }
+    
+    return data_model::ContextKind(str.c_str());
+}
+}  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_context_kind.cpp
+++ b/libs/internal/src/serialization/json_context_kind.cpp
@@ -18,7 +18,7 @@ tl::expected<std::optional<data_model::ContextKind>, JsonError> tag_invoke(
         /* Empty string is not a valid context kind. */
         return tl::make_unexpected(JsonError::kSchemaFailure);
     }
-    
+
     return data_model::ContextKind(str.c_str());
 }
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_flag.cpp
+++ b/libs/internal/src/serialization/json_flag.cpp
@@ -1,5 +1,6 @@
 #include <boost/json.hpp>
 #include <launchdarkly/serialization/json_context_aware_reference.hpp>
+#include <launchdarkly/serialization/json_context_kind.hpp>
 #include <launchdarkly/serialization/json_flag.hpp>
 #include <launchdarkly/serialization/json_primitives.hpp>
 #include <launchdarkly/serialization/json_rule_clause.hpp>
@@ -100,7 +101,8 @@ tl::expected<std::optional<data_model::Flag::Target>, JsonError> tag_invoke(
     data_model::Flag::Target target;
     PARSE_FIELD(target.values, obj, "values");
     PARSE_FIELD(target.variation, obj, "variation");
-    PARSE_FIELD_DEFAULT(target.contextKind, obj, "contextKind", "user");
+    PARSE_FIELD_DEFAULT(target.contextKind, obj, "contextKind",
+                        data_model::ContextKind("user"));
     return target;
 }
 

--- a/libs/server-sdk/tests/dependency_tracker_test.cpp
+++ b/libs/server-sdk/tests/dependency_tracker_test.cpp
@@ -13,6 +13,7 @@ using launchdarkly::server_side::data_store::SegmentDescriptor;
 using launchdarkly::AttributeReference;
 using launchdarkly::Value;
 using launchdarkly::data_model::Clause;
+using launchdarkly::data_model::ContextKind;
 using launchdarkly::data_model::Flag;
 using launchdarkly::data_model::ItemDescriptor;
 using launchdarkly::data_model::Segment;
@@ -197,7 +198,7 @@ TEST(DependencyTrackerTest, UsesSegmentRulesToCalculateDependencies) {
 
     flag_a.rules.push_back(Flag::Rule{std::vector<Clause>{
         Clause{Clause::Op::kSegmentMatch, std::vector<Value>{"segmentA"}, false,
-               "user", AttributeReference()}}});
+               ContextKind("user"), AttributeReference()}}});
 
     tracker.UpdateDependencies("flagA", FlagDescriptor(flag_a));
     tracker.UpdateDependencies("segmentA", SegmentDescriptor(segment_a));
@@ -231,7 +232,7 @@ TEST(DependencyTrackerTest, TracksSegmentDependencyOfPrerequisite) {
 
     flag_a.rules.push_back(Flag::Rule{std::vector<Clause>{
         Clause{Clause::Op::kSegmentMatch, std::vector<Value>{"segmentA"}, false,
-               "", AttributeReference()}}});
+               ContextKind(""), AttributeReference()}}});
 
     flag_b.prerequisites.push_back(Flag::Prerequisite{"flagA", 0});
 
@@ -270,8 +271,8 @@ TEST(DependencyTrackerTest, HandlesSegmentsDependentOnOtherSegments) {
     segment_b.rules.push_back(Segment::Rule{
         std::vector<Clause>{Clause{Clause::Op::kSegmentMatch,
                                    std::vector<Value>{"segmentA"}, false,
-                                   "user", AttributeReference()}},
-        std::nullopt, std::nullopt, "", AttributeReference()});
+                                   ContextKind("user"), AttributeReference()}},
+        std::nullopt, std::nullopt, ContextKind(""), AttributeReference()});
 
     tracker.UpdateDependencies("segmentA", SegmentDescriptor(segment_a));
     tracker.UpdateDependencies("segmentB", SegmentDescriptor(segment_b));


### PR DESCRIPTION
Previously, context kind was an `std::string`. 

The requirement that it not be an empty string was enforced by parent data model deserializers. 

Now, we have a dedicated type-safe wrapper via`BOOST_STRONG_TYPEDEF`. The custom `tag_invoke` enforces the invariant so it's not possible to deserialize it inconsistently. 