### PR TITLE
fix: allow for specification of initial reconnect delay in streaming data source

### DIFF
--- a/contract-tests/sdk-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/sdk-contract-tests/src/entity_manager.cpp
@@ -48,14 +48,19 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
             endpoints.EventsBaseUrl(*in.serviceEndpoints->events);
         }
     }
+    auto& datasource = config_builder.DataSource();
 
     if (in.streaming) {
         if (in.streaming->baseUri) {
             endpoints.StreamingBaseUrl(*in.streaming->baseUri);
         }
+        if (in.streaming->initialRetryDelayMs) {
+            auto streaming = DataSourceBuilder::Streaming();
+            streaming.InitialReconnectDelay(
+                std::chrono::milliseconds(*in.streaming->initialRetryDelayMs));
+            datasource.Method(std::move(streaming));
+        }
     }
-
-    auto& datasource = config_builder.DataSource();
 
     if (in.polling) {
         if (in.polling->baseUri) {

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -91,7 +91,6 @@ void StreamingDataSource::Start() {
         return;
     }
 
-    // TODO: Initial reconnect delay. sc-204393
     boost::urls::url url = uri_components.value();
 
     if (data_source_config_.with_reasons) {
@@ -116,6 +115,9 @@ void StreamingDataSource::Start() {
     client_builder.write_timeout(http_config_.WriteTimeout());
 
     client_builder.connect_timeout(http_config_.ConnectTimeout());
+
+    client_builder.initial_reconnect_delay(
+        streaming_config.initial_reconnect_delay);
 
     for (auto const& header : http_config_.BaseHeaders()) {
         client_builder.header(header.first, header.second);

--- a/libs/server-sent-events/include/launchdarkly/sse/client.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/client.hpp
@@ -91,6 +91,14 @@ class Builder {
     Builder& write_timeout(std::chrono::milliseconds timeout);
 
     /**
+     * Specifies the initial delay before reconnection when backoff takes place
+     * due to an error on the connection.
+     * @param timeout
+     * @return Reference to this builder.
+     */
+    Builder& initial_reconnect_delay(std::chrono::milliseconds delay);
+
+    /**
      * Specify the method for the initial request. The default method is GET.
      * @param verb The HTTP method.
      * @return Reference to this builder.
@@ -138,6 +146,7 @@ class Builder {
     std::optional<std::chrono::milliseconds> read_timeout_;
     std::optional<std::chrono::milliseconds> write_timeout_;
     std::optional<std::chrono::milliseconds> connect_timeout_;
+    std::optional<std::chrono::milliseconds> initial_reconnect_delay_;
     LogCallback logging_cb_;
     EventReceiver receiver_;
     ErrorCallback error_cb_;


### PR DESCRIPTION
The public API was already available, but we didn't have the plumbing required to get it into the SSE client. Therefore, I'm regarding it as a bugfix. 

This came up because we need it to pass some streaming contract tests, which in part fail because our default delays are too high (starting at 1 second). 