### PR TITLE
chore: resolve ValidChar function lint/compile warnings

### DIFF
--- a/libs/common/src/config/app_info_builder.cpp
+++ b/libs/common/src/config/app_info_builder.cpp
@@ -22,7 +22,7 @@ tl::expected<std::string, Error> AppInfoBuilder::Tag::Build() const {
 
 bool ValidChar(char c) {
     if (c > 0) {
-        // The MSVC implementation of isalnum will assert if the number it
+        // The MSVC implementation of isalnum will assert if the number is
         // outside its lookup table (0-0xFF, inclusive.)
         // iswalnum would not, but is less restrictive than desired.
         return std::isalnum(c) != 0 || c == '-' || c == '.' || c == '_';

--- a/libs/common/src/config/app_info_builder.cpp
+++ b/libs/common/src/config/app_info_builder.cpp
@@ -21,9 +21,9 @@ tl::expected<std::string, Error> AppInfoBuilder::Tag::Build() const {
 }
 
 bool ValidChar(char c) {
-    if(c > 0 && c < 255) {
-        // The MSVC implementation of isalnum will assert if the number it outside
-        // its lookup table.
+    if (c > 0) {
+        // The MSVC implementation of isalnum will assert if the number it
+        // outside its lookup table (0-0xFF, inclusive.)
         // iswalnum would not, but is less restrictive than desired.
         return std::isalnum(c) != 0 || c == '-' || c == '.' || c == '_';
     }


### PR DESCRIPTION
The argument to `ValidChar` is a `char`, so its max value is `255` rendering the check redundant. This causes a warning on our Mac compilations as well as a linter warning. 

(unless we have a platform that has a char wider than 8 bits..)