### PR TITLE
chore: update boost version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif ()
 
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.80 REQUIRED COMPONENTS json url coroutine)
+find_package(Boost 1.81 REQUIRED COMPONENTS json url coroutine)
 message(STATUS "LaunchDarkly: using Boost v${Boost_VERSION}")
 
 add_subdirectory(libs/client-sdk)


### PR DESCRIPTION
Our documented minimum version of boost is 1.81. The `CMakeLists.txt` erroneously specified 1.80, which could potentially lead to 1.80 being selected and the build failing.

This commit bumps it to 1.81, which includes the necessary `url` library.