### PR TITLE
chore: refactor openssl setup into dedicated x-platform action

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -31,12 +31,15 @@ runs:
       with:
         platform_version: ${{ inputs.platform_version }}
         toolset: ${{ inputs.toolset }}
-
+    - name: Install OpenSSL
+      uses: ./.github/actions/install-openssl
+      id: install-openssl
     - name: Build Library
       shell: bash
       run: ./scripts/build.sh ${{ inputs.cmake_target }} ON
       env:
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+        OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
     - name: Build Tests
       id: build-tests
       if: inputs.run_tests == 'true'
@@ -44,6 +47,7 @@ runs:
       run: ./scripts/build.sh gtest_${{ inputs.cmake_target }} ON
       env:
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+        OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
     - name: Run Tests
       if: steps.build-tests.outcome == 'success'
       shell: bash

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,0 +1,32 @@
+name: Install OpenSSL
+description: 'Install OpenSSL >= 3 if not already present.'
+
+runs:
+  using: composite
+  steps:
+    # The ubuntu runner already has OpenSSL > 3 and CMake can find it.
+    - name: Install for Ubuntu.
+      if: runner.os == 'Linux'
+      shell: bash
+      run: echo "Nothing to do!"
+
+    # The Mac runner already has OpenSSL > 3 via brew, but we need to expose its
+    # install path to CMake.
+    - name: Install for Mac
+      if: runner.os == 'macOS'
+      shell: bash
+      run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
+
+    # The Windows runner has an older version of OpenSSL and needs to be upgraded.
+    # Additionally it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
+    # the runner Github gives us.
+    - name: Install for Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        choco upgrade openssl --no-progress
+        if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
+        else
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -39,37 +39,18 @@ jobs:
   build-test-client-mac:
     runs-on: macos-12
     steps:
-      - run: |
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
-          # For debugging
-          echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
       - uses: actions/checkout@v3
       - uses: ./.github/actions/ci
-        env:
-          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
         with:
           cmake_target: launchdarkly-cpp-client
           platform_version: 12
   build-test-client-windows:
     runs-on: windows-2022
     steps:
-      - name: Upgrade OpenSSL
-        shell: bash
-        run: |
-          choco upgrade openssl --no-progress
-      - name: Determine OpenSSL Installation Directory
-        shell: bash
-        run: |
-          if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
-            echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
-          else
-            echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
-          fi
       - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: ./.github/actions/ci
         env:
-          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
           BOOST_LIBRARY_DIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
           BOOST_LIBRARYDIR: 'C:\local\boost_1_81_0\lib64-msvc-14.3'
         with:


### PR DESCRIPTION
Setting up the correct OpenSSL version should be encapsulated in the `ci` action, but it leaked out when I added the code to ensure OpenSSL > 3 on all runners.

Putting it back in its place. Motivated because I'm making another action that could use this.