### PR TITLE
fix: handle undefined flag variations in fallthrough

### DIFF
--- a/contract-tests/server-contract-tests/test-suppressions.txt
+++ b/contract-tests/server-contract-tests/test-suppressions.txt
@@ -1,3 +1,4 @@
+# SC-214431
 evaluation/parameterized/bad attribute reference errors - clause with no attribute/test-flag/evaluate flag with detail
 evaluation/parameterized/bad attribute reference errors - empty path component/test-flag/evaluate flag with detail
 evaluation/parameterized/bad attribute reference errors - tilde followed by invalid escape character/test-flag/evaluate flag with detail
@@ -60,12 +61,8 @@ evaluation/parameterized/prerequisites/prerequisite cycle is detected at top lev
 evaluation/parameterized/prerequisites/prerequisite cycle is detected at top level, recursion stops/prerequisite cycle is detected at top level, recursion stops/evaluate all flags
 evaluation/parameterized/prerequisites/prerequisite cycle is detected at deeper level, recursion stops/prerequisite cycle is detected at deeper level, recursion stops/evaluate flag with detail
 evaluation/parameterized/prerequisites/prerequisite cycle is detected at deeper level, recursion stops/prerequisite cycle is detected at deeper level, recursion stops/evaluate all flags
-evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/fallthrough rollout/fallthrough rollout/evaluate flag without detail
 evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/fallthrough rollout/fallthrough rollout/evaluate flag with detail
-evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/fallthrough rollout/fallthrough rollout/evaluate all flags
-evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/rule rollout/rule rollout/evaluate flag without detail
 evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/rule rollout/rule rollout/evaluate flag with detail
-evaluation/parameterized/rollout or experiment - error for empty variations list in rollout/rule rollout/rule rollout/evaluate all flags
 evaluation/parameterized/segment match/user matches via include in multi-kind user/user matches via include in multi-kind user/evaluate flag without detail
 evaluation/parameterized/segment match/user matches via include in multi-kind user/user matches via include in multi-kind user/evaluate flag with detail
 evaluation/parameterized/segment match/user matches via include in multi-kind user/user matches via include in multi-kind user/evaluate all flags

--- a/libs/internal/include/launchdarkly/data_model/flag.hpp
+++ b/libs/internal/include/launchdarkly/data_model/flag.hpp
@@ -54,7 +54,7 @@ struct Flag {
         explicit Rollout(std::vector<WeightedVariation>);
     };
 
-    using VariationOrRollout = std::variant<Variation, Rollout>;
+    using VariationOrRollout = std::variant<std::optional<Variation>, Rollout>;
 
     struct Prerequisite {
         std::string key;

--- a/libs/internal/src/serialization/json_flag.cpp
+++ b/libs/internal/src/serialization/json_flag.cpp
@@ -202,13 +202,13 @@ tag_invoke(boost::json::value_to_tag<
         return std::make_optional(*rollout);
     }
 
-    data_model::Flag::Variation variation{};
-    /* If there's no rollout, this must be a variation. If there's no
-     * data at all, we must treat it as variation 0 (since upstream encoders may
-     * omit 0.) */
-    PARSE_FIELD_DEFAULT(variation, obj, "variation", 0);
+    std::optional<data_model::Flag::Variation> variation;
+    
+    /* If there's no rollout, this must be a variation. If there's no variation,
+     * then this will be detected as a malformed flag at evaluation time. */
+    PARSE_CONDITIONAL_FIELD(variation, obj, "variation");
 
-    return std::make_optional(variation);
+    return variation;
 }
 
 namespace data_model {

--- a/libs/internal/src/serialization/json_flag.cpp
+++ b/libs/internal/src/serialization/json_flag.cpp
@@ -203,7 +203,7 @@ tag_invoke(boost::json::value_to_tag<
     }
 
     std::optional<data_model::Flag::Variation> variation;
-    
+
     /* If there's no rollout, this must be a variation. If there's no variation,
      * then this will be detected as a malformed flag at evaluation time. */
     PARSE_CONDITIONAL_FIELD(variation, obj, "variation");
@@ -264,9 +264,12 @@ void tag_invoke(
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, data_model::Flag::Rollout>) {
                 obj.emplace("rollout", boost::json::value_from(arg));
-            } else if constexpr (std::is_same_v<T,
-                                                data_model::Flag::Variation>) {
-                obj.emplace("variation", arg);
+            } else if constexpr (std::is_same_v<
+                                     T, std::optional<
+                                            data_model::Flag::Variation>>) {
+                if (arg) {
+                    obj.emplace("variation", *arg);
+                }
             }
         },
         variation_or_rollout);

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -326,7 +326,8 @@ TEST(FlagRuleTests, DeserializesMinimumValid) {
     ASSERT_FALSE(result->trackEvents);
     ASSERT_TRUE(result->clauses.empty());
     ASSERT_FALSE(result->id);
-    ASSERT_EQ(std::get<data_model::Flag::Variation>(result->variationOrRollout),
+    ASSERT_EQ(std::get<std::optional<data_model::Flag::Variation>>(
+                  result->variationOrRollout),
               data_model::Flag::Variation(123));
 }
 
@@ -348,7 +349,8 @@ TEST(FlagRuleTests, DeserializesAllFields) {
     ASSERT_TRUE(result->trackEvents);
     ASSERT_TRUE(result->clauses.empty());
     ASSERT_EQ(result->id, "foo");
-    ASSERT_EQ(std::get<data_model::Flag::Variation>(result->variationOrRollout),
+    ASSERT_EQ(std::get<std::optional<data_model::Flag::Variation>>(
+                  result->variationOrRollout),
               data_model::Flag::Variation(123));
 }
 

--- a/libs/server-sdk/src/evaluation/bucketing.cpp
+++ b/libs/server-sdk/src/evaluation/bucketing.cpp
@@ -160,8 +160,12 @@ tl::expected<BucketResult, Error> Variation(
     return std::visit(
         [&](auto&& arg) -> tl::expected<BucketResult, Error> {
             using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, Flag::Variation>) {
-                return BucketResult(arg);
+            if constexpr (std::is_same_v<T, std::optional<Flag::Variation>>) {
+                if (!arg) {
+                    return tl::make_unexpected(
+                        Error::RolloutMissingVariations());
+                }
+                return BucketResult(*arg);
             } else if constexpr (std::is_same_v<T, Flag::Rollout>) {
                 if (arg.variations.empty()) {
                     return tl::make_unexpected(


### PR DESCRIPTION
Fixes handling of undefined variations in VariationOrRollout structures. Previously, the lack of a variation was treated as 0, as I had assumed the normal data model rules apply. 

Instead, there is a special case that variation _must_ be defined or else a flag is malformed. 