### PR TITLE
chore: add data source status backwards-compat unit test

### DIFF
--- a/libs/client-sdk/tests/client_test.cpp
+++ b/libs/client-sdk/tests/client_test.cpp
@@ -30,7 +30,7 @@ TEST(ClientTest, BoolVariationDefaultPassesThrough) {
     Client client(ConfigBuilder("sdk-123").Build().value(),
                   ContextBuilder().Kind("cat", "shadow").Build());
 
-    const std::string flag = "extra-cat-food";
+    std::string const flag = "extra-cat-food";
     std::vector<bool> values = {true, false};
     for (auto const& v : values) {
         ASSERT_EQ(client.BoolVariation(flag, v), v);
@@ -41,7 +41,7 @@ TEST(ClientTest, BoolVariationDefaultPassesThrough) {
 TEST(ClientTest, StringVariationDefaultPassesThrough) {
     Client client(ConfigBuilder("sdk-123").Build().value(),
                   ContextBuilder().Kind("cat", "shadow").Build());
-    const std::string flag = "treat";
+    std::string const flag = "treat";
     std::vector<std::string> values = {"chicken", "fish", "cat-grass"};
     for (auto const& v : values) {
         ASSERT_EQ(client.StringVariation(flag, v), v);
@@ -52,7 +52,7 @@ TEST(ClientTest, StringVariationDefaultPassesThrough) {
 TEST(ClientTest, IntVariationDefaultPassesThrough) {
     Client client(ConfigBuilder("sdk-123").Build().value(),
                   ContextBuilder().Kind("cat", "shadow").Build());
-    const std::string flag = "weight";
+    std::string const flag = "weight";
     std::vector<int> values = {0, 12, 13, 24, 1000};
     for (auto const& v : values) {
         ASSERT_EQ(client.IntVariation("weight", v), v);
@@ -63,7 +63,7 @@ TEST(ClientTest, IntVariationDefaultPassesThrough) {
 TEST(ClientTest, DoubleVariationDefaultPassesThrough) {
     Client client(ConfigBuilder("sdk-123").Build().value(),
                   ContextBuilder().Kind("cat", "shadow").Build());
-    const std::string flag = "weight";
+    std::string const flag = "weight";
     std::vector<double> values = {0.0, 12.0, 13.0, 24.0, 1000.0};
     for (auto const& v : values) {
         ASSERT_EQ(client.DoubleVariation(flag, v), v);
@@ -75,7 +75,7 @@ TEST(ClientTest, JsonVariationDefaultPassesThrough) {
     Client client(ConfigBuilder("sdk-123").Build().value(),
                   ContextBuilder().Kind("cat", "shadow").Build());
 
-    const std::string flag = "assorted-values";
+    std::string const flag = "assorted-values";
     std::vector<Value> values = {
         Value({"running", "jumping"}), Value(3), Value(1.0), Value(true),
         Value(std::map<std::string, Value>{{"weight", 20}})};
@@ -83,4 +83,30 @@ TEST(ClientTest, JsonVariationDefaultPassesThrough) {
         ASSERT_EQ(client.JsonVariation(flag, v), v);
         ASSERT_EQ(*client.JsonVariationDetail(flag, v), v);
     }
+}
+
+// This test mainly serves to catch any changes made to the types in the Data
+// Source Status API that are not backwards-compatible.
+TEST(ClientTest, DataSourceStatus) {
+    Client client(ConfigBuilder("sdk-123").Build().value(),
+                  ContextBuilder().Kind("cat", "shadow").Build());
+
+    client_side::data_sources::DataSourceStatus ds_status =
+        client.DataSourceStatus().Status();
+
+    std::optional<client_side::data_sources::DataSourceStatus::ErrorInfo>
+        last_err = ds_status.LastError();
+
+    ASSERT_FALSE(last_err);
+
+    client_side::data_sources::DataSourceStatus::DataSourceState state =
+        ds_status.State();
+
+    ASSERT_EQ(state, client_side::data_sources::DataSourceStatus::
+                         DataSourceState::kInitializing);
+
+    client_side::data_sources::DataSourceStatus::DateTime date =
+        ds_status.StateSince();
+
+    ASSERT_NE(date, client_side::data_sources::DataSourceStatus::DateTime{});
 }


### PR DESCRIPTION
Adds a unit test that should catch if we make a breaking change to the types accessible via `client.DataSourceStatus()`.

This is useful because the upcoming server-side SDK refactors the Data Source Status types into the common library, and we must therefore provide aliases in the client SDK.