### PR TITLE
docs: specify OpenSSL v1.1 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 1. CMake 3.19 or higher
 1. Ninja (if using the included build scripts)
 1. Boost version 1.81 or higher
-1. OpenSSL
+1. OpenSSL 1.1
 
 Additional dependencies are fetched via CMake. For details see the `cmake` folder.
 


### PR DESCRIPTION
To research:
```
Undefined symbols for architecture arm64:
  "_EVP_PKEY_is_a", referenced from:
      boost::asio::ssl::context::use_rsa_private_key(boost::asio::const_buffer const&, boost::asio::ssl::context_base::file_format, boost::system::error_code&) in liblaunchdarkly-cpp-client.a(asio.cpp.o)
      boost::asio::ssl::context::use_rsa_private_key_file(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, boost::asio::ssl::context_base::file_format, boost::system::error_code&) in liblaunchdarkly-cpp-client.a(asio.cpp.o)
  "_SSL_CTX_set0_tmp_dh_pkey", referenced from:
      boost::asio::ssl::context::do_use_tmp_dh(bio_st*, boost::system::error_code&) in liblaunchdarkly-cpp-client.a(asio.cpp.o)
```
It appears `ssl::context` might depend on deprecated symbols that were removed in OpenSSL 3. 