### PR TITLE
feat: plumb server side initial backoff delay

### DIFF
--- a/contract-tests/server-contract-tests/test-suppressions.txt
+++ b/contract-tests/server-contract-tests/test-suppressions.txt
@@ -1,9 +1,3 @@
-streaming/retry behavior/retry after IO error on reconnect
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 400
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 408
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 429
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 500
-streaming/retry behavior/retry after recoverable HTTP error on reconnect/error 503
 streaming/validation/drop and reconnect if stream event has malformed JSON/put event
 streaming/validation/drop and reconnect if stream event has malformed JSON/patch event
 streaming/validation/drop and reconnect if stream event has malformed JSON/delete event

--- a/libs/server-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/server-sdk/src/data_sources/streaming_data_source.cpp
@@ -77,7 +77,6 @@ void StreamingDataSource::Start() {
         return;
     }
 
-    // TODO: Initial reconnect delay. sc-204393
     boost::urls::url url = uri_components.value();
 
     auto client_builder = launchdarkly::sse::Builder(exec_, url.buffer());
@@ -92,6 +91,9 @@ void StreamingDataSource::Start() {
     client_builder.write_timeout(http_config_.WriteTimeout());
 
     client_builder.connect_timeout(http_config_.ConnectTimeout());
+
+    client_builder.initial_reconnect_delay(
+        streaming_config_.initial_reconnect_delay);
 
     for (auto const& header : http_config_.BaseHeaders()) {
         client_builder.header(header.first, header.second);


### PR DESCRIPTION
Hooks up the initial reconnect delay parameter to the server-side streaming data source. Allows us to remove another batch of contract test failures. 