### PR TITLE
chore: add bootstrap sha for server-side, set to last release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,7 @@
       "prerelease": true,
       "bump-minor-pre-major": true,
       "release-as": "0.1.0",
-      "commit-search-depth": 10
+      "bootstrap-sha": "82d72df338a2a89d6f55e3ebe21b4c987a9cc2c0"
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
Setting to commit `82d72df338a2a89d6f55e3ebe21b4c987a9cc2c0`, which is the previously successful release. This allegedly won't work according to release-please docs (can only be a top-level config).

Maybe it would work there. Can try if this fails.