### PR TITLE
fix: LDDataSourceStatusListener_Init should take pointer

### DIFF
--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -642,7 +642,7 @@ struct LDDataSourceStatusListener {
  * @param listener Listener to initialize.
  */
 LD_EXPORT(void)
-LDDataSourceStatusListener_Init(struct LDDataSourceStatusListener listener);
+LDDataSourceStatusListener_Init(struct LDDataSourceStatusListener* listener);
 
 /**
  * Listen for changes to the data source status.

--- a/libs/client-sdk/src/bindings/c/sdk.cpp
+++ b/libs/client-sdk/src/bindings/c/sdk.cpp
@@ -409,9 +409,9 @@ LDDataSourceStatus_ErrorInfo_Time(LDDataSourceStatus_ErrorInfo info) {
 }
 
 LD_EXPORT(void)
-LDDataSourceStatusListener_Init(LDDataSourceStatusListener listener) {
-    listener.StatusChanged = nullptr;
-    listener.UserData = nullptr;
+LDDataSourceStatusListener_Init(struct LDDataSourceStatusListener* listener) {
+    listener->StatusChanged = nullptr;
+    listener->UserData = nullptr;
 }
 
 LD_EXPORT(LDListenerConnection)

--- a/libs/client-sdk/tests/client_c_bindings_test.cpp
+++ b/libs/client-sdk/tests/client_c_bindings_test.cpp
@@ -101,8 +101,14 @@ TEST(ClientBindings, RegisterDataSourceStatusChangeListener) {
 
     LDClientSDK sdk = LDClientSDK_New(config, context);
 
-    struct LDDataSourceStatusListener listener {};
-    LDDataSourceStatusListener_Init(listener);
+    struct LDDataSourceStatusListener listener {
+        reinterpret_cast<DataSourceStatusCallbackFn>(0x123),
+            reinterpret_cast<void*>(0x456)
+    };
+    LDDataSourceStatusListener_Init(&listener);
+
+    ASSERT_EQ(listener.StatusChanged, nullptr);
+    ASSERT_EQ(listener.UserData, nullptr);
 
     listener.UserData = const_cast<char*>("Potato");
     listener.StatusChanged = StatusListenerFunction;


### PR DESCRIPTION
This function previously took `LDDataSourceStatusListener` by value; now it takes a pointer.

The impact would be if a customer forgot to initialize the struct, then the member(s) would be undefined.

Found this after finding similar https://github.com/launchdarkly/cpp-sdks/pull/218. Following that PR, it will be released as a bugfix patch.