### PR TITLE
chore: detect where OpenSSL is installed on Windows runner

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -103,10 +103,8 @@ runs:
       run: |
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
-          echo "OpenSSL was installed to Program Files\OpenSSL-Win64"
         else
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
-          echo "OpenSSL was installed to Program Files\OpenSSL"
         fi
     - name: Build Windows Artifacts
       if: runner.os == 'Windows'

--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -97,12 +97,20 @@ runs:
       shell: bash
       run: |
         choco upgrade openssl --no-progress
-
+    - name: Determine OpenSSL Installation Directory
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
+        else
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
+        fi
     - name: Build Windows Artifacts
       if: runner.os == 'Windows'
       shell: bash
       env:
-        OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL-Win64'
+        OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
         BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -103,8 +103,10 @@ runs:
       run: |
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
+          echo "OpenSSL was installed to Program Files\OpenSSL-Win64"
         else
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
+          echo "OpenSSL was installed to Program Files\OpenSSL"
         fi
     - name: Build Windows Artifacts
       if: runner.os == 'Windows'

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco upgrade openssl --no-progress
+          choco install openssl --no-progress --install-directory='C:\Program Files\OpenSSL'
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci
         env:
-          OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL-Win64'
+          OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL'
           BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
           BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco install openssl --no-progress
+          choco upgrade openssl --no-progress
       - name: Determine OpenSSL Installation Directory
         shell: bash
         run: |

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -57,12 +57,20 @@ jobs:
       - name: Upgrade OpenSSL
         shell: bash
         run: |
-          choco install openssl --no-progress --install-directory='C:\Program Files\OpenSSL'
+          choco install openssl --no-progress
+      - name: Determine OpenSSL Installation Directory
+        shell: bash
+        run: |
+          if [-d "C:\Program Files\OpenSSL-Win64"]; then
+            echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
+          else
+            echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
+          fi
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci
         env:
-          OPENSSL_ROOT_DIR: 'C:\Program Files\OpenSSL'
+          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
           BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
           BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Determine OpenSSL Installation Directory
         shell: bash
         run: |
-          if [-d "C:\Program Files\OpenSSL-Win64"]; then
+          if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
             echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
           else
             echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -1,5 +1,6 @@
 # Checks out the tag, builds release builds, and attaches them to the release for the tag.
 # If you need to change build scripts, then update the tag to include the modifications.
+# NOTE: This workflow uses sdk-release/action.yml @ the tag specified in the workflow_dispatch input.
 on:
   workflow_dispatch:
     inputs:
@@ -55,18 +56,18 @@ jobs:
           sdk_path: ${{ needs.split-input.outputs.sdk_path}}
           sdk_cmake_target: ${{ needs.split-input.outputs.sdk_cmake_target}}
   release-sdk-provenance:
-    needs: ['release-sdk']
+    needs: [ 'release-sdk' ]
     strategy:
       matrix:
         # Generates a combined attestation for each platform
         os: [ linux, windows, macos ]
-    permissions: 
+    permissions:
       actions: read
       id-token: write
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
     with:
       base64-subjects: "${{ needs.release-sdk.outputs[format('hashes-{0}', matrix.os)] }}"
-      upload-assets: true 
+      upload-assets: true
       upload-tag-name: ${{ inputs.tag }}
       provenance-name: ${{ format('{0}-multiple-provenance.intoto.jsonl', matrix.os) }}


### PR DESCRIPTION
We have intermittent CI failures because OpenSSL is installed to either `Program Files\OpenSSL-Win64` or `Program Files\OpenSSL`. I'm not entirely sure why, but it seems to be luck of the draw on the runner.

This should detect where it was installed and pass it to CMake. 

We can't force the install location because that requires a licensed chocolatey. Chocolatey also writes out the install location - for this particular package - but we'd have to process its output. Instead, this just tests the two known installation directories.

- [x] Tested with manual release