### PR TITLE
chore: refactor client-release action to support server-side SDK

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -1,17 +1,23 @@
 # This is a composite workflow that an generate all the release artifacts
-# for the C++ client SDK.
+# for the C++ client-side & server-side SDKs.
 
 # This can be ran automatically with the tag_name output from release-please,
 # or ran triggered manually with a user provided tag.
 
-name: C++ Client Release
-description: C++ Client Release Process
+name: C++ SDK Release
+description: C++ SDK Release Process
 inputs:
   tag_name:
     description: 'The tag name of the release to upload artifacts to.'
     required: true
   github_token:
+    description: 'The GitHub token to use for uploading artifacts.'
     required: true
+  sdk_path:
+    description: 'Path to the sdk, e.g. libs/client-sdk.'
+    required: true
+  sdk_cmake_target:
+    description: 'CMake target of the sdk, e.g. launchdarkly-cpp-client.'
 
 runs:
   using: composite
@@ -28,10 +34,10 @@ runs:
       run: |
         sudo apt-get install doxygen
         sudo apt-get install graphviz
-        ./scripts/build-release.sh launchdarkly-cpp-client
-        ./scripts/build-docs.sh libs/client-sdk
+        ./scripts/build-release.sh ${{ inputs.sdk_cmake_target }}
+        ./scripts/build-docs.sh ${{ inputs.sdk_path }}
       env:
-        WORKSPACE: libs/client-sdk
+        WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Archive Release Linux - GCC/x64/Static
@@ -64,7 +70,7 @@ runs:
       if: runner.os == 'Linux'
       uses: ./.github/actions/publish-docs
       with:
-        workspace_path: libs/client-sdk
+        workspace_path: ${{ inputs.sdk_path }}
 
     - name: Configure MSVC
       if: runner.os == 'Windows'
@@ -78,7 +84,7 @@ runs:
         BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
-      run: ./scripts/build-windows.sh launchdarkly-cpp-client
+      run: ./scripts/build-windows.sh ${{ inputs.sdk_cmake_target }}
 
     - name: Archive Release Windows - MSVC/x64/Static
       if: runner.os == 'Windows'
@@ -130,9 +136,9 @@ runs:
         echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> "$GITHUB_ENV"
         export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
         
-        ./scripts/build-release.sh launchdarkly-cpp-client
+        ./scripts/build-release.sh ${{ inputs.sdk_cmake_target }}
       env:
-        WORKSPACE: libs/client-sdk
+        WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Archive Release Mac - AppleClang/x64/Static

--- a/.github/workflows/manual-client-release-artifacts.yml
+++ b/.github/workflows/manual-client-release-artifacts.yml
@@ -22,8 +22,10 @@ jobs:
           ref: ${{ inputs.tag }}
       - id: release-client
         name: Full release of libs/client-sdk
-        uses: ./.github/actions/client-release
+        uses: ./.github/actions/sdk-release
         with:
           # The tag of the release to upload artifacts to.
           tag_name: ${{ inputs.tag }}
           github_token: ${{secrets.GITHUB_TOKEN}}
+          sdk_path: 'libs/client-sdk'
+          sdk_cmake_target: 'launchdarkly-cpp-client'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,8 +30,10 @@ jobs:
       - uses: actions/checkout@v3
       - id: release-client
         name: Full release of libs/client-sdk
-        uses: ./.github/actions/client-release
+        uses: ./.github/actions/sdk-release
         with:
           # The tag of the release to upload artifacts to.
           tag_name: ${{ needs.release-please.outputs.package-client-tag }}
           github_token: ${{secrets.GITHUB_TOKEN}}
+          sdk_path: 'libs/client-sdk'
+          sdk_cmake_target: 'launchdarkly-cpp-client'


### PR DESCRIPTION
The intention is to be able to reuse `actions/client-release` for the server-side SDK.It currently has hardcoded paths and CMake targets for the client-side SDK.

To make it generic, I've added new inputs for specifying those parameters.

I'm not 100% sure this is the best way to achieve my goal, but it seems relatively straightforward. 

