### PR TITLE
fix: EvaluationStack should take ownership of key argument

### DIFF
--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
@@ -2,7 +2,7 @@
 
 namespace launchdarkly::server_side::evaluation::detail {
 
-Guard::Guard(std::unordered_set<std::string>& set, std::string const& key)
+Guard::Guard(std::unordered_set<std::string>& set, std::string key)
     : set_(set), key_(key) {
     set_.insert(key_);
 }
@@ -12,19 +12,19 @@ Guard::~Guard() {
 }
 
 std::optional<Guard> EvaluationStack::NoticePrerequisite(
-    std::string const& prerequisite_key) {
+    std::string prerequisite_key) {
     if (prerequisites_seen_.count(prerequisite_key) != 0) {
         return std::nullopt;
     }
-    return std::make_optional<Guard>(prerequisites_seen_, prerequisite_key);
+    return std::make_optional<Guard>(prerequisites_seen_,
+                                     std::move(prerequisite_key));
 }
 
-std::optional<Guard> EvaluationStack::NoticeSegment(
-    std::string const& segment_key) {
+std::optional<Guard> EvaluationStack::NoticeSegment(std::string segment_key) {
     if (segments_seen_.count(segment_key) != 0) {
         return std::nullopt;
     }
-    return std::make_optional<Guard>(segments_seen_, segment_key);
+    return std::make_optional<Guard>(segments_seen_, std::move(segment_key));
 }
 
 }  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.cpp
@@ -3,7 +3,7 @@
 namespace launchdarkly::server_side::evaluation::detail {
 
 Guard::Guard(std::unordered_set<std::string>& set, std::string key)
-    : set_(set), key_(key) {
+    : set_(set), key_(std::move(key)) {
     set_.insert(key_);
 }
 

--- a/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/detail/evaluation_stack.hpp
@@ -11,7 +11,7 @@ namespace launchdarkly::server_side::evaluation::detail {
  * Upon destruction, the key is forgotten.
  */
 struct Guard {
-    Guard(std::unordered_set<std::string>& set, std::string const& key);
+    Guard(std::unordered_set<std::string>& set, std::string key);
     ~Guard();
 
     Guard(Guard const&) = delete;
@@ -22,7 +22,7 @@ struct Guard {
 
    private:
     std::unordered_set<std::string>& set_;
-    std::string const& key_;
+    std::string const key_;
 };
 
 /**
@@ -41,7 +41,7 @@ class EvaluationStack {
      * @return Guard object if not seen before, otherwise std::nullopt.
      */
     [[nodiscard]] std::optional<Guard> NoticePrerequisite(
-        std::string const& prerequisite_key);
+        std::string prerequisite_key);
 
     /**
      * If the given segment key has not been seen, marks it as seen
@@ -50,8 +50,7 @@ class EvaluationStack {
      * @param prerequisite_key Key of the segment.
      * @return Guard object if not seen before, otherwise std::nullopt.
      */
-    [[nodiscard]] std::optional<Guard> NoticeSegment(
-        std::string const& segment_key);
+    [[nodiscard]] std::optional<Guard> NoticeSegment(std::string segment_key);
 
    private:
     std::unordered_set<std::string> prerequisites_seen_;

--- a/libs/server-sdk/src/evaluation/evaluation_error.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <ostream>
 
 namespace launchdarkly::server_side::evaluation {


### PR DESCRIPTION
Current API of `EvaluationStack` is very easy to accidentally misuse because it takes a reference to its key argument. If the arg is destroyed, then we'll have a use-after-free. 