### PR TITLE
fix: enforce validated ContextKind usage in Segment data model

### DIFF
--- a/libs/internal/include/launchdarkly/data_model/segment.hpp
+++ b/libs/internal/include/launchdarkly/data_model/segment.hpp
@@ -2,6 +2,7 @@
 
 #include <launchdarkly/attribute_reference.hpp>
 #include <launchdarkly/data_model/context_aware_reference.hpp>
+#include <launchdarkly/data_model/context_kind.hpp>
 #include <launchdarkly/data_model/rule_clause.hpp>
 #include <launchdarkly/value.hpp>
 
@@ -16,9 +17,8 @@
 namespace launchdarkly::data_model {
 
 struct Segment {
-    using Kind = std::string;
     struct Target {
-        Kind contextKind;
+        ContextKind contextKind;
         std::vector<std::string> values;
     };
 
@@ -43,11 +43,8 @@ struct Segment {
     std::vector<Rule> rules;
     std::optional<std::string> salt;
     bool unbounded;
-    std::optional<Kind> unboundedContextKind;
+    std::optional<ContextKind> unboundedContextKind;
     std::optional<std::uint64_t> generation;
-
-    // TODO(sc209882): in data model, ensure empty Kind string is error
-    // condition.
 
     /**
      * Returns the segment's version. Satisfies ItemDescriptor template

--- a/libs/internal/include/launchdarkly/serialization/json_context_kind.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_context_kind.hpp
@@ -16,4 +16,13 @@ tl::expected<std::optional<data_model::ContextKind>, JsonError> tag_invoke(
         unused,
     boost::json::value const& json_value);
 
+// Serializers need to be in launchdarkly::data_model for ADL.
+namespace data_model {
+
+void tag_invoke(boost::json::value_from_tag const& unused,
+                boost::json::value& json_value,
+                data_model::ContextKind const& segment);
+
+}
+
 }  // namespace launchdarkly

--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -162,7 +162,7 @@ void WriteMinimal(boost::json::object& obj,
                   std::string const& key,  // No copy when not used.
                   std::optional<T> val) {
     if (val.has_value()) {
-        obj.emplace(key, val.value());
+        obj.emplace(key, boost::json::value_from(val.value()));
     }
 }
 

--- a/libs/internal/src/serialization/json_context_kind.cpp
+++ b/libs/internal/src/serialization/json_context_kind.cpp
@@ -21,4 +21,13 @@ tl::expected<std::optional<data_model::ContextKind>, JsonError> tag_invoke(
 
     return data_model::ContextKind(str.c_str());
 }
+
+namespace data_model {
+void tag_invoke(boost::json::value_from_tag const& unused,
+                boost::json::value& json_value,
+                data_model::ContextKind const& context_kind) {
+    boost::ignore_unused(unused);
+    json_value.emplace_string() = context_kind.t;
+}
+}  // namespace data_model
 }  // namespace launchdarkly

--- a/libs/internal/src/serialization/json_segment.cpp
+++ b/libs/internal/src/serialization/json_segment.cpp
@@ -20,7 +20,10 @@ tl::expected<std::optional<data_model::Segment::Target>, JsonError> tag_invoke(
 
     data_model::Segment::Target target{};
 
-    PARSE_FIELD_DEFAULT(target.contextKind, obj, "contextKind", "user");
+    // The zero value of a ContextKind ("" - empty string) is not valid in the
+    // domain of possible contexts. This field is parsed as REQUIRED to
+    // specify that fact.
+    PARSE_REQUIRED_FIELD(target.contextKind, obj, "contextKind");
 
     PARSE_FIELD(target.values, obj, "values");
 
@@ -125,7 +128,7 @@ void tag_invoke(boost::json::value_from_tag const& unused,
                 data_model::Segment::Target const& target) {
     auto& obj = json_value.emplace_object();
     obj.emplace("values", boost::json::value_from(target.values));
-    obj.emplace("contextKind", target.contextKind);
+    obj.emplace("contextKind", boost::json::value_from(target.contextKind));
 }
 
 void tag_invoke(boost::json::value_from_tag const& unused,

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -637,7 +637,7 @@ TEST(FlagTests, SerializeAll) {
 }
 
 TEST(SegmentTargetTests, SerializeAll) {
-    data_model::Segment::Target target{"bob", {"bill", "sam"}};
+    data_model::Segment::Target target{ContextKind("bob"), {"bill", "sam"}};
 
     auto json = boost::json::value_from(target);
     auto expected = boost::json::parse(
@@ -683,8 +683,8 @@ TEST(SegmentTests, SerializeBasicAll) {
         87,
         {"bob", "sam"},
         {"sally", "johan"},
-        {{"vegetable", {"potato", "yam"}}},
-        {{"material", {"cardboard", "plastic"}}},
+        {{ContextKind("vegetable"), {"potato", "yam"}}},
+        {{ContextKind("material"), {"cardboard", "plastic"}}},
         {{{{data_model::Clause::Op::kIn,
             {"a", "b"},
             true,
@@ -730,8 +730,9 @@ TEST(SegmentTests, SerializeBasicAll) {
 }
 
 TEST(SegmentTests, SerializeUnbounded) {
-    data_model::Segment segment{"my-segment", 87,      {},   {},        {}, {},
-                                {},           "salty", true, "company", 12};
+    data_model::Segment segment{
+        "my-segment",           87, {}, {}, {}, {}, {}, "salty", true,
+        ContextKind("company"), 12};
 
     auto json = boost::json::value_from(segment);
     auto expected = boost::json::parse(


### PR DESCRIPTION
Resolves an outstanding TODO in `server-side` by enforcing segments to deserialize with valid context kinds.