### PR TITLE
fix: adding slsa provenance generation to release-client workflow

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -18,6 +18,16 @@ inputs:
     required: true
   sdk_cmake_target:
     description: 'CMake target of the sdk, e.g. launchdarkly-cpp-client.'
+outputs:
+  hashes-linux:
+    description: "base64-encoded sha256 hash of linux build artifacts"
+    value: ${{ steps.hash-linux.outputs.hashes-linux }}
+  hashes-windows:
+    description: "base64-encoded sha256 hash of windows build artifacts"
+    value: ${{ steps.hash-windows.outputs.hashes-windows }}
+  hashes-macos:
+    description: "base64-encoded sha256 hash of macos build artifacts"
+    value: ${{ steps.hash-macos.outputs.hashes-macos }}
 
 runs:
   using: composite
@@ -56,6 +66,12 @@ runs:
         type: 'zip'
         filename: 'linux-gcc-x64-dynamic.zip'
 
+    - name: Hash Linux Build Artifacts for provenance
+      if: runner.os == 'Linux'
+      shell: bash
+      id: hash-linux
+      run: |
+        echo "hashes-linux=$(sha256sum linux-gcc-x64-static.zip linux-gcc-x64-dynamic.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Linux Build Artifacts
       if: runner.os == 'Linux'
@@ -118,6 +134,13 @@ runs:
         type: 'zip'
         filename: 'windows-msvc-x64-dynamic-debug.zip'
 
+    - name: Hash Windows Build Artifacts for provenance
+      if: runner.os == 'Windows'
+      shell: bash
+      id: hash-windows
+      run: |
+        echo "hashes-windows=$(sha256sum windows-msvc-x64-static.zip windows-msvc-x64-dynamic.zip windows-msvc-x64-static-debug.zip windows-msvc-x64-dynamic-debug.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
+
     - name: Upload Windows Build Artifacts
       if: runner.os == 'Windows'
       shell: bash
@@ -156,6 +179,13 @@ runs:
         path: 'build-dynamic/release'
         type: 'zip'
         filename: 'mac-clang-x64-dynamic.zip'
+
+    - name: Hash Mac Build Artifacts for provenance
+      if: runner.os == 'macOS'
+      shell: bash
+      id: hash-macos
+      run: |
+        echo "hashes-macos=$(sha256sum mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Mac Build Artifacts
       if: runner.os == 'macOS'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
     if: ${{ needs.release-please.outputs.package-client-released }}
+    outputs:
+      hashes-linux: ${{ steps.release-client.outputs.hashes-linux }}
+      hashes-windows: ${{ steps.release-client.outputs.hashes-windows }}
+      hashes-macos: ${{ steps.release-client.outputs.hashes-macos }}
     steps:
       - uses: actions/checkout@v3
       - id: release-client
@@ -37,3 +41,17 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           sdk_path: 'libs/client-sdk'
           sdk_cmake_target: 'launchdarkly-cpp-client'
+
+  release-client-provenance:
+    needs: ['release-client']
+    strategy:
+      matrix:
+        # Generates a combined attestation for each platform
+        os: [ linux, windows, macos ]
+    permissions: 
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
+    with:
+      base64-subjects: "${{ needs.release-client.outputs[format('hashes-{0}', matrix.os)] }}"


### PR DESCRIPTION
Using [generic SLSA provenance generator ](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#a-different-attestation-for-each-iteration) to build provenance attestations for our client SDK artifacts. [Tech spec for reference ](https://launchdarkly.atlassian.net/wiki/spaces/SEC/pages/2529919025/Integrating+SLSA+compliance+with+SDK+release+workflows#Provenance-only-generator)

Since we're using a matrix strategy for the build, there will be one attestation file for all the artifacts for each platform (i.e., attestation for Linux artifacts, one for Windows artifacts, one for MacOS artifacts). 

Based off of POC here: https://github.com/launchdarkly/learn-release-please/pull/35/files though this time it should be more accurate since we're hashing the exact artifacts that we're uploading to the Github release, whereas there wasn't a good way to do that with the yarn-generated package in the POC repo. 