### PR TITLE
chore: add server-side SDK to release-please config

### DIFF
--- a/.github/workflows/manual-publish-doc.yml
+++ b/.github/workflows/manual-publish-doc.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - libs/client-sdk
+          - libs/server-sdk
 name: Publish Documentation
 jobs:
   build-publish:

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - libs/client-sdk:launchdarkly-cpp-client
+          - libs/server-sdk:launchdarkly-cpp-server
 
 name: Publish SDK Artifacts
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "libs/client-sdk": "3.1.1",
+  "libs/server-sdk": "0.1.0",
   "libs/server-sent-events": "0.2.0",
-  "libs/common": "0.4.0",
-  "libs/internal": "0.2.0"
+  "libs/common": "0.5.0",
+  "libs/internal": "0.3.0"
 }

--- a/libs/server-sdk/CMakeLists.txt
+++ b/libs/server-sdk/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.19)
 
 project(
         LaunchDarklyCPPServer
-        VERSION 0.1
+        VERSION 0.1.0 # {x-release-please-version}
         DESCRIPTION "LaunchDarkly C++ Server SDK"
         LANGUAGES CXX C
 )

--- a/libs/server-sdk/package.json
+++ b/libs/server-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-internal": "0.1.6",
-    "launchdarkly-cpp-common": "0.3.3"
+    "launchdarkly-cpp-internal": "0.2.0",
+    "launchdarkly-cpp-common": "0.4.0"
   }
 }

--- a/libs/server-sdk/package.json
+++ b/libs/server-sdk/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-internal": "0.2.0",
-    "launchdarkly-cpp-common": "0.4.0"
+    "launchdarkly-cpp-internal": "0.3.0",
+    "launchdarkly-cpp-common": "0.5.0"
   }
 }

--- a/libs/server-sdk/package.json
+++ b/libs/server-sdk/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "launchdarkly-cpp-server",
+  "description": "This package.json exists for modeling dependencies for the release process.",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "launchdarkly-cpp-internal": "0.1.6",
+    "launchdarkly-cpp-common": "0.3.3"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,13 @@
         "CMakeLists.txt"
       ]
     },
+    "libs/server-sdk": {
+      "extra-files": [
+        "include/launchdarkly/server_side/client.hpp",
+        "tests/client_test.cpp",
+        "CMakeLists.txt"
+      ]
+    },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"
     },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,9 +14,11 @@
     "libs/server-sdk": {
       "extra-files": [
         "include/launchdarkly/server_side/client.hpp",
+        "tests/server_c_bindings_test.cpp",
         "tests/client_test.cpp",
         "CMakeLists.txt"
-      ]
+      ],
+      "prerelease": true
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,7 +18,8 @@
         "tests/client_test.cpp",
         "CMakeLists.txt"
       ],
-      "prerelease": true
+      "prerelease": true,
+      "bump-minor-pre-major": true
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
Adds the server-side SDK into release please @ `0.1.0`. I've marked `prerelease: true`, so it should be marked as such when we do a Github release.