### PR TITLE
chore: run build-release.sh in client/server CI

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -15,10 +15,16 @@ inputs:
     required: false
     default: 'true'
   platform_version:
+    description: 'Boost platform version'
     required: false
     default: "22.04"
   toolset:
+    description: 'Boost toolset'
     required: false
+  simulate_release:
+    description: 'Whether to run ./build-release.sh for the CMake target'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -50,3 +56,9 @@ runs:
       # This uses the binary, versus "make tests" because the binary
       # has better performance and output.
       run: ./build/gtest_${{ inputs.cmake_target }}
+    - name: Simulate Release
+      if: inputs.simulate_release == 'true'
+      shell: bash
+      run: ./scripts/build-release.sh ${{ inputs.cmake_target }}
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-client
+          simulate_release: true
   build-test-client-mac:
     runs-on: macos-12
     steps:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-server
+          simulate_release: true
   build-test-server-mac:
     runs-on: macos-12
     steps:


### PR DESCRIPTION
Right now our release process isn't tested on every commit - if the release fails due to a build issue, we need to make a new release.

This commit runs `./build-release` in our Linux CI step. It's not building docs nor running on all types executors, but I think this is a good compromise to catch 99% of issues that might occur.