### PR TITLE
chore: fix OpenSSL root dir

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,8 +39,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost@1.83
-        echo "BOOST_ROOT=$(brew --prefix boost@1.83)" >> $GITHUB_OUTPUT
+        brew install boost
+        echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_OUTPUT
 
     - name: Determine root
       id: determine-root

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,7 +39,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost
+        brew install boost@1.82
         echo "BOOST_ROOT=$(boost --prefix boost@1.82)" >> $GITHUB_OUTPUT
 
     - name: Determine root

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,8 +39,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost@1.82
-        echo "BOOST_ROOT=$(boost --prefix boost@1.82)" >> $GITHUB_OUTPUT
+        brew install boost@1.83
+        echo "BOOST_ROOT=$(brew --prefix boost@1.83)" >> $GITHUB_OUTPUT
 
     - name: Determine root
       id: determine-root

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -13,14 +13,18 @@ runs:
     # The Mac runner already has OpenSSL > 3 via brew, but we need to expose its
     # install path to CMake.
     - name: Install for Mac
+      id: brew-action
       if: runner.os == 'macOS'
       shell: bash
-      run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
+      run: |
+        echo "OpenSSL Prefix: $(brew --prefix openssl@3)"
+        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
     # The Windows runner has an older version of OpenSSL and needs to be upgraded.
-    # Additionally it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
+    # Additionally, it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
     # the runner Github gives us.
     - name: Install for Windows
+      id: choco-action
       if: runner.os == 'Windows'
       shell: bash
       run: |
@@ -30,3 +34,19 @@ runs:
         else
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
         fi
+
+    - name: Determine root
+      id: determine-root
+      shell: bash
+      run: |
+        if [ ! -z "$ROOT_CHOCO" ]; then
+          echo "OPENSSL_ROOT_DIR=$ROOT_CHOCO" >> $GITHUB_OUTPUT
+          echo Setting OPENSSL_ROOT_DIR to "$ROOT_CHOCO"
+        elif [ ! -z "$ROOT_BREW" ]; then
+          echo "OPENSSL_ROOT_DIR=$ROOT_BREW" >> $GITHUB_OUTPUT
+          echo Setting OPENSSL_ROOT_DIR to "$ROOT_BREW"
+        fi
+
+      env:
+        ROOT_CHOCO: ${{ steps.choco-action.outputs.OPENSSL_ROOT_DIR }}
+        ROOT_BREW: ${{ steps.brew-action.outputs.OPENSSL_ROOT_DIR }}


### PR DESCRIPTION
We seem to be getting Boost 1.82 or 1.83 luck of the draw on Mac runners. Unfortunately, 1.83 has a breaking change - Boost.url is no longer header-only. 

The existing script was wrong anyways, since it was assuming `brew install boost` would get 1.82.