### PR TITLE
fix: deserializing certain values leads to infinite loop

### DIFF
--- a/libs/internal/src/serialization/json_value.cpp
+++ b/libs/internal/src/serialization/json_value.cpp
@@ -104,11 +104,5 @@ void tag_invoke(boost::json::value_from_tag const&,
     }
 }
 
-tl::expected<Value, JsonError> tag_invoke(
-    boost::json::value_to_tag<tl::expected<Value, JsonError>> const& tag,
-    boost::json::value const& json_value) {
-    return boost::json::value_to<Value>(json_value);
-}
-
 // NOLINTEND modernize-return-braced-init-list
 }  // namespace launchdarkly


### PR DESCRIPTION
We had an infinite loop where the `Value` tag invoke deserializer was calling the `tl::expected<Value, JsonError` version, which called back to itself.

This was manifesting as a runtime infinite loop. 

It's not caught by contract tests since I believe the trigger is having a list of variations that are themselves arrays, like:
```
"variations": [["a","b","c",123,true,"false"], [ .. other stuff ..], ... ]
```
The fix is to break the cycle and remove the incorrect implementation.