### PR TITLE
chore: run client hello app in CI

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -15,10 +15,16 @@ inputs:
     required: false
     default: 'true'
   platform_version:
+    description: 'Boost platform version'
     required: false
     default: "22.04"
   toolset:
+    description: 'Boost toolset'
     required: false
+  simulate_release:
+    description: 'Whether to run ./build-release.sh for the CMake target'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -50,3 +56,9 @@ runs:
       # This uses the binary, versus "make tests" because the binary
       # has better performance and output.
       run: ./build/gtest_${{ inputs.cmake_target }}
+    - name: Simulate Release
+      if: inputs.simulate_release == 'true'
+      shell: bash
+      run: ./scripts/build-release.sh ${{ inputs.cmake_target }}
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Whether to run ./build-release.sh for the CMake target'
     required: false
     default: 'false'
+  hello_app_cmake_target:
+    description: 'The name of the CMake target for the hello app if applicable, i.e. hello-cpp-client'
+    required: false
+    default: ''
 
 runs:
   using: composite

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -43,6 +43,7 @@ runs:
       run: ./scripts/build.sh ${{ inputs.cmake_target }} ON
       env:
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+
     - name: Build Tests
       id: build-tests
       if: inputs.run_tests == 'true'
@@ -50,12 +51,21 @@ runs:
       run: ./scripts/build.sh gtest_${{ inputs.cmake_target }} ON
       env:
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+
     - name: Run Tests
       if: steps.build-tests.outcome == 'success'
       shell: bash
       # This uses the binary, versus "make tests" because the binary
       # has better performance and output.
       run: ./build/gtest_${{ inputs.cmake_target }}
+
+    - name: Smoke Test
+      if: inputs.hello_app_cmake_target != ''
+      uses: ./github/actions/hello-world
+      with:
+        cmake_target: ${{ inputs.hello_app_cmake_target }}
+        command: "./build/examples/${{ inputs.hello_app_cmake_target }}"
+
     - name: Simulate Release
       if: inputs.simulate_release == 'true'
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -25,8 +25,12 @@ inputs:
     description: 'Whether to run ./build-release.sh for the CMake target'
     required: false
     default: 'false'
-  hello_app_cmake_target:
-    description: 'The name of the CMake target for the hello app if applicable, i.e. hello-cpp-client'
+  hello_app_cmake_target_1:
+    description: 'The CMake target name of a hello app to execute, e.g. hello-cpp-client'
+    required: false
+    default: ''
+  hello_app_cmake_target_2:
+    description: 'A secondary CMake target name of a hello app to execute, e.g. hello-cpp-client'
     required: false
     default: ''
 
@@ -63,12 +67,19 @@ runs:
       # has better performance and output.
       run: ./build/gtest_${{ inputs.cmake_target }}
 
-    - name: Smoke Test
-      if: inputs.hello_app_cmake_target != ''
+    - name: Smoke Test 1
+      if: inputs.hello_app_cmake_target_1 != ''
       uses: ./.github/actions/hello-world
       with:
-        cmake_target: ${{ inputs.hello_app_cmake_target }}
-        binary_dir: "build/examples/${{ inputs.hello_app_cmake_target }}"
+        cmake_target: ${{ inputs.hello_app_cmake_target_1 }}
+        binary_dir: "build/examples/${{ inputs.hello_app_cmake_target_1 }}"
+
+    - name: Smoke Test 2
+      if: inputs.hello_app_cmake_target_2 != ''
+      uses: ./.github/actions/hello-world
+      with:
+        cmake_target: ${{ inputs.hello_app_cmake_target_2 }}
+        binary_dir: "build/examples/${{ inputs.hello_app_cmake_target_2 }}"
 
     - name: Simulate Release
       if: inputs.simulate_release == 'true'

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Smoke Test
       if: inputs.hello_app_cmake_target != ''
-      uses: ./github/actions/hello-world
+      uses: ./.github/actions/hello-world
       with:
         cmake_target: ${{ inputs.hello_app_cmake_target }}
         command: "./build/examples/${{ inputs.hello_app_cmake_target }}"

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -68,7 +68,7 @@ runs:
       uses: ./.github/actions/hello-world
       with:
         cmake_target: ${{ inputs.hello_app_cmake_target }}
-        command: "./build/examples/${{ inputs.hello_app_cmake_target }}"
+        binary_dir: "build/examples/${{ inputs.hello_app_cmake_target }}"
 
     - name: Simulate Release
       if: inputs.simulate_release == 'true'

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -18,6 +18,7 @@ runs:
       run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
     - name: 'Run Hello App'
       shell: bash
-      run: |
-        ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
-        grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1) 
+      run: ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} > output.txt && cat output.txt
+    - name: 'Inspect Output'
+      shell: bash
+      run: grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1)

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -19,6 +19,6 @@ runs:
     - name: 'Run Hello App'
       shell: bash
       run: |
-        set +x
+        set +e
         ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
         grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1)

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -4,8 +4,8 @@ inputs:
   cmake_target:
     description: 'The name of the CMake target. i.e. hello-cpp-client'
     required: true
-  command:
-    description: 'Command that executes the hello binary'
+  binary_dir:
+    description: 'Output directory for the hello world binary'
     required: true
 
 
@@ -14,7 +14,8 @@ runs:
   steps:
     - name: "Build Hello App"
       shell: bash
+      # Should generate a binary in 'inputs.binary_dir'
       run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
     - name: 'Run Hello App'
       shell: bash
-      run: ${{ inputs.command }}
+      run: "./${{ inputs.binary_dir }}/${{ inputs.cmake_target}}"

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -18,7 +18,7 @@ runs:
       run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
     - name: 'Run Hello App'
       shell: bash
-      run: ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} > output.txt && cat output.txt
+      run: ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
     - name: 'Inspect Output'
       shell: bash
       run: grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1)

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -18,7 +18,7 @@ runs:
       run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
     - name: 'Run Hello App'
       shell: bash
-      run: ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
-    - name: 'Inspect Output'
-      shell: bash
-      run: grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1)
+      run: |
+        set +x
+        ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
+        grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1)

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -19,5 +19,5 @@ runs:
     - name: 'Run Hello App'
       shell: bash
       run: |
-        "./${{ inputs.binary_dir }}/${{ inputs.cmake_target}}" | tee output.txt
+        ./${{ inputs.binary_dir }}/${{ inputs.cmake_target}} | tee output.txt
         grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1) 

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -1,0 +1,20 @@
+name: "Hello World Smoke Test"
+description: 'Runs the "hello app" for an SDK.'
+inputs:
+  cmake_target:
+    description: 'The name of the CMake target. i.e. hello-cpp-client'
+    required: true
+  command:
+    description: 'Command that executes the hello binary'
+    required: true
+
+
+runs:
+  using: composite
+  steps:
+    - name: "Build Hello App"
+      shell: bash
+      run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
+    - name: 'Run Hello App'
+      shell: bash
+      run: ${{ inputs.command }}

--- a/.github/actions/hello-world/action.yml
+++ b/.github/actions/hello-world/action.yml
@@ -18,4 +18,6 @@ runs:
       run: ./scripts/build.sh ${{ inputs.cmake_target }} OFF
     - name: 'Run Hello App'
       shell: bash
-      run: "./${{ inputs.binary_dir }}/${{ inputs.cmake_target}}"
+      run: |
+        "./${{ inputs.binary_dir }}/${{ inputs.cmake_target}}" | tee output.txt
+        grep "Please edit" output.txt || (echo "binary did not ask for SDK key as expected" && exit 1) 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -36,7 +36,8 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-client
-          hello_app_cmake_target: hello-c-client
+          hello_app_cmake_target_1: hello-c-client
+          hello_app_cmake_target_2: hello-cpp-client
           simulate_release: true
   build-test-client-mac:
     runs-on: macos-12

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-client
+          simulate_release: true
   build-test-client-mac:
     runs-on: macos-12
     steps:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-client
+          hello_app_cmake_target: hello-c-client
           simulate_release: true
   build-test-client-mac:
     runs-on: macos-12

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-server
+          simulate_release: true
   build-test-server-mac:
     runs-on: macos-12
     steps:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           cmake_target: launchdarkly-cpp-server
+          hello_app_cmake_target_1: hello-c-server
+          hello_app_cmake_target_2: hello-cpp-server
           simulate_release: true
   build-test-server-mac:
     runs-on: macos-12

--- a/examples/hello-c-client/main.c
+++ b/examples/hello-c-client/main.c
@@ -18,16 +18,20 @@
 // the client to become initialized.
 #define INIT_TIMEOUT_MILLISECONDS 3000
 
+char const* get_with_env_fallback(char const* source_val,
+                                  char const* env_variable,
+                                  char const* error_msg);
+
 int main() {
-    if (!strlen(MOBILE_KEY)) {
-        printf(
-            "*** Please edit main.c to set MOBILE_KEY to your LaunchDarkly "
-            "mobile key first\n\n");
-        return 1;
-    }
+    char const* mobile_key = get_with_env_fallback(
+        MOBILE_KEY, "LD_MOBILE_KEY",
+        "Please edit main.c to set MOBILE_KEY to your LaunchDarkly mobile key "
+        "first.\n\nAlternatively, set the LD_MOBILE_KEY environment "
+        "variable.\n"
+        "The value of MOBILE_KEY in main.c takes priority over LD_MOBILE_KEY.");
 
     LDClientConfigBuilder config_builder =
-        LDClientConfigBuilder_New(MOBILE_KEY);
+        LDClientConfigBuilder_New(mobile_key);
 
     LDClientConfig config = NULL;
     LDStatus config_status =
@@ -67,12 +71,28 @@ int main() {
 
     // Here we ensure that the SDK shuts down cleanly and has a chance to
     // deliver analytics events to LaunchDarkly before the program exits. If
-    // analytics events are not delivered, the user properties and flag usage
-    // statistics will not appear on your dashboard. In a normal long-running
-    // application, the SDK would continue running and events would be delivered
-    // automatically in the background.
+    // analytics events are not delivered, the context properties and flag
+    // usage statistics will not appear on your dashboard. In a normal
+    // long-running application, the SDK would continue running and events
+    // would be delivered automatically in the background.
 
     LDClientSDK_Free(client);
 
     return 0;
+}
+
+char const* get_with_env_fallback(char const* source_val,
+                                  char const* env_variable,
+                                  char const* error_msg) {
+    if (strlen(source_val)) {
+        return source_val;
+    }
+
+    char const* from_env = getenv(env_variable);
+    if (from_env && strlen(from_env)) {
+        return from_env;
+    }
+
+    printf("*** %s\n\n", error_msg);
+    exit(1);
 }


### PR DESCRIPTION
So far we've been building the `hello-*` apps in CI, but not running them - meaning it's the responsibility of the SDK author.

This commit executes the hello app in CI, serving as an end-to-end test for:
- [ ] Static linking of the C bindings
- [ ] Static linking of native C++ 

Ideally we'd have such tests for multiple CMake configurations, such as linking as static vs dynamic library.