### PR TITLE
fix: build with OpenSSL > 3.0 on all platforms

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -92,11 +92,17 @@ runs:
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
 
+    - name: Upgrade OpenSSL
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        choco upgrade openssl --no-progress
+
     - name: Build Windows Artifacts
       if: runner.os == 'Windows'
       shell: bash
       env:
-        OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL'
+        OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL-Win64'
         BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -155,9 +155,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew link --overwrite openssl@1.1
-        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> "$GITHUB_ENV"
-        export OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)
+        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
+        export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
         
         ./scripts/build-release.sh ${{ inputs.sdk_cmake_target }}
       env:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: macos-12
     steps:
       - run: |
-          brew link --overwrite openssl@1.1
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> "$GITHUB_ENV"
+          brew link --overwrite openssl@3
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
           # For debugging
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)"
+          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
       - uses: actions/checkout@v3
       - uses: ./.github/actions/ci
         env:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco upgrade openssl --no-progress
+          choco list openssl
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -41,7 +41,6 @@ jobs:
     runs-on: macos-12
     steps:
       - run: |
-          brew link --overwrite openssl@3
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
           # For debugging
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
@@ -55,6 +54,10 @@ jobs:
   build-test-windows:
     runs-on: windows-2022
     steps:
+      - name: Upgrade OpenSSL
+        shell: bash
+        run: |
+          choco upgrade openssl
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco list openssl
+          choco upgrade openssl --no-progress
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco upgrade openssl
+          choco upgrade openssl --no-progress
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci
         env:
-          OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL'
+          OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL-Win64'
           BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
           BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ if (BUILD_TESTING)
 endif ()
 
 set(OPENSSL_USE_STATIC_LIBS ON)
-set(OPENSSL_ROOT_DIR "/opt/homebrew/opt/openssl@1.1")
 find_package(OpenSSL REQUIRED)
 message(STATUS "LaunchDarkly: using OpenSSL v${OPENSSL_VERSION}")
 


### PR DESCRIPTION
We were previously using openssl 1.1 on some platforms due to issues with the Github Actions executors.

These issues are no longer present, so we can use openssl > 3 instead. 

- [x] Linux: 3.0.2 
- [x] Mac: 3.1.2
- [x] Windows: 3.1.1

_(created story for removing the choco upgrade in Windows once Github releases a new runner)_