### PR TITLE
build: slight renaming of provenance output to meet best practice

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -25,9 +25,9 @@ outputs:
   hashes-windows:
     description: "base64-encoded sha256 hash of windows build artifacts"
     value: ${{ steps.hash-windows.outputs.hashes-windows }}
-  hashes-macos:
+  hashes-mac:
     description: "base64-encoded sha256 hash of macos build artifacts"
-    value: ${{ steps.hash-macos.outputs.hashes-macos }}
+    value: ${{ steps.hash-mac.outputs.hashes-mac }}
 
 runs:
   using: composite
@@ -183,9 +183,9 @@ runs:
     - name: Hash Mac Build Artifacts for provenance
       if: runner.os == 'macOS'
       shell: bash
-      id: hash-macos
+      id: hash-mac
       run: |
-        echo "hashes-macos=$(shasum -a 256 mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -b 0)" >> "$GITHUB_OUTPUT"
+        echo "hashes-mac=$(shasum -a 256 mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -b 0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Mac Build Artifacts
       if: runner.os == 'macOS'

--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -25,9 +25,9 @@ outputs:
   hashes-windows:
     description: "base64-encoded sha256 hash of windows build artifacts"
     value: ${{ steps.hash-windows.outputs.hashes-windows }}
-  hashes-mac:
+  hashes-macos:
     description: "base64-encoded sha256 hash of macos build artifacts"
-    value: ${{ steps.hash-mac.outputs.hashes-mac }}
+    value: ${{ steps.hash-macos.outputs.hashes-macos }}
 
 runs:
   using: composite
@@ -183,9 +183,9 @@ runs:
     - name: Hash Mac Build Artifacts for provenance
       if: runner.os == 'macOS'
       shell: bash
-      id: hash-mac
+      id: hash-macos
       run: |
-        echo "hashes-mac=$(shasum -a 256 mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -b 0)" >> "$GITHUB_OUTPUT"
+        echo "hashes-macos=$(shasum -a 256 mac-clang-x64-static.zip mac-clang-x64-dynamic.zip | base64 -b 0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Mac Build Artifacts
       if: runner.os == 'macOS'

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       hashes-linux: ${{ steps.release-sdk.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-sdk.outputs.hashes-windows }}
-      hashes-mac: ${{ steps.release-sdk.outputs.hashes-mac }}
+      hashes-macos: ${{ steps.release-sdk.outputs.hashes-macos }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         # Generates a combined attestation for each platform
-        os: [ linux, windows, mac ]
+        os: [ linux, windows, macos ]
     permissions: 
       actions: read
       id-token: write

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -40,7 +40,7 @@ jobs:
     outputs:
       hashes-linux: ${{ steps.release-sdk.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-sdk.outputs.hashes-windows }}
-      hashes-macos: ${{ steps.release-sdk.outputs.hashes-macos }}
+      hashes-mac: ${{ steps.release-sdk.outputs.hashes-mac }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         # Generates a combined attestation for each platform
-        os: [ linux, windows, macos ]
+        os: [ linux, windows, mac ]
     permissions: 
       actions: read
       id-token: write
@@ -69,4 +69,4 @@ jobs:
       base64-subjects: "${{ needs.release-sdk.outputs[format('hashes-{0}', matrix.os)] }}"
       upload-assets: true 
       upload-tag-name: ${{ inputs.tag }}
-      provenance-name: ${{ format('{0}-multiple.intoto.jsonl', matrix.os) }}
+      provenance-name: ${{ format('{0}-multiple-provenance.intoto.jsonl', matrix.os) }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       hashes-linux: ${{ steps.release-client.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-client.outputs.hashes-windows }}
-      hashes-mac: ${{ steps.release-client.outputs.hashes-mac }}
+      hashes-macos: ${{ steps.release-client.outputs.hashes-macos }}
     steps:
       - uses: actions/checkout@v3
       - id: release-client
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         # Generates a combined attestation for each platform
-        os: [ linux, windows, mac ]
+        os: [ linux, windows, macos ]
     permissions: 
       actions: read
       id-token: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       hashes-linux: ${{ steps.release-client.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-client.outputs.hashes-windows }}
-      hashes-macos: ${{ steps.release-client.outputs.hashes-macos }}
+      hashes-mac: ${{ steps.release-client.outputs.hashes-mac }}
     steps:
       - uses: actions/checkout@v3
       - id: release-client
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         # Generates a combined attestation for each platform
-        os: [ linux, windows, macos ]
+        os: [ linux, windows, mac ]
     permissions: 
       actions: read
       id-token: write
@@ -57,4 +57,4 @@ jobs:
       base64-subjects: "${{ needs.release-client.outputs[format('hashes-{0}', matrix.os)] }}"
       upload-assets: true 
       upload-tag-name: ${{ needs.release-please.outputs.package-client-tag }}
-      provenance-name: ${{ format('{0}-multiple.intoto.jsonl', matrix.os) }}
+      provenance-name: ${{ format('{0}-multiple-provenance.intoto.jsonl', matrix.os) }}


### PR DESCRIPTION
Adding `-provenance` suffix to make the provenance artifacts clearer to consumers. Additionally, renaming `macos-` prefix to `mac-` to match the prefix of the mac build artifacts, per guidance from https://slsa.dev/spec/v1.0/distributing-provenance#relationship-between-artifacts-and-attestations