### PR TITLE
fix: LD_BUILD_SHARED_LIBS build flag usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ message(STATUS "LaunchDarkly: using OpenSSL v${OPENSSL_VERSION}")
 # linked into the binary.
 set(Boost_USE_STATIC_LIBS ON)
 
-if (NOT LD_BUILD_STATIC_LIBS)
+if (LD_BUILD_SHARED_LIBS)
     # When building a shared library we hide all symbols
     # aside from this we have specifically exported for the C-API.
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -129,7 +129,7 @@ add_subdirectory(libs/common)
 add_subdirectory(libs/internal)
 add_subdirectory(libs/server-sent-events)
 
-# Built as static or shared depending on LD_BUILD_STATIC_LIBS variable.
+# Built as static or shared depending on LD_BUILD_SHARED_LIBS variable.
 # This target "links" in common, internal, and sse as object libraries.
 add_subdirectory(libs/client-sdk)
 

--- a/cmake/certify.cmake
+++ b/cmake/certify.cmake
@@ -10,16 +10,14 @@ endif ()
 FetchContent_Declare(boost_certify
         GIT_REPOSITORY https://github.com/djarek/certify.git
         GIT_TAG 97f5eebfd99a5d6e99d07e4820240994e4e59787
-        )
+)
 
 set(BUILD_TESTING OFF)
 
 FetchContent_GetProperties(boost_certify)
-if(NOT boost_certify_POPULATED)
+if (NOT boost_certify_POPULATED)
     FetchContent_Populate(boost_certify)
     add_subdirectory(${boost_certify_SOURCE_DIR} ${boost_certify_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+endif ()
 
 set(BUILD_TESTING "${ORIGINAL_BUILD_TESTING}")
-
-set(BUILD_SHARED_LIBS "${ORIGINAL_BUILD_SHARED_LIBS}")

--- a/libs/client-sdk/src/CMakeLists.txt
+++ b/libs/client-sdk/src/CMakeLists.txt
@@ -76,7 +76,7 @@ set_property(TARGET ${LIBNAME} PROPERTY
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 install(TARGETS ${LIBNAME})
-if (BUILD_SHARED_LIBS AND MSVC)
+if (LD_BUILD_SHARED_LIBS AND MSVC)
     install(FILES $<TARGET_PDB_FILE:${LIBNAME}> DESTINATION bin OPTIONAL)
 endif ()
 # Using PUBLIC_HEADERS would flatten the include.

--- a/libs/client-sdk/src/CMakeLists.txt
+++ b/libs/client-sdk/src/CMakeLists.txt
@@ -53,7 +53,7 @@ target_sources(${LIBNAME} PRIVATE
 )
 
 
-if (MSVC OR LD_BUILD_STATIC_LIBS)
+if (MSVC OR (NOT LD_BUILD_SHARED_LIBS))
     target_link_libraries(${LIBNAME}
             PUBLIC launchdarkly::common
             PRIVATE Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy)


### PR DESCRIPTION
In my previous PR cleaning up cmake variables, during development I renamed the `BUILD_SHARED_LIBS` flag to `BUILD_STATIC_LIBS`, but then reconsidered and stuck with the original naming.

Unfortunately I didn't un-rename some usages of it - so we ended up having some instances of `LD_BUILD_STATIC_LIBS` in our `CMakeLists.txt`.

It appears this didn't have an obvious impact on our build/release process because:
1) Since `NOT LD_BUILD_STATIC_LIBS` would always be true (variable not defined), then it would have been setting `-fvisibility=hidden` on both shared and static builds. I'm pretty sure that flag has no affect when building static libs so it was a no-op in that situation.
2) Using the `target_sources` trick for pulling in the boost libraries always works whether we're building static libs or dynamic libs, so another no-op. 

It'd be nice to test this going forward. Some ideas:
- Generate a report on the artifact sizes, like the C Server SDK 
- Generate a report corresponding to something like `nm -gU artifact.dylib | wc -l` to get the number of symbols (e.g. 8k when visibility=hidden, 26k without)
- Force the SDK to be compiled as a shared lib with unit testing enabled, and assert that the compilation fails due to missing symbols 


Manual workflow run:
- [x] https://github.com/launchdarkly/cpp-sdks/actions/runs/6565100278
