### PR TITLE
docs: update bug report instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/client-sdk--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/client-sdk--bug-report.md
@@ -22,13 +22,17 @@ assignees: ''
   A clear and concise description of what you expected to happen.
   
   **Logs**
-  If applicable, add any log output related to your problem.
+  If applicable, add any log output related to your problem. 
+  To get more logs from the SDK, change the log level using environment variable `LD_LOG_LEVEL`. For example:
+  ```
+   LD_LOG_LEVEL=debug ./your-application
+  ```
   
   **SDK version**
   The version of this SDK that you are using.
   
   **Language version, developer tools**
-  For instance, Go 1.11 or Ruby 2.5.3. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler too.
+  For instance, C++17 or C11. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler  too.
   
   **OS/platform**
   For instance, Ubuntu 16.04, Windows 10, or Android 4.0.3. If your code is running in a browser, please also include the browser type and version.


### PR DESCRIPTION
Now that `LD_LOG_LEVEL` environment variable works as expected, we should call this out in the bug report template. This will aid in gathering more useful debug logs or lead to resolution without further analysis. 

Example:

```
LD_LOG_LEVEL=debug ./application-that-uses-sdk
```