### PR TITLE
refactor: move sse-client package dep from common to client-sdk

### DIFF
--- a/libs/client-sdk/package.json
+++ b/libs/client-sdk/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "launchdarkly-cpp-internal": "0.1.8",
-    "launchdarkly-cpp-common": "0.3.5"
+    "launchdarkly-cpp-common": "0.3.5",
+    "launchdarkly-cpp-sse-client": "0.1.2"
   }
 }

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -2,8 +2,5 @@
   "name": "launchdarkly-cpp-common",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "0.3.5",
-  "private": true,
-  "dependencies": {
-    "launchdarkly-cpp-sse-client": "0.1.2"
-  }
+  "private": true
 }


### PR DESCRIPTION
Currently we have:
```
client-sdk -> common -> sse-client
```

The `common` lib doesn't depend on `sse-client`, so this results in unnecessary `common` revisions. 

This commit makes `sse-client` a dependency of `client-sdk`. 