### PR TITLE
feat: Server SDK initial backoff delay plumbing & contract test fix

### DIFF
--- a/contract-tests/client-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/client-contract-tests/src/entity_manager.cpp
@@ -48,14 +48,19 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
             endpoints.EventsBaseUrl(*in.serviceEndpoints->events);
         }
     }
+    auto& datasource = config_builder.DataSource();
 
     if (in.streaming) {
         if (in.streaming->baseUri) {
             endpoints.StreamingBaseUrl(*in.streaming->baseUri);
         }
+        if (in.streaming->initialRetryDelayMs) {
+            auto streaming = DataSourceBuilder::Streaming();
+            streaming.InitialReconnectDelay(
+                std::chrono::milliseconds(*in.streaming->initialRetryDelayMs));
+            datasource.Method(std::move(streaming));
+        }
     }
-
-    auto& datasource = config_builder.DataSource();
 
     if (in.polling) {
         if (in.polling->baseUri) {

--- a/contract-tests/server-contract-tests/test-suppressions.txt
+++ b/contract-tests/server-contract-tests/test-suppressions.txt
@@ -1,9 +1,3 @@
-streaming/retry behavior/retry after IO error on reconnect
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 400
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 408
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 429
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 500
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 503
 streaming/validation/drop and reconnect if stream event has malformed JSON/put event
 streaming/validation/drop and reconnect if stream event has malformed JSON/patch event
 streaming/validation/drop and reconnect if stream event has malformed JSON/delete event

--- a/libs/client-sdk/README.md
+++ b/libs/client-sdk/README.md
@@ -12,7 +12,7 @@ For using LaunchDarkly in server-side C/C++ applications, refer to our [Server-S
 
 LaunchDarkly overview
 -------------------------
-[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves trillions of feature flags
 daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started)
 using LaunchDarkly today!
 
@@ -36,7 +36,7 @@ installing and using the SDK.
 ### Incorporating the SDK
 
 The SDK can be used via a C++ or C interface and can be incorporated via a static library or shared object. The static
-library and shared object each have their on use cases and limitations.
+library and shared object each have their own use cases and limitations.
 
 The static library supports both the C++ and C interface. When using the static library, you should ensure that it is
 compiled using a compatible configuration and toolchain. For instance, when using MSVC, it needs to be using the same
@@ -89,7 +89,7 @@ behave correctly.
 Contributing
 ------------
 
-We encourage pull requests and other contributions from the community. Check out
+We encourage pull requests and other contributions from the community. Read
 our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
 About LaunchDarkly

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -91,7 +91,6 @@ void StreamingDataSource::Start() {
         return;
     }
 
-    // TODO: Initial reconnect delay. sc-204393
     boost::urls::url url = uri_components.value();
 
     if (data_source_config_.with_reasons) {
@@ -116,6 +115,9 @@ void StreamingDataSource::Start() {
     client_builder.write_timeout(http_config_.WriteTimeout());
 
     client_builder.connect_timeout(http_config_.ConnectTimeout());
+
+    client_builder.initial_reconnect_delay(
+        streaming_config.initial_reconnect_delay);
 
     for (auto const& header : http_config_.BaseHeaders()) {
         client_builder.header(header.first, header.second);

--- a/libs/server-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/server-sdk/src/data_sources/streaming_data_source.cpp
@@ -77,7 +77,6 @@ void StreamingDataSource::Start() {
         return;
     }
 
-    // TODO: Initial reconnect delay. sc-204393
     boost::urls::url url = uri_components.value();
 
     auto client_builder = launchdarkly::sse::Builder(exec_, url.buffer());
@@ -92,6 +91,9 @@ void StreamingDataSource::Start() {
     client_builder.write_timeout(http_config_.WriteTimeout());
 
     client_builder.connect_timeout(http_config_.ConnectTimeout());
+
+    client_builder.initial_reconnect_delay(
+        streaming_config_.initial_reconnect_delay);
 
     for (auto const& header : http_config_.BaseHeaders()) {
         client_builder.header(header.first, header.second);

--- a/libs/server-sent-events/include/launchdarkly/sse/client.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/client.hpp
@@ -91,6 +91,14 @@ class Builder {
     Builder& write_timeout(std::chrono::milliseconds timeout);
 
     /**
+     * Specifies the initial delay before reconnection when backoff takes place
+     * due to an error on the connection.
+     * @param timeout
+     * @return Reference to this builder.
+     */
+    Builder& initial_reconnect_delay(std::chrono::milliseconds delay);
+
+    /**
      * Specify the method for the initial request. The default method is GET.
      * @param verb The HTTP method.
      * @return Reference to this builder.
@@ -138,6 +146,7 @@ class Builder {
     std::optional<std::chrono::milliseconds> read_timeout_;
     std::optional<std::chrono::milliseconds> write_timeout_;
     std::optional<std::chrono::milliseconds> connect_timeout_;
+    std::optional<std::chrono::milliseconds> initial_reconnect_delay_;
     LogCallback logging_cb_;
     EventReceiver receiver_;
     ErrorCallback error_cb_;


### PR DESCRIPTION
Wires up the streaming data source initial backoff delay parameter, allowing us to pass additional contract tests. 