### PR TITLE
fix: shasum generation for macos artifacts + uploading provenance to Github release

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -185,7 +185,7 @@ runs:
       shell: bash
       id: hash-macos
       run: |
-        echo "hashes-macos=$(sha256sum mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
+        echo "hashes-macos=$(sha256sum mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -b 0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Mac Build Artifacts
       if: runner.os == 'macOS'

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -67,3 +67,5 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
     with:
       base64-subjects: "${{ needs.release-sdk.outputs[format('hashes-{0}', matrix.os)] }}"
+      upload-assets: true 
+      upload-tag-name: ${{ inputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,3 +55,5 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
     with:
       base64-subjects: "${{ needs.release-client.outputs[format('hashes-{0}', matrix.os)] }}"
+      upload-assets: true 
+      upload-tag-name: ${{ needs.release-please.outputs.package-client-tag }}


### PR DESCRIPTION
`shasum` has different parameters in MacOS vs Linux/Windows:

```
Run echo "hashes-macos=$(sha256sum mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
/Users/runner/work/_temp/8965ab70-9f6a-4960-9224-3651a6a4797a.sh: line 1: sha256sum: command not found
base64: invalid option -- w
Usage:	base64 [-hvDd] [-b num] [-i in_file] [-o out_file]
```

Changing this to `base64 -b 0` should fix it and get the intended result 