### PR TITLE
fix: avoid copying Value in Evaluator algorithm

### DIFF
--- a/libs/server-sdk/src/evaluation/bucketing.cpp
+++ b/libs/server-sdk/src/evaluation/bucketing.cpp
@@ -73,7 +73,7 @@ tl::expected<std::pair<ContextHashValue, RolloutKindLookup>, Error> Bucket(
             Error::InvalidAttributeReference(ref.RedactionName()));
     }
 
-    Value value = context.Get(context_kind, ref);
+    Value const& value = context.Get(context_kind, ref);
 
     bool is_bucketable = value.Type() == Value::Type::kNumber ||
                          value.Type() == Value::Type::kString;

--- a/libs/server-sdk/src/evaluation/evaluator.cpp
+++ b/libs/server-sdk/src/evaluation/evaluator.cpp
@@ -189,7 +189,7 @@ std::optional<std::size_t> AnyTargetMatchVariation(
 std::optional<std::size_t> TargetMatchVariation(
     launchdarkly::Context const& context,
     Flag::Target const& target) {
-    Value key = context.Get(target.contextKind, "key");
+    Value const& key = context.Get(target.contextKind, "key");
     if (key.IsNull()) {
         return std::nullopt;
     }


### PR DESCRIPTION
Removes potentially costly, unecessary copies of `Value` in the evaluation algorithm.