### PR TITLE
fix: stream connections longer than 5 minutes are dropped 

### DIFF
--- a/contract-tests/sse-contract-tests/include/event_outbox.hpp
+++ b/contract-tests/sse-contract-tests/include/event_outbox.hpp
@@ -72,11 +72,11 @@ class EventOutbox : public std::enable_shared_from_this<EventOutbox> {
    private:
     RequestType build_request(
         std::size_t counter,
-        std::variant<launchdarkly::sse::Event, launchdarkly::sse::Error> ev);
+        std::variant<launchdarkly::sse::Event, launchdarkly::sse::Error> event);
     void on_resolve(beast::error_code ec, tcp::resolver::results_type results);
     void on_connect(beast::error_code ec,
                     tcp::resolver::results_type::endpoint_type);
     void on_flush_timer(boost::system::error_code ec);
     void on_write(beast::error_code ec, std::size_t);
-    void do_shutdown(beast::error_code ec, std::string what);
+    void do_shutdown(beast::error_code ec);
 };

--- a/contract-tests/sse-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/sse-contract-tests/src/entity_manager.cpp
@@ -27,7 +27,7 @@ std::optional<std::string> EntityManager::create(ConfigParams const& params) {
     }
 
     if (params.body) {
-        client_builder.body(std::move(*params.body));
+        client_builder.body(*params.body);
     }
 
     if (params.readTimeoutMs) {
@@ -44,12 +44,13 @@ std::optional<std::string> EntityManager::create(ConfigParams const& params) {
         LD_LOG(logger_, LogLevel::kDebug) << std::move(msg);
     });
 
-    client_builder.receiver([copy = poster](launchdarkly::sse::Event e) {
-        copy->post_event(std::move(e));
+    client_builder.receiver([copy = poster](launchdarkly::sse::Event event) {
+        copy->post_event(std::move(event));
     });
 
-    client_builder.errors(
-        [copy = poster](launchdarkly::sse::Error e) { copy->post_error(e); });
+    client_builder.errors([copy = poster](launchdarkly::sse::Error event) {
+        copy->post_error(event);
+    });
 
     auto client = client_builder.build();
     if (!client) {

--- a/contract-tests/sse-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/sse-contract-tests/src/entity_manager.cpp
@@ -35,6 +35,11 @@ std::optional<std::string> EntityManager::create(ConfigParams const& params) {
             std::chrono::milliseconds(*params.readTimeoutMs));
     }
 
+    if (params.initialDelayMs) {
+        client_builder.initial_reconnect_delay(
+            std::chrono::milliseconds(*params.initialDelayMs));
+    }
+
     client_builder.logger([this](std::string msg) {
         LD_LOG(logger_, LogLevel::kDebug) << std::move(msg);
     });

--- a/contract-tests/sse-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/sse-contract-tests/src/entity_manager.cpp
@@ -53,7 +53,7 @@ std::optional<std::string> EntityManager::create(ConfigParams const& params) {
         return std::nullopt;
     }
 
-    client->run();
+    client->async_connect();
 
     entities_.emplace(id, std::make_pair(client, poster));
     return id;

--- a/contract-tests/sse-contract-tests/src/event_outbox.cpp
+++ b/contract-tests/sse-contract-tests/src/event_outbox.cpp
@@ -93,6 +93,8 @@ EventOutbox::RequestType EventOutbox::build_request(
                         break;
                     case Error::UnrecoverableClientError:
                         msg.comment = "unrecoverable client error";
+                    case Error::ReadTimeout:
+                        msg.comment = "read timeout";
                     default:
                         msg.comment = "unspecified error";
                 }

--- a/contract-tests/sse-contract-tests/src/event_outbox.cpp
+++ b/contract-tests/sse-contract-tests/src/event_outbox.cpp
@@ -67,7 +67,7 @@ EventOutbox::RequestType EventOutbox::build_request(
     RequestType req;
 
     req.set(http::field::host, callback_host_);
-    req.method(http::verb::get);
+    req.method(http::verb::post);
     req.target(callback_url_ + "/" + std::to_string(counter));
 
     nlohmann::json json;

--- a/contract-tests/sse-contract-tests/src/main.cpp
+++ b/contract-tests/sse-contract-tests/src/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
     launchdarkly::Logger logger{
         std::make_unique<ConsoleBackend>("sse-contract-tests")};
 
-    const std::string default_port = "8123";
+    std::string const default_port = "8123";
     std::string port = default_port;
     if (argc == 2) {
         port =
@@ -38,6 +38,7 @@ int main(int argc, char* argv[]) {
         srv.add_capability("report");
         srv.add_capability("post");
         srv.add_capability("reconnection");
+        srv.add_capability("read-timeout");
 
         net::signal_set signals{ioc, SIGINT, SIGTERM};
 

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -163,7 +163,7 @@ void StreamingDataSource::Start() {
             kCouldNotParseEndpoint);
         return;
     }
-    client_->run();
+    client_->async_connect();
 }
 
 void StreamingDataSource::ShutdownAsync(std::function<void()> completion) {

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -138,7 +138,7 @@ void StreamingDataSource::Start() {
 
     client_builder.logger([weak_self](auto msg) {
         if (auto self = weak_self.lock()) {
-            LD_LOG(self->logger_, LogLevel::kDebug) << msg;
+            LD_LOG(self->logger_, LogLevel::kDebug) << "sse-client: " << msg;
         }
     });
 

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -27,6 +27,8 @@ static char const* DataSourceErrorToString(launchdarkly::sse::Error error) {
             return "server responded with an invalid redirection";
         case sse::Error::UnrecoverableClientError:
             return "unrecoverable client-side error";
+        case sse::Error::ReadTimeout:
+            return "read timeout reached";
     }
 }
 

--- a/libs/common/src/config/logging_builder.cpp
+++ b/libs/common/src/config/logging_builder.cpp
@@ -60,7 +60,9 @@ LoggingBuilder::BasicLogging& LoggingBuilder::BasicLogging::Tag(
     return *this;
 }
 LoggingBuilder::BasicLogging::BasicLogging()
-    : level_(Defaults<AnySDK>::LogLevel()), tag_(Defaults<AnySDK>::LogTag()) {}
+    : level_(GetLogLevelEnum(std::getenv("LD_LOG_LEVEL"),
+                             Defaults<AnySDK>::LogLevel())),
+      tag_(Defaults<AnySDK>::LogTag()) {}
 
 LoggingBuilder::CustomLogging& LoggingBuilder::CustomLogging::Backend(
     std::shared_ptr<ILogBackend> backend) {

--- a/libs/server-sent-events/include/launchdarkly/sse/client.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/client.hpp
@@ -160,7 +160,7 @@ class Builder {
 class Client {
    public:
     virtual ~Client() = default;
-    virtual void run() = 0;
+    virtual void async_connect() = 0;
     virtual void async_shutdown(std::function<void()> completion) = 0;
 };
 

--- a/libs/server-sent-events/include/launchdarkly/sse/error.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/error.hpp
@@ -6,5 +6,6 @@ enum class Error {
     NoContent = 1,
     InvalidRedirectLocation = 2,
     UnrecoverableClientError = 3,
+    ReadTimeout = 4,
 };
 }

--- a/libs/server-sent-events/src/client.cpp
+++ b/libs/server-sent-events/src/client.cpp
@@ -309,6 +309,7 @@ class FoxyClient : public Client,
             if (shutting_down_) {
                 return;
             }
+            errors_(Error::ReadTimeout);
             return do_backoff(
                 "aborting read of response body (timeout/shutdown)");
         }

--- a/libs/server-sent-events/src/client.cpp
+++ b/libs/server-sent-events/src/client.cpp
@@ -175,10 +175,16 @@ class FoxyClient : public Client,
         if (ec == boost::asio::error::operation_aborted) {
             return;
         }
-        run();
+        do_run();
     }
 
-    void run() override {
+    void async_connect() override {
+        boost::asio::post(
+            session_->get_executor(),
+            beast::bind_front_handler(&FoxyClient::do_run, shared_from_this()));
+    }
+
+    void do_run() {
         session_->async_connect(
             host_, port_,
             beast::bind_front_handler(&FoxyClient::on_connect,

--- a/vendor/foxy/include/foxy/impl/session/async_read.impl.hpp
+++ b/vendor/foxy/include/foxy/impl/session/async_read.impl.hpp
@@ -1,9 +1,8 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
-// com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
@@ -11,56 +10,54 @@
 #ifndef FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
 #define FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
 
-#include <foxy/detail/timed_op_wrapper_v3.hpp>
 #include <foxy/session.hpp>
+#include <foxy/detail/timed_op_wrapper_v3.hpp>
 
-namespace launchdarkly::foxy {
+namespace launchdarkly::foxy
+{
 template <class Stream, class DynamicBuffer>
 template <class Parser, class ReadHandler>
-auto basic_session<Stream, DynamicBuffer>::async_read(
-    Parser& parser,
-    ReadHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                       void(boost::system::error_code,
-                                            std::size_t)>::return_type {
-    return ::launchdarkly::foxy::detail::async_timer<void(
-        boost::system::error_code, std::size_t)>(
-        [&parser, self = this, coro = boost::asio::coroutine()](
-            auto& cb, boost::system::error_code ec = {},
-            std::size_t bytes_transferrred = 0) mutable {
-            BOOST_ASIO_CORO_REENTER(coro) {
-                BOOST_ASIO_CORO_YIELD boost::beast::http::async_read(
-                    self->stream, self->buffer, parser, std::move(cb));
+auto
+basic_session<Stream, DynamicBuffer>::async_read(Parser& parser, ReadHandler&& handler) & ->
+  typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                     void(boost::system::error_code, std::size_t)>::return_type
+{
+  return ::launchdarkly::foxy::detail::async_timer<void(boost::system::error_code, std::size_t)>(
+    [&parser, self = this, coro = boost::asio::coroutine()](
+      auto& cb, boost::system::error_code ec = {}, std::size_t bytes_transferrred = 0) mutable {
+      BOOST_ASIO_CORO_REENTER(coro)
+      {
+        BOOST_ASIO_CORO_YIELD boost::beast::http::async_read(self->stream, self->buffer, parser,
+                                                             std::move(cb));
 
-                cb.complete(ec, bytes_transferrred);
-            }
-        },
-        *this, std::forward<ReadHandler>(handler));
+        cb.complete(ec, bytes_transferrred);
+      }
+    },
+    *this, std::forward<ReadHandler>(handler));
 }
 
 template <class Stream, class DynamicBuffer>
 template <class Parser, class ReadHandler>
-auto basic_session<Stream, DynamicBuffer>::async_read_some(
-    Parser& parser,
-    ReadHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                       void(boost::system::error_code,
-                                            std::size_t)>::return_type {
-    return ::launchdarkly::foxy::detail::async_timer<void(
-        boost::system::error_code, std::size_t)>(
-        [&parser, self = this, coro = boost::asio::coroutine()](
-            auto& cb, boost::system::error_code ec = {},
-            std::size_t bytes_transferrred = 0) mutable {
-            BOOST_ASIO_CORO_REENTER(coro) {
-                BOOST_ASIO_CORO_YIELD boost::beast::http::async_read_some(
-                    self->stream, self->buffer, parser, std::move(cb));
+auto
+basic_session<Stream, DynamicBuffer>::async_read_some(Parser& parser, ReadHandler&& handler) & ->
+  typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                     void(boost::system::error_code, std::size_t)>::return_type
+{
+  return ::launchdarkly::foxy::detail::async_timer<void(boost::system::error_code, std::size_t)>(
+    [&parser, self = this, coro = boost::asio::coroutine()](
+      auto& cb, boost::system::error_code ec = {}, std::size_t bytes_transferrred = 0) mutable {
+      BOOST_ASIO_CORO_REENTER(coro)
+      {
+        BOOST_ASIO_CORO_YIELD boost::beast::http::async_read_some(self->stream, self->buffer, parser,
+                                                             std::move(cb));
 
-                cb.complete(ec, bytes_transferrred);
-            }
-        },
-        *this, std::forward<ReadHandler>(handler));
+        cb.complete(ec, bytes_transferrred);
+      }
+    },
+    *this, std::forward<ReadHandler>(handler));
 }
 
-}  // namespace launchdarkly::foxy
 
-#endif  // FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
+} // namespace launchdarkly::foxy
+
+#endif // FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_

--- a/vendor/foxy/include/foxy/impl/session/async_read.impl.hpp
+++ b/vendor/foxy/include/foxy/impl/session/async_read.impl.hpp
@@ -1,8 +1,9 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
+// com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
-// or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
@@ -10,32 +11,56 @@
 #ifndef FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
 #define FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
 
-#include <foxy/session.hpp>
 #include <foxy/detail/timed_op_wrapper_v3.hpp>
+#include <foxy/session.hpp>
 
-namespace launchdarkly::foxy
-{
+namespace launchdarkly::foxy {
 template <class Stream, class DynamicBuffer>
 template <class Parser, class ReadHandler>
-auto
-basic_session<Stream, DynamicBuffer>::async_read(Parser& parser, ReadHandler&& handler) & ->
-  typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                     void(boost::system::error_code, std::size_t)>::return_type
-{
-  return ::launchdarkly::foxy::detail::async_timer<void(boost::system::error_code, std::size_t)>(
-    [&parser, self = this, coro = boost::asio::coroutine()](
-      auto& cb, boost::system::error_code ec = {}, std::size_t bytes_transferrred = 0) mutable {
-      BOOST_ASIO_CORO_REENTER(coro)
-      {
-        BOOST_ASIO_CORO_YIELD boost::beast::http::async_read(self->stream, self->buffer, parser,
-                                                             std::move(cb));
+auto basic_session<Stream, DynamicBuffer>::async_read(
+    Parser& parser,
+    ReadHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                       void(boost::system::error_code,
+                                            std::size_t)>::return_type {
+    return ::launchdarkly::foxy::detail::async_timer<void(
+        boost::system::error_code, std::size_t)>(
+        [&parser, self = this, coro = boost::asio::coroutine()](
+            auto& cb, boost::system::error_code ec = {},
+            std::size_t bytes_transferrred = 0) mutable {
+            BOOST_ASIO_CORO_REENTER(coro) {
+                BOOST_ASIO_CORO_YIELD boost::beast::http::async_read(
+                    self->stream, self->buffer, parser, std::move(cb));
 
-        cb.complete(ec, bytes_transferrred);
-      }
-    },
-    *this, std::forward<ReadHandler>(handler));
+                cb.complete(ec, bytes_transferrred);
+            }
+        },
+        *this, std::forward<ReadHandler>(handler));
 }
 
-} // namespace launchdarkly::foxy
+template <class Stream, class DynamicBuffer>
+template <class Parser, class ReadHandler>
+auto basic_session<Stream, DynamicBuffer>::async_read_some(
+    Parser& parser,
+    ReadHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                       void(boost::system::error_code,
+                                            std::size_t)>::return_type {
+    return ::launchdarkly::foxy::detail::async_timer<void(
+        boost::system::error_code, std::size_t)>(
+        [&parser, self = this, coro = boost::asio::coroutine()](
+            auto& cb, boost::system::error_code ec = {},
+            std::size_t bytes_transferrred = 0) mutable {
+            BOOST_ASIO_CORO_REENTER(coro) {
+                BOOST_ASIO_CORO_YIELD boost::beast::http::async_read_some(
+                    self->stream, self->buffer, parser, std::move(cb));
 
-#endif // FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_
+                cb.complete(ec, bytes_transferrred);
+            }
+        },
+        *this, std::forward<ReadHandler>(handler));
+}
+
+}  // namespace launchdarkly::foxy
+
+#endif  // FOXY_IMPL_SESSION_ASYNC_READ_IMPL_HPP_

--- a/vendor/foxy/include/foxy/session.hpp
+++ b/vendor/foxy/include/foxy/session.hpp
@@ -1,8 +1,9 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
+// com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
-// or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
@@ -10,8 +11,8 @@
 #ifndef FOXY_SESSION_HPP_
 #define FOXY_SESSION_HPP_
 
-#include <foxy/session_opts.hpp>
 #include <foxy/multi_stream.hpp>
+#include <foxy/session_opts.hpp>
 #include <foxy/type_traits.hpp>
 
 #include <boost/asio/async_result.hpp>
@@ -22,78 +23,90 @@
 #include <boost/mp11/bind.hpp>
 
 #include <boost/beast/core/async_base.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
-#include <boost/beast/core/flat_buffer.hpp>
 
-namespace launchdarkly::foxy
-{
+namespace launchdarkly::foxy {
 template <class Stream, class DynamicBuffer>
-struct basic_session
-{
-public:
-  static_assert(boost::beast::is_async_stream<Stream>::value,
-                "Requirements on the Stream type were not met. Stream must be a Beast.AsyncStream");
+struct basic_session {
+   public:
+    static_assert(boost::beast::is_async_stream<Stream>::value,
+                  "Requirements on the Stream type were not met. Stream must "
+                  "be a Beast.AsyncStream");
 
-  static_assert(boost::asio::is_dynamic_buffer<DynamicBuffer>::value,
-                "Requirements on the DynamicBuffer type were not met. DynamicBuffer must be an "
-                "Asio.DynamicBuffer");
+    static_assert(boost::asio::is_dynamic_buffer<DynamicBuffer>::value,
+                  "Requirements on the DynamicBuffer type were not met. "
+                  "DynamicBuffer must be an "
+                  "Asio.DynamicBuffer");
 
-  using stream_type   = ::launchdarkly::foxy::basic_multi_stream<Stream>;
-  using buffer_type   = DynamicBuffer;
-  using timer_type    = boost::asio::steady_timer;
-  using executor_type = typename stream_type::executor_type;
+    using stream_type = ::launchdarkly::foxy::basic_multi_stream<Stream>;
+    using buffer_type = DynamicBuffer;
+    using timer_type = boost::asio::steady_timer;
+    using executor_type = typename stream_type::executor_type;
 
-  session_opts opts;
-  stream_type  stream;
-  buffer_type  buffer;
-  timer_type   timer;
+    session_opts opts;
+    stream_type stream;
+    buffer_type buffer;
+    timer_type timer;
 
-  basic_session()                     = delete;
-  basic_session(basic_session const&) = delete;
-  basic_session(basic_session&&)      = default;
+    basic_session() = delete;
+    basic_session(basic_session const&) = delete;
+    basic_session(basic_session&&) = default;
 
-  template <class... BufferArgs>
-  basic_session(boost::asio::any_io_executor executor, session_opts opts_, BufferArgs&&... bargs);
+    template <class... BufferArgs>
+    basic_session(boost::asio::any_io_executor executor,
+                  session_opts opts_,
+                  BufferArgs&&... bargs);
 
-  template <class... BufferArgs>
-  basic_session(boost::asio::io_context& io, session_opts opts_, BufferArgs&&... bargs);
+    template <class... BufferArgs>
+    basic_session(boost::asio::io_context& io,
+                  session_opts opts_,
+                  BufferArgs&&... bargs);
 
-  template <class... BufferArgs>
-  basic_session(stream_type stream_, session_opts opts_, BufferArgs&&... bargs);
+    template <class... BufferArgs>
+    basic_session(stream_type stream_,
+                  session_opts opts_,
+                  BufferArgs&&... bargs);
 
-  auto
-  get_executor() -> executor_type;
+    auto get_executor() -> executor_type;
 
-  template <class Parser, class ReadHandler>
-  auto
-  async_read_header(Parser& parser, ReadHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                       void(boost::system::error_code, std::size_t)>::return_type;
+    template <class Parser, class ReadHandler>
+    auto async_read_header(Parser& parser, ReadHandler&& handler) & ->
+        typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                           void(boost::system::error_code,
+                                                std::size_t)>::return_type;
 
-  template <class Parser, class ReadHandler>
-  auto
-  async_read(Parser& parser, ReadHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                       void(boost::system::error_code, std::size_t)>::return_type;
+    template <class Parser, class ReadHandler>
+    auto async_read(Parser& parser, ReadHandler&& handler) & ->
+        typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                           void(boost::system::error_code,
+                                                std::size_t)>::return_type;
 
-  template <class Serializer, class WriteHandler>
-  auto
-  async_write_header(Serializer& serializer, WriteHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<WriteHandler>,
-                                       void(boost::system::error_code, std::size_t)>::return_type;
+    template <class Parser, class ReadHandler>
+    auto async_read_some(Parser& parser, ReadHandler&& handler) & ->
+        typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                           void(boost::system::error_code,
+                                                std::size_t)>::return_type;
 
-  template <class Serializer, class WriteHandler>
-  auto
-  async_write(Serializer& serializer, WriteHandler&& handler) & ->
-    typename boost::asio::async_result<std::decay_t<WriteHandler>,
-                                       void(boost::system::error_code, std::size_t)>::return_type;
+    template <class Serializer, class WriteHandler>
+    auto async_write_header(Serializer& serializer, WriteHandler&& handler) & ->
+        typename boost::asio::async_result<std::decay_t<WriteHandler>,
+                                           void(boost::system::error_code,
+                                                std::size_t)>::return_type;
+
+    template <class Serializer, class WriteHandler>
+    auto async_write(Serializer& serializer, WriteHandler&& handler) & ->
+        typename boost::asio::async_result<std::decay_t<WriteHandler>,
+                                           void(boost::system::error_code,
+                                                std::size_t)>::return_type;
 };
 
-using session = basic_session<boost::asio::ip::tcp::socket, boost::beast::flat_buffer>;
+using session =
+    basic_session<boost::asio::ip::tcp::socket, boost::beast::flat_buffer>;
 
-} // namespace launchdarkly::foxy
+}  // namespace launchdarkly::foxy
 
 #include <foxy/impl/session.impl.hpp>
 
-#endif // FOXY_SESSION_HPP_
+#endif  // FOXY_SESSION_HPP_

--- a/vendor/foxy/include/foxy/session.hpp
+++ b/vendor/foxy/include/foxy/session.hpp
@@ -1,9 +1,8 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
-// com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
@@ -11,8 +10,8 @@
 #ifndef FOXY_SESSION_HPP_
 #define FOXY_SESSION_HPP_
 
-#include <foxy/multi_stream.hpp>
 #include <foxy/session_opts.hpp>
+#include <foxy/multi_stream.hpp>
 #include <foxy/type_traits.hpp>
 
 #include <boost/asio/async_result.hpp>
@@ -23,90 +22,84 @@
 #include <boost/mp11/bind.hpp>
 
 #include <boost/beast/core/async_base.hpp>
-#include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
 
-namespace launchdarkly::foxy {
+namespace launchdarkly::foxy
+{
 template <class Stream, class DynamicBuffer>
-struct basic_session {
-   public:
-    static_assert(boost::beast::is_async_stream<Stream>::value,
-                  "Requirements on the Stream type were not met. Stream must "
-                  "be a Beast.AsyncStream");
+struct basic_session
+{
+public:
+  static_assert(boost::beast::is_async_stream<Stream>::value,
+                "Requirements on the Stream type were not met. Stream must be a Beast.AsyncStream");
 
-    static_assert(boost::asio::is_dynamic_buffer<DynamicBuffer>::value,
-                  "Requirements on the DynamicBuffer type were not met. "
-                  "DynamicBuffer must be an "
-                  "Asio.DynamicBuffer");
+  static_assert(boost::asio::is_dynamic_buffer<DynamicBuffer>::value,
+                "Requirements on the DynamicBuffer type were not met. DynamicBuffer must be an "
+                "Asio.DynamicBuffer");
 
-    using stream_type = ::launchdarkly::foxy::basic_multi_stream<Stream>;
-    using buffer_type = DynamicBuffer;
-    using timer_type = boost::asio::steady_timer;
-    using executor_type = typename stream_type::executor_type;
+  using stream_type   = ::launchdarkly::foxy::basic_multi_stream<Stream>;
+  using buffer_type   = DynamicBuffer;
+  using timer_type    = boost::asio::steady_timer;
+  using executor_type = typename stream_type::executor_type;
 
-    session_opts opts;
-    stream_type stream;
-    buffer_type buffer;
-    timer_type timer;
+  session_opts opts;
+  stream_type  stream;
+  buffer_type  buffer;
+  timer_type   timer;
 
-    basic_session() = delete;
-    basic_session(basic_session const&) = delete;
-    basic_session(basic_session&&) = default;
+  basic_session()                     = delete;
+  basic_session(basic_session const&) = delete;
+  basic_session(basic_session&&)      = default;
 
-    template <class... BufferArgs>
-    basic_session(boost::asio::any_io_executor executor,
-                  session_opts opts_,
-                  BufferArgs&&... bargs);
+  template <class... BufferArgs>
+  basic_session(boost::asio::any_io_executor executor, session_opts opts_, BufferArgs&&... bargs);
 
-    template <class... BufferArgs>
-    basic_session(boost::asio::io_context& io,
-                  session_opts opts_,
-                  BufferArgs&&... bargs);
+  template <class... BufferArgs>
+  basic_session(boost::asio::io_context& io, session_opts opts_, BufferArgs&&... bargs);
 
-    template <class... BufferArgs>
-    basic_session(stream_type stream_,
-                  session_opts opts_,
-                  BufferArgs&&... bargs);
+  template <class... BufferArgs>
+  basic_session(stream_type stream_, session_opts opts_, BufferArgs&&... bargs);
 
-    auto get_executor() -> executor_type;
+  auto
+  get_executor() -> executor_type;
 
-    template <class Parser, class ReadHandler>
-    auto async_read_header(Parser& parser, ReadHandler&& handler) & ->
-        typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                           void(boost::system::error_code,
-                                                std::size_t)>::return_type;
+  template <class Parser, class ReadHandler>
+  auto
+  async_read_header(Parser& parser, ReadHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                       void(boost::system::error_code, std::size_t)>::return_type;
 
-    template <class Parser, class ReadHandler>
-    auto async_read(Parser& parser, ReadHandler&& handler) & ->
-        typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                           void(boost::system::error_code,
-                                                std::size_t)>::return_type;
+  template <class Parser, class ReadHandler>
+  auto
+  async_read(Parser& parser, ReadHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                       void(boost::system::error_code, std::size_t)>::return_type;
+  
+  template <class Parser, class ReadHandler>
+  auto
+  async_read_some(Parser& parser, ReadHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<ReadHandler>,
+                                       void(boost::system::error_code, std::size_t)>::return_type;
 
-    template <class Parser, class ReadHandler>
-    auto async_read_some(Parser& parser, ReadHandler&& handler) & ->
-        typename boost::asio::async_result<std::decay_t<ReadHandler>,
-                                           void(boost::system::error_code,
-                                                std::size_t)>::return_type;
+  template <class Serializer, class WriteHandler>
+  auto
+  async_write_header(Serializer& serializer, WriteHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<WriteHandler>,
+                                       void(boost::system::error_code, std::size_t)>::return_type;
 
-    template <class Serializer, class WriteHandler>
-    auto async_write_header(Serializer& serializer, WriteHandler&& handler) & ->
-        typename boost::asio::async_result<std::decay_t<WriteHandler>,
-                                           void(boost::system::error_code,
-                                                std::size_t)>::return_type;
-
-    template <class Serializer, class WriteHandler>
-    auto async_write(Serializer& serializer, WriteHandler&& handler) & ->
-        typename boost::asio::async_result<std::decay_t<WriteHandler>,
-                                           void(boost::system::error_code,
-                                                std::size_t)>::return_type;
+  template <class Serializer, class WriteHandler>
+  auto
+  async_write(Serializer& serializer, WriteHandler&& handler) & ->
+    typename boost::asio::async_result<std::decay_t<WriteHandler>,
+                                       void(boost::system::error_code, std::size_t)>::return_type;
 };
 
-using session =
-    basic_session<boost::asio::ip::tcp::socket, boost::beast::flat_buffer>;
+using session = basic_session<boost::asio::ip::tcp::socket, boost::beast::flat_buffer>;
 
-}  // namespace launchdarkly::foxy
+} // namespace launchdarkly::foxy
 
 #include <foxy/impl/session.impl.hpp>
 
-#endif  // FOXY_SESSION_HPP_
+#endif // FOXY_SESSION_HPP_


### PR DESCRIPTION
This fixes [streaming connection dropping after 5 minutes](https://github.com/launchdarkly/cpp-sdks/issues/243). 

The problem was applying a 5 minute timeout to an `async_read` _operation_, when the actual intent was to apply it to the act of receiving _any data_. 

The timeout exists to prevent the client from hanging infinitely if the server stops responding. LaunchDarkly sends heartbeats to clear the timer.

With `async_read`, the operation won't complete until the response body is finished. Since the body will never finish until the client shuts down (or server interrupts it), it's not possible to institute a timeout. 

The solution is to use `async_read_some`, which completes whenever data arrives.

This way, we can assign the 5 minute timeout as an upper bound on receiving any data, as was originally intended. 

-----

A side effect of this change was breaking the `reconnection` SSE contract tests, which proved to be somewhat of a rabbithole. 

The upshot is that we weren't handling chunked encoding properly when chunked encoding _ends_. The original code assumes we either terminate an async read with an error, or it goes on forever. 

In fact it should perform the backoff algorithm if we detect the end of chunked encoding.

-----

I've also included more comments, more debug logging, and renamed some symbols for clarity. This should aid in debugging issues like this more efficiently. 


- [ ] Long running connection test (4 hours no drops)
