### PR TITLE
build: dynamically link boost when producing shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,15 +105,18 @@ endif ()
 find_package(OpenSSL REQUIRED)
 message(STATUS "LaunchDarkly: using OpenSSL v${OPENSSL_VERSION}")
 
-# Even though the main SDK might be a static or shared lib, boost should always statically
-# linked into the binary.
-set(Boost_USE_STATIC_LIBS ON)
 
 if (LD_BUILD_SHARED_LIBS)
     # When building a shared library we hide all symbols
     # aside from this we have specifically exported for the C-API.
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
     set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+else ()
+    # If the SDK is being compiled as a static library, link boost in statically so that there's only
+    # one artifact. Otherwise if the SDK is a dynamic library, then link in boost dynamically because:
+    # - Boost is compiled without fpic, so we can't link it into our shared lib unless we compile it separately with fpic
+    # - If the user wants shared libraries, then they probably want to link boost's shared libraries too.
+    set(Boost_USE_STATIC_LIBS ON)
 endif ()
 
 set(Boost_USE_MULTITHREADED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ option(BUILD_TESTING "Top-level switch for testing. Turn off to disable unit and
 
 option(LD_BUILD_SHARED_LIBS "Build the SDKs as shared libraries" OFF)
 
+cmake_dependent_option(LD_DYNAMIC_LINK_BOOST
+        "Dynamically link boost instead of building with its static libraries"
+        ON  # Default to dynamically linking boost, because we can't provide static libs on all platforms that
+        # are position-independent.
+        "LD_BUILD_SHARED_LIBS" # only relevant if building SDK as shared lib
+        OFF # If not building shared libs, then static link boost instead.
+)
+
 cmake_dependent_option(LD_BUILD_UNIT_TESTS
         "Build the C++ unit tests."
         ON                                        # default to enabling unit tests
@@ -47,7 +55,7 @@ cmake_dependent_option(LD_BUILD_CONTRACT_TESTS
 # to link against that statically or dynamically.
 
 option(LD_DYNAMIC_LINK_OPENSSL
-        "Dynamically link OpenSSL instead of building with static library"
+        "Dynamically link OpenSSL instead of building with its static library"
         OFF # default to linking OpenSSL statically
 )
 
@@ -106,17 +114,19 @@ find_package(OpenSSL REQUIRED)
 message(STATUS "LaunchDarkly: using OpenSSL v${OPENSSL_VERSION}")
 
 
+if (LD_DYNAMIC_LINK_BOOST)
+    message(STATUS "LaunchDarkly: searching for shared Boost libraries")
+    set(Boost_USE_STATIC_LIBS OFF)
+else ()
+    message(STATUS "LaunchDarkly: searching for static Boost libraries")
+    set(Boost_USE_STATIC_LIBS ON)
+endif ()
+
 if (LD_BUILD_SHARED_LIBS)
     # When building a shared library we hide all symbols
     # aside from this we have specifically exported for the C-API.
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
     set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-else ()
-    # If the SDK is being compiled as a static library, link boost in statically so that there's only
-    # one artifact. Otherwise if the SDK is a dynamic library, then link in boost dynamically because:
-    # - Boost is compiled without fpic, so we can't link it into our shared lib unless we compile it separately with fpic
-    # - If the user wants shared libraries, then they probably want to link boost's shared libraries too.
-    set(Boost_USE_STATIC_LIBS ON)
 endif ()
 
 set(Boost_USE_MULTITHREADED ON)

--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ For information on integrating an SDK package please refer to the SDK specific R
 
 Various CMake options are available to customize the client/server SDK builds.
 
-| Option                    | Description                                                                            | Default                                                | Requires                                  |
-|---------------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------|
-| `BUILD_TESTING`           | Coarse-grained switch; turn off to disable all testing and only build the SDK targets. | On                                                     | N/A                                       |
-| `LD_BUILD_UNIT_TESTS`     | Whether C++ unit tests are built.                                                      | On                                                     | `BUILD_TESTING; NOT LD_BUILD_SHARED_LIBS` |
-| `LD_TESTING_SANITIZERS`   | Whether sanitizers should be enabled.                                                  | On                                                     | `LD_BUILD_UNIT_TESTS`                     |
-| `LD_BUILD_CONTRACT_TESTS` | Whether the contract test service (used in CI) is built.                               | Off                                                    | `BUILD_TESTING`                           |
-| `LD_BUILD_EXAMPLES`       | Whether example apps (hello world) are built.                                          | On                                                     | N/A                                       |
-| `LD_BUILD_SHARED_LIBS`    | Whether the SDKs are built as static or shared libraries.                              | Off  (static lib)                                      | N/A                                       |
-| `LD_DYNAMIC_LINK_BOOST`   | If building SDK as shared lib, whether to dynamically link Boost or not.               | On (link boost dynamically when producing shared libs) | `LD_BUILD_SHARED_LIBS`                    |
-| `LD_DYNAMIC_LINK_OPENSSL` | Whether OpenSSL is dynamically linked or not.                                          | Off  (static link)                                     | N/A                                       |
+| Option                    | Description                                                                                                                                       | Default                                                | Requires                                  |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------|
+| `BUILD_TESTING`           | Coarse-grained switch; turn off to disable all testing and only build the SDK targets.                                                            | On                                                     | N/A                                       |
+| `LD_BUILD_UNIT_TESTS`     | Whether C++ unit tests are built.                                                                                                                 | On                                                     | `BUILD_TESTING; NOT LD_BUILD_SHARED_LIBS` |
+| `LD_TESTING_SANITIZERS`   | Whether sanitizers should be enabled.                                                                                                             | On                                                     | `LD_BUILD_UNIT_TESTS`                     |
+| `LD_BUILD_CONTRACT_TESTS` | Whether the contract test service (used in CI) is built.                                                                                          | Off                                                    | `BUILD_TESTING`                           |
+| `LD_BUILD_EXAMPLES`       | Whether example apps (hello world) are built.                                                                                                     | On                                                     | N/A                                       |
+| `LD_BUILD_SHARED_LIBS`    | Whether the SDKs are built as static or shared libraries.                                                                                         | Off  (static lib)                                      | N/A                                       |
+| `LD_DYNAMIC_LINK_BOOST`   | If building SDK as shared lib, whether to dynamically link Boost or not. Ensure that the shared boost libraries are present on the target system. | On (link boost dynamically when producing shared libs) | `LD_BUILD_SHARED_LIBS`                    |
+| `LD_DYNAMIC_LINK_OPENSSL` | Whether OpenSSL is dynamically linked or not.                                                                                                     | Off  (static link)                                     | N/A                                       |
 
 **Note:** _if building the SDKs as shared libraries, then unit tests won't be able to link correctly since the SDK's C++
 symbols aren't exposed. To run unit tests, build a static library._

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ For information on integrating an SDK package please refer to the SDK specific R
 
 Various CMake options are available to customize the client/server SDK builds.
 
-| Option                    | Description                                                                            | Default            | Requires                                  |
-|---------------------------|----------------------------------------------------------------------------------------|--------------------|-------------------------------------------|
-| `BUILD_TESTING`           | Coarse-grained switch; turn off to disable all testing and only build the SDK targets. | On                 | N/A                                       |
-| `LD_BUILD_UNIT_TESTS`     | Whether C++ unit tests are built.                                                      | On                 | `BUILD_TESTING; NOT LD_BUILD_SHARED_LIBS` |
-| `LD_TESTING_SANITIZERS`   | Whether sanitizers should be enabled.                                                  | On                 | `LD_BUILD_UNIT_TESTS`                     |
-| `LD_BUILD_CONTRACT_TESTS` | Whether the contract test service (used in CI) is built.                               | Off                | `BUILD_TESTING`                           |
-| `LD_BUILD_EXAMPLES`       | Whether example apps (hello world) are built.                                          | On                 | N/A                                       |
-| `LD_BUILD_SHARED_LIBS`    | Whether the SDKs are built as static or shared libraries.                              | Off  (static lib)  | N/A                                       |
-| `LD_DYNAMIC_LINK_OPENSSL` | Whether OpenSSL be dynamically linked.                                                 | Off  (static link) | N/A                                       |
+| Option                    | Description                                                                            | Default                                                | Requires                                  |
+|---------------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------|
+| `BUILD_TESTING`           | Coarse-grained switch; turn off to disable all testing and only build the SDK targets. | On                                                     | N/A                                       |
+| `LD_BUILD_UNIT_TESTS`     | Whether C++ unit tests are built.                                                      | On                                                     | `BUILD_TESTING; NOT LD_BUILD_SHARED_LIBS` |
+| `LD_TESTING_SANITIZERS`   | Whether sanitizers should be enabled.                                                  | On                                                     | `LD_BUILD_UNIT_TESTS`                     |
+| `LD_BUILD_CONTRACT_TESTS` | Whether the contract test service (used in CI) is built.                               | Off                                                    | `BUILD_TESTING`                           |
+| `LD_BUILD_EXAMPLES`       | Whether example apps (hello world) are built.                                          | On                                                     | N/A                                       |
+| `LD_BUILD_SHARED_LIBS`    | Whether the SDKs are built as static or shared libraries.                              | Off  (static lib)                                      | N/A                                       |
+| `LD_DYNAMIC_LINK_BOOST`   | If building SDK as shared lib, whether to dynamically link Boost or not.               | On (link boost dynamically when producing shared libs) | `LD_BUILD_SHARED_LIBS`                    |
+| `LD_DYNAMIC_LINK_OPENSSL` | Whether OpenSSL is dynamically linked or not.                                          | Off  (static link)                                     | N/A                                       |
 
 **Note:** _if building the SDKs as shared libraries, then unit tests won't be able to link correctly since the SDK's C++
 symbols aren't exposed. To run unit tests, build a static library._

--- a/libs/client-sdk/src/CMakeLists.txt
+++ b/libs/client-sdk/src/CMakeLists.txt
@@ -41,22 +41,10 @@ target_sources(${LIBNAME} PRIVATE
 )
 
 
-if (MSVC OR (NOT LD_BUILD_SHARED_LIBS))
-    target_link_libraries(${LIBNAME}
-            PUBLIC launchdarkly::common
-            PRIVATE Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy)
-else ()
-    # The default static lib builds, for linux, are position independent.
-    # So they do not link into a shared object without issues. So, when
-    # building shared objects do not link the static libraries and instead
-    # use the "src.hpp" files for required libraries.
-    # macOS shares the same path for simplicity.
-    target_link_libraries(${LIBNAME}
-            PUBLIC launchdarkly::common
-            PRIVATE Boost::headers launchdarkly::sse launchdarkly::internal foxy)
+target_link_libraries(${LIBNAME}
+        PUBLIC launchdarkly::common
+        PRIVATE Boost::disable_autolinking Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy)
 
-    target_sources(${LIBNAME} PRIVATE boost.cpp)
-endif ()
 
 add_library(launchdarkly::client ALIAS ${LIBNAME})
 

--- a/libs/client-sdk/src/boost.cpp
+++ b/libs/client-sdk/src/boost.cpp
@@ -1,5 +1,0 @@
-// This file is used to include boost url/json when building a shared library on linux/mac.
-// Windows links static libs in this case and does not include these src files, as there
-// are issues compiling the value.ipp file from JSON with MSVC.
-#include <boost/url/src.hpp>
-#include <boost/json/src.hpp>

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -16,7 +16,6 @@ endif ()
 target_sources(${LIBNAME}
         PRIVATE
         ${HEADER_LIST}
-        boost.cpp
         client.cpp
         client_impl.cpp
         config/config.cpp

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -60,22 +60,11 @@ target_sources(${LIBNAME}
         bindings/c/all_flags_state/all_flags_state.cpp
 )
 
-if (MSVC OR (NOT LD_BUILD_SHARED_LIBS))
-    target_link_libraries(${LIBNAME}
-            PUBLIC launchdarkly::common
-            PRIVATE Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy timestamp)
-else ()
-    # The default static lib builds, for linux, are position independent.
-    # So they do not link into a shared object without issues. So, when
-    # building shared objects do not link the static libraries and instead
-    # use the "src.hpp" files for required libraries.
-    # macOS shares the same path for simplicity.
-    target_link_libraries(${LIBNAME}
-            PUBLIC launchdarkly::common
-            PRIVATE Boost::headers launchdarkly::sse launchdarkly::internal foxy timestamp)
 
-    target_sources(${LIBNAME} PRIVATE boost.cpp)
-endif ()
+target_link_libraries(${LIBNAME}
+        PUBLIC launchdarkly::common
+        PRIVATE Boost::disable_autolinking Boost::headers Boost::json Boost::url launchdarkly::sse launchdarkly::internal foxy timestamp)
+
 
 add_library(launchdarkly::server ALIAS ${LIBNAME})
 

--- a/libs/server-sdk/src/boost.cpp
+++ b/libs/server-sdk/src/boost.cpp
@@ -1,6 +1,5 @@
-// This file is used to include boost url/json when building a shared library on
+// This file is used to include boost json when building a shared library on
 // linux/mac. Windows links static libs in this case and does not include these
 // src files, as there are issues compiling the value.ipp file from JSON with
 // MSVC.
 #include <boost/json/src.hpp>
-#include <boost/url/src.hpp>

--- a/libs/server-sdk/src/boost.cpp
+++ b/libs/server-sdk/src/boost.cpp
@@ -1,5 +1,0 @@
-// This file is used to include boost json when building a shared library on
-// linux/mac. Windows links static libs in this case and does not include these
-// src files, as there are issues compiling the value.ipp file from JSON with
-// MSVC.
-#include <boost/json/src.hpp>


### PR DESCRIPTION
Boost 1.83 introduced a change where `boost.url` needs to be linked in. 

We had a goal of hiding boost when building our shared libraries. Previously, we did this by including boost.json and boost.url headers in `boost.cpp`.

 Now, we need to link in the compiled libraries but this poses a problem when we produce our shared library - the ones we fetch for Linux weren't compiled with `-fPIC`. We could setup some custom repo of artifacts built with that option, but I think that is too much of a lift.

Instead, we can change our strategy: when instructed to produce shared libs, we can link boost dynamically by default.

Provided is a new `LD_DYNAMIC_LINK_BOOST` flag to revert this behavior and find static boost libs instead. 