### PR TITLE
chore: revert commit depth specification on libs/server-sdk

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,7 @@
       ],
       "prerelease": true,
       "bump-minor-pre-major": true,
-      "release-as": "0.1.0",
-      "commit-search-depth": 10
+      "release-as": "0.1.0"
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
This fix was a dead-end.