### PR TITLE
chore: remove server-side version from release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,5 @@
 {
   "libs/client-sdk": "3.2.1",
-  "libs/server-sdk": "0.1.0",
   "libs/server-sent-events": "0.2.0",
   "libs/common": "0.5.0",
   "libs/internal": "0.3.0"

--- a/libs/server-sdk/package.json
+++ b/libs/server-sdk/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "launchdarkly-cpp-internal": "0.3.0",
-    "launchdarkly-cpp-common": "0.5.0"
+    "launchdarkly-cpp-common": "0.5.0",
+    "launchdarkly-cpp-sse-client": "0.2.0"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
         "CMakeLists.txt"
       ],
       "prerelease": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.1.0"
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
This is an attempt to fix the pending release. 

Ideally, release please would detect that no release is necessary or that a 0.1.0 initial release of the server side only is necessary.

Right now, it thinks that the `sse-client` needs a release, and it's therefore bumping that and the server/client SDKs.