### PR TITLE
chore: limit commit-search-depth to 10 for server-side package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
       ],
       "prerelease": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.1.0"
+      "release-as": "0.1.0",
+      "commit-search-depth": 10
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
It appears release-please is looking far back in history when determining the release version of the server package. During this search, it also appears to be running into a SSE commit that didn't use conventional commit formatting.

Now, it's unclear if this is connected - but it might be making release-please think that an SSE bump is required.

My theory is that by limiting to 10 commits (not sure how low this could be - 0?) we can eliminate the issue. This should be ok since we know for a fact no conventional commits have happened to SSE client that would affect the server. 

This all feels rather unintuitive though. I'd like to keep digging but this is becoming a time sink.