### PR TITLE
fix: initialization of LDFlagListener 

### DIFF
--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -9,6 +9,7 @@
 #include <launchdarkly/bindings/c/context.h>
 #include <launchdarkly/bindings/c/data/evaluation_detail.h>
 #include <launchdarkly/bindings/c/export.h>
+#include <launchdarkly/bindings/c/flag_listener.h>
 #include <launchdarkly/bindings/c/listener_connection.h>
 #include <launchdarkly/bindings/c/memory_routines.h>
 #include <launchdarkly/bindings/c/status.h>
@@ -411,52 +412,6 @@ LDClientSDK_AllFlags(LDClientSDK sdk);
  * @param sdk SDK.
  */
 LD_EXPORT(void) LDClientSDK_Free(LDClientSDK sdk);
-
-typedef void (*FlagChangedCallbackFn)(char const* flag_key,
-                                      LDValue new_value,
-                                      LDValue old_value,
-                                      bool deleted,
-                                      void* user_data);
-
-/**
- * Defines a feature flag listener which may be used to listen for flag changes.
- * The struct should be initialized using LDFlagListener_Init before use.
- */
-struct LDFlagListener {
-    /**
-     * Callback function which is invoked for flag changes.
-     *
-     * The provided pointers are only valid for the duration of the function
-     * call (excluding UserData, whose lifetime is controlled by the caller).
-     *
-     * @param flag_key The name of the flag that changed.
-     * @param new_value The new value of the flag. If there was not an new
-     * value, because the flag was deleted, then the LDValue will be of a null
-     * type. Check the deleted parameter to see if a flag was deleted.
-     * @param old_value The old value of the flag. If there was not an old
-     * value, for instance a newly created flag, then the Value will be of a
-     * null type.
-     * @param deleted True if the flag has been deleted.
-     */
-    FlagChangedCallbackFn FlagChanged;
-
-    /**
-     * UserData is forwarded into callback functions.
-     */
-    void* UserData;
-};
-
-/**
- * Initializes a flag listener. Must be called before passing the listener
- * to LDClientSDK_FlagNotifier_OnFlagChange.
- *
- * Create the struct, initialize the struct, set the FlagChanged handler
- * and optionally UserData, and then pass the struct to
- * LDClientSDK_FlagNotifier_OnFlagChange.
- *
- * @param listener Listener to initialize.
- */
-LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener listener);
 
 /**
  * Listen for changes for the specific flag.

--- a/libs/client-sdk/src/bindings/c/sdk.cpp
+++ b/libs/client-sdk/src/bindings/c/sdk.cpp
@@ -377,11 +377,6 @@ LD_EXPORT(time_t) LDDataSourceStatus_StateSince(LDDataSourceStatus status) {
         .count();
 }
 
-LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener listener) {
-    listener.FlagChanged = nullptr;
-    listener.UserData = nullptr;
-}
-
 LD_EXPORT(LDDataSourceStatus_ErrorKind)
 LDDataSourceStatus_ErrorInfo_GetKind(LDDataSourceStatus_ErrorInfo info) {
     LD_ASSERT_NOT_NULL(info);

--- a/libs/client-sdk/tests/client_c_bindings_test.cpp
+++ b/libs/client-sdk/tests/client_c_bindings_test.cpp
@@ -59,8 +59,15 @@ TEST(ClientBindings, RegisterFlagListener) {
     LDClientSDK_Start(sdk, 3000, &success);
     EXPECT_TRUE(success);
 
-    struct LDFlagListener listener {};
-    LDFlagListener_Init(listener);
+    struct LDFlagListener listener {
+        reinterpret_cast<FlagChangedCallbackFn>(0x123),
+            reinterpret_cast<void*>(0x456)
+    };
+
+    LDFlagListener_Init(&listener);
+    ASSERT_EQ(listener.FlagChanged, nullptr);
+    ASSERT_EQ(listener.UserData, nullptr);
+
     listener.UserData = const_cast<char*>("Potato");
     listener.FlagChanged = FlagListenerFunction;
 

--- a/libs/common/include/launchdarkly/bindings/c/flag_listener.h
+++ b/libs/common/include/launchdarkly/bindings/c/flag_listener.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <launchdarkly/bindings/c/export.h>
+#include <launchdarkly/bindings/c/value.h>
 
 #ifdef __cplusplus
 extern "C" {  // only need to export C interface if
@@ -54,7 +55,7 @@ struct LDFlagListener {
  *
  * @param listener Listener to initialize.
  */
-LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener listener);
+LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener* listener);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/flag_listener.h
+++ b/libs/common/include/launchdarkly/bindings/c/flag_listener.h
@@ -1,0 +1,63 @@
+/** @file */
+// NOLINTBEGIN modernize-use-using
+
+#pragma once
+
+#include <launchdarkly/bindings/c/export.h>
+
+#ifdef __cplusplus
+extern "C" {  // only need to export C interface if
+// used by C++ source code
+#endif
+
+typedef void (*FlagChangedCallbackFn)(char const* flag_key,
+                                      LDValue new_value,
+                                      LDValue old_value,
+                                      bool deleted,
+                                      void* user_data);
+
+/**
+ * Defines a feature flag listener which may be used to listen for flag changes.
+ * The struct should be initialized using LDFlagListener_Init before use.
+ */
+struct LDFlagListener {
+    /**
+     * Callback function which is invoked for flag changes.
+     *
+     * The provided pointers are only valid for the duration of the function
+     * call (excluding UserData, whose lifetime is controlled by the caller).
+     *
+     * @param flag_key The name of the flag that changed.
+     * @param new_value The new value of the flag. If there was not an new
+     * value, because the flag was deleted, then the LDValue will be of a null
+     * type. Check the deleted parameter to see if a flag was deleted.
+     * @param old_value The old value of the flag. If there was not an old
+     * value, for instance a newly created flag, then the Value will be of a
+     * null type.
+     * @param deleted True if the flag has been deleted.
+     */
+    FlagChangedCallbackFn FlagChanged;
+
+    /**
+     * UserData is forwarded into callback functions.
+     */
+    void* UserData;
+};
+
+/**
+ * Initializes a flag listener. Must be called before passing the listener
+ * to LDClientSDK_FlagNotifier_OnFlagChange.
+ *
+ * Create the struct, initialize the struct, set the FlagChanged handler
+ * and optionally UserData, and then pass the struct to
+ * LDClientSDK_FlagNotifier_OnFlagChange.
+ *
+ * @param listener Listener to initialize.
+ */
+LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener listener);
+
+#ifdef __cplusplus
+}
+#endif
+
+// NOLINTEND modernize-use-using

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(${LIBNAME} OBJECT
         bindings/c/config/logging_builder.cpp
         bindings/c/data/evaluation_detail.cpp
         bindings/c/listener_connection.cpp
+        bindings/c/flag_listener.cpp
         bindings/c/memory_routines.cpp
         log_level.cpp
         config/persistence_builder.cpp

--- a/libs/common/src/bindings/c/flag_listener.cpp
+++ b/libs/common/src/bindings/c/flag_listener.cpp
@@ -1,0 +1,6 @@
+#include <launchdarkly/bindings/c/flag_listener.h>
+
+LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener* listener) {
+    listener->FlagChanged = nullptr;
+    listener->UserData = nullptr;
+}


### PR DESCRIPTION
This commit moves the definition and implementation of `LDFlagListener` into `common`, so it can be easily shared with the server.

Additionally, it fixes a bug in the specification of the `LDFlagListener_Init` method. It previously took `LDFlagListener` by value; now it takes a pointer. 

The impact would be if a customer forgot to initialize the struct, then the member(s) would be undefined. 