### PR TITLE
refactor: move DataSourceStatus ErrorInfo C Bindings into common

### DIFF
--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -8,6 +8,7 @@
 
 #include <launchdarkly/bindings/c/context.h>
 #include <launchdarkly/bindings/c/data/evaluation_detail.h>
+#include <launchdarkly/bindings/c/data_source/error_info.h>
 #include <launchdarkly/bindings/c/export.h>
 #include <launchdarkly/bindings/c/flag_listener.h>
 #include <launchdarkly/bindings/c/listener_connection.h>
@@ -447,7 +448,6 @@ LDClientSDK_FlagNotifier_OnFlagChange(LDClientSDK sdk,
                                       struct LDFlagListener listener);
 
 typedef struct _LDDataSourceStatus* LDDataSourceStatus;
-typedef struct _LDDataSourceStatus_ErrorInfo* LDDataSourceStatus_ErrorInfo;
 
 /**
  * Enumeration of possible data source states.
@@ -504,40 +504,6 @@ enum LDDataSourceStatus_State {
 };
 
 /**
- * A description of an error condition that the data source encountered.
- */
-enum LDDataSourceStatus_ErrorKind {
-    /**
-     * An unexpected error, such as an uncaught exception, further
-     * described by the error message.
-     */
-    LD_DATASOURCESTATUS_ERRORKIND_UNKNOWN = 0,
-
-    /**
-     * An I/O error such as a dropped connection.
-     */
-    LD_DATASOURCESTATUS_ERRORKIND_NETWORK_ERROR = 1,
-
-    /**
-     * The LaunchDarkly service returned an HTTP response with an error
-     * status, available in the status code.
-     */
-    LD_DATASOURCESTATUS_ERRORKIND_ERROR_RESPONSE = 2,
-
-    /**
-     * The SDK received malformed data from the LaunchDarkly service.
-     */
-    LD_DATASOURCESTATUS_ERRORKIND_INVALID_DATA = 3,
-
-    /**
-     * The data source itself is working, but when it tried to put an
-     * update into the data store, the data store failed (so the SDK may
-     * not have the latest data).
-     */
-    LD_DATASOURCESTATUS_ERRORKIND_STORE_ERROR = 4,
-};
-
-/**
  * Get an enumerated value representing the overall current state of the data
  * source.
  */
@@ -582,34 +548,6 @@ LDDataSourceStatus_GetLastError(LDDataSourceStatus status);
  * down.
  */
 LD_EXPORT(time_t) LDDataSourceStatus_StateSince(LDDataSourceStatus status);
-
-/**
- * Get an enumerated value representing the general category of the error.
- */
-LD_EXPORT(enum LDDataSourceStatus_ErrorKind)
-LDDataSourceStatus_ErrorInfo_GetKind(LDDataSourceStatus_ErrorInfo info);
-
-/**
- * The HTTP status code if the error was
- * LD_DATASOURCESTATUS_ERRORKIND_ERROR_RESPONSE.
- */
-LD_EXPORT(uint64_t)
-LDDataSourceStatus_ErrorInfo_StatusCode(LDDataSourceStatus_ErrorInfo info);
-
-/**
- * Any additional human-readable information relevant to the error.
- *
- * The format is subject to change and should not be relied on
- * programmatically.
- */
-LD_EXPORT(char const*)
-LDDataSourceStatus_ErrorInfo_Message(LDDataSourceStatus_ErrorInfo info);
-
-/**
- * The date/time that the error occurred, in seconds since epoch.
- */
-LD_EXPORT(time_t)
-LDDataSourceStatus_ErrorInfo_Time(LDDataSourceStatus_ErrorInfo info);
 
 typedef void (*DataSourceStatusCallbackFn)(LDDataSourceStatus status,
                                            void* user_data);
@@ -684,13 +622,6 @@ LDClientSDK_DataSourceStatus_Status(LDClientSDK sdk);
  * @param status The data source status to free.
  */
 LD_EXPORT(void) LDDataSourceStatus_Free(LDDataSourceStatus status);
-
-/**
- * Frees the data source status error information.
- * @param status The error information to free.
- */
-LD_EXPORT(void)
-LDDataSourceStatus_ErrorInfo_Free(LDDataSourceStatus_ErrorInfo info);
 
 #ifdef __cplusplus
 }

--- a/libs/client-sdk/src/bindings/c/sdk.cpp
+++ b/libs/client-sdk/src/bindings/c/sdk.cpp
@@ -24,9 +24,6 @@ struct Detail;
         launchdarkly::client_side::data_sources::DataSourceStatus*>(ptr))
 #define FROM_DATASOURCESTATUS(ptr) (reinterpret_cast<LDDataSourceStatus>(ptr))
 
-#define TO_DATASOURCESTATUS_ERRORINFO(ptr)                      \
-    (reinterpret_cast<launchdarkly::client_side::data_sources:: \
-                          DataSourceStatus::ErrorInfo*>(ptr))
 #define FROM_DATASOURCESTATUS_ERRORINFO(ptr) \
     (reinterpret_cast<LDDataSourceStatus_ErrorInfo>(ptr))
 
@@ -377,37 +374,6 @@ LD_EXPORT(time_t) LDDataSourceStatus_StateSince(LDDataSourceStatus status) {
         .count();
 }
 
-LD_EXPORT(LDDataSourceStatus_ErrorKind)
-LDDataSourceStatus_ErrorInfo_GetKind(LDDataSourceStatus_ErrorInfo info) {
-    LD_ASSERT_NOT_NULL(info);
-
-    return static_cast<enum LDDataSourceStatus_ErrorKind>(
-        TO_DATASOURCESTATUS_ERRORINFO(info)->Kind());
-}
-
-LD_EXPORT(uint64_t)
-LDDataSourceStatus_ErrorInfo_StatusCode(LDDataSourceStatus_ErrorInfo info) {
-    LD_ASSERT_NOT_NULL(info);
-
-    return TO_DATASOURCESTATUS_ERRORINFO(info)->StatusCode();
-}
-
-LD_EXPORT(char const*)
-LDDataSourceStatus_ErrorInfo_Message(LDDataSourceStatus_ErrorInfo info) {
-    LD_ASSERT_NOT_NULL(info);
-
-    return TO_DATASOURCESTATUS_ERRORINFO(info)->Message().c_str();
-}
-
-LD_EXPORT(time_t)
-LDDataSourceStatus_ErrorInfo_Time(LDDataSourceStatus_ErrorInfo info) {
-    LD_ASSERT_NOT_NULL(info);
-
-    return std::chrono::duration_cast<std::chrono::seconds>(
-               TO_DATASOURCESTATUS_ERRORINFO(info)->Time().time_since_epoch())
-        .count();
-}
-
 LD_EXPORT(void)
 LDDataSourceStatusListener_Init(struct LDDataSourceStatusListener* listener) {
     listener->StatusChanged = nullptr;
@@ -443,11 +409,6 @@ LDClientSDK_DataSourceStatus_Status(LDClientSDK sdk) {
 
 LD_EXPORT(void) LDDataSourceStatus_Free(LDDataSourceStatus status) {
     delete TO_DATASOURCESTATUS(status);
-}
-
-LD_EXPORT(void)
-LDDataSourceStatus_ErrorInfo_Free(LDDataSourceStatus_ErrorInfo info) {
-    delete TO_DATASOURCESTATUS_ERRORINFO(info);
 }
 
 // NOLINTEND cppcoreguidelines-pro-type-reinterpret-cast

--- a/libs/common/include/launchdarkly/bindings/c/data_source/error_info.h
+++ b/libs/common/include/launchdarkly/bindings/c/data_source/error_info.h
@@ -1,0 +1,59 @@
+/** @file error_info.h
+ * @brief LaunchDarkly Server-side C Bindings for Data Source Error Info.
+ */
+// NOLINTBEGIN modernize-use-using
+#pragma once
+
+#include <launchdarkly/bindings/c/data_source/error_kind.h>
+#include <launchdarkly/bindings/c/export.h>
+
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {  // only need to export C interface if
+// used by C++ source code
+#endif
+
+typedef struct _LDDataSourceStatus_ErrorInfo* LDDataSourceStatus_ErrorInfo;
+
+/**
+ * Get an enumerated value representing the general category of the error.
+ */
+LD_EXPORT(enum LDDataSourceStatus_ErrorKind)
+LDDataSourceStatus_ErrorInfo_GetKind(LDDataSourceStatus_ErrorInfo info);
+
+/**
+ * The HTTP status code if the error was
+ * LD_DATASOURCESTATUS_ERRORKIND_ERROR_RESPONSE.
+ */
+LD_EXPORT(uint64_t)
+LDDataSourceStatus_ErrorInfo_StatusCode(LDDataSourceStatus_ErrorInfo info);
+
+/**
+ * Any additional human-readable information relevant to the error.
+ *
+ * The format is subject to change and should not be relied on
+ * programmatically.
+ */
+LD_EXPORT(char const*)
+LDDataSourceStatus_ErrorInfo_Message(LDDataSourceStatus_ErrorInfo info);
+
+/**
+ * The date/time that the error occurred, in seconds since epoch.
+ */
+LD_EXPORT(time_t)
+LDDataSourceStatus_ErrorInfo_Time(LDDataSourceStatus_ErrorInfo info);
+
+/**
+ * Frees the data source status error information.
+ * @param status The error information to free.
+ */
+LD_EXPORT(void)
+LDDataSourceStatus_ErrorInfo_Free(LDDataSourceStatus_ErrorInfo info);
+
+#ifdef __cplusplus
+}
+#endif
+
+// NOLINTEND modernize-use-using

--- a/libs/common/include/launchdarkly/bindings/c/data_source/error_kind.h
+++ b/libs/common/include/launchdarkly/bindings/c/data_source/error_kind.h
@@ -1,0 +1,52 @@
+/** @file error_kind.h
+ * @brief LaunchDarkly Server-side C Bindings for Data Source Error Kinds.
+ */
+// NOLINTBEGIN modernize-use-using
+#pragma once
+
+#include <launchdarkly/bindings/c/export.h>
+
+#ifdef __cplusplus
+extern "C" {  // only need to export C interface if
+// used by C++ source code
+#endif
+
+/**
+ * A description of an error condition that the data source encountered.
+ */
+enum LDDataSourceStatus_ErrorKind {
+    /**
+     * An unexpected error, such as an uncaught exception, further
+     * described by the error message.
+     */
+    LD_DATASOURCESTATUS_ERRORKIND_UNKNOWN = 0,
+
+    /**
+     * An I/O error such as a dropped connection.
+     */
+    LD_DATASOURCESTATUS_ERRORKIND_NETWORK_ERROR = 1,
+
+    /**
+     * The LaunchDarkly service returned an HTTP response with an error
+     * status, available in the status code.
+     */
+    LD_DATASOURCESTATUS_ERRORKIND_ERROR_RESPONSE = 2,
+
+    /**
+     * The SDK received malformed data from the LaunchDarkly service.
+     */
+    LD_DATASOURCESTATUS_ERRORKIND_INVALID_DATA = 3,
+
+    /**
+     * The data source itself is working, but when it tried to put an
+     * update into the data store, the data store failed (so the SDK may
+     * not have the latest data).
+     */
+    LD_DATASOURCESTATUS_ERRORKIND_STORE_ERROR = 4,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+// NOLINTEND modernize-use-using

--- a/libs/common/include/launchdarkly/data_sources/data_source_status_error_info.hpp
+++ b/libs/common/include/launchdarkly/data_sources/data_source_status_error_info.hpp
@@ -2,7 +2,9 @@
 
 #include <launchdarkly/data_sources/data_source_status_error_kind.hpp>
 
+#include <chrono>
 #include <cstdint>
+#include <string>
 
 namespace launchdarkly::common::data_sources {
 
@@ -11,7 +13,7 @@ namespace launchdarkly::common::data_sources {
  */
 class DataSourceStatusErrorInfo {
    public:
-    using StatusCodeType = uint64_t;
+    using StatusCodeType = std::uint64_t;
     using ErrorKind = DataSourceStatusErrorKind;
     using DateTime = std::chrono::time_point<std::chrono::system_clock>;
 

--- a/libs/common/include/launchdarkly/data_sources/data_source_status_error_kind.hpp
+++ b/libs/common/include/launchdarkly/data_sources/data_source_status_error_kind.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 namespace launchdarkly::common::data_sources {
 
 /**

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${LIBNAME} OBJECT
         bindings/c/listener_connection.cpp
         bindings/c/flag_listener.cpp
         bindings/c/memory_routines.cpp
+        bindings/c/data_source/error_info.cpp
         log_level.cpp
         config/persistence_builder.cpp
         config/logging_builder.cpp

--- a/libs/common/src/bindings/c/data_source/error_info.cpp
+++ b/libs/common/src/bindings/c/data_source/error_info.cpp
@@ -1,0 +1,46 @@
+#include <launchdarkly/bindings/c/data_source/error_info.h>
+
+#include <launchdarkly/data_sources/data_source_status_base.hpp>
+#include <launchdarkly/detail/c_binding_helpers.hpp>
+
+using namespace launchdarkly::common;
+
+#define TO_DATASOURCESTATUS_ERRORINFO(ptr) \
+    (reinterpret_cast<                     \
+        launchdarkly::common::data_sources::DataSourceStatusErrorInfo*>(ptr))
+
+LD_EXPORT(LDDataSourceStatus_ErrorKind)
+LDDataSourceStatus_ErrorInfo_GetKind(LDDataSourceStatus_ErrorInfo info) {
+    LD_ASSERT_NOT_NULL(info);
+
+    return static_cast<enum LDDataSourceStatus_ErrorKind>(
+        TO_DATASOURCESTATUS_ERRORINFO(info)->Kind());
+}
+
+LD_EXPORT(uint64_t)
+LDDataSourceStatus_ErrorInfo_StatusCode(LDDataSourceStatus_ErrorInfo info) {
+    LD_ASSERT_NOT_NULL(info);
+
+    return TO_DATASOURCESTATUS_ERRORINFO(info)->StatusCode();
+}
+
+LD_EXPORT(char const*)
+LDDataSourceStatus_ErrorInfo_Message(LDDataSourceStatus_ErrorInfo info) {
+    LD_ASSERT_NOT_NULL(info);
+
+    return TO_DATASOURCESTATUS_ERRORINFO(info)->Message().c_str();
+}
+
+LD_EXPORT(time_t)
+LDDataSourceStatus_ErrorInfo_Time(LDDataSourceStatus_ErrorInfo info) {
+    LD_ASSERT_NOT_NULL(info);
+
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               TO_DATASOURCESTATUS_ERRORINFO(info)->Time().time_since_epoch())
+        .count();
+}
+
+LD_EXPORT(void)
+LDDataSourceStatus_ErrorInfo_Free(LDDataSourceStatus_ErrorInfo info) {
+    delete TO_DATASOURCESTATUS_ERRORINFO(info);
+}


### PR DESCRIPTION
This moves all the `_ErrorInfo_` C bindings out of the client-side SDK and into the common library, allowing them to be shared with the server.

This should be backwards compatible because the `sdk.h` includes the new `error_info.h`, providing the same symbols as before. 