### PR TITLE
fix: allow for installing only the client or server SDK independently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ option(LD_DYNAMIC_LINK_OPENSSL
 
 option(LD_BUILD_EXAMPLES "Build hello-world examples." ON)
 
+# If using 'make' as the build system, CMake causes the 'install' target to have a dependency on 'all', meaning
+# it will cause a full build. This disables that, allowing us to build piecemeal instead. This is useful
+# so that we only need to build the client or server for a given release (if only the client or server were affected.)
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
+
 # All projects in this repo should share the same version of 3rd party depends.
 # It's the only way to remain sane.
 set(CMAKE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/libs/client-sdk/src/CMakeLists.txt
+++ b/libs/client-sdk/src/CMakeLists.txt
@@ -63,7 +63,8 @@ add_library(launchdarkly::client ALIAS ${LIBNAME})
 set_property(TARGET ${LIBNAME} PROPERTY
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
-install(TARGETS ${LIBNAME})
+# Optional in case only the server SDK is being built.
+install(TARGETS ${LIBNAME} OPTIONAL)
 if (LD_BUILD_SHARED_LIBS AND MSVC)
     install(FILES $<TARGET_PDB_FILE:${LIBNAME}> DESTINATION bin OPTIONAL)
 endif ()

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -80,7 +80,8 @@ add_library(launchdarkly::server ALIAS ${LIBNAME})
 set_property(TARGET ${LIBNAME} PROPERTY
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
-install(TARGETS ${LIBNAME})
+# Optional in case only the client SDK is being built.
+install(TARGETS ${LIBNAME} OPTIONAL)
 if (LD_BUILD_SHARED_LIBS AND MSVC)
     install(FILES $<TARGET_PDB_FILE:${LIBNAME}> DESTINATION bin OPTIONAL)
 endif ()


### PR DESCRIPTION
Latest client release failed because I failed to consider that the `install` step currently requires all artifacts (both client, and now server) to be built. Since we use `cmake --build . --target "$clientOrServer"`, it failed on the install step because server isn't built.

This commit makes installation optional for either. 

- [x] https://github.com/launchdarkly/cpp-sdks/actions/runs/6617958497