### PR TITLE
chore: set OpenSSL root dir properly in CI

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,8 +39,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost@1.83
-        echo "BOOST_ROOT=$(brew --prefix boost@1.83)" >> $GITHUB_OUTPUT
+        brew install boost
+        echo "BOOST_ROOT=$(brew --prefix boost)" >> $GITHUB_OUTPUT
 
     - name: Determine root
       id: determine-root

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,7 +39,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost
+        brew install boost@1.82
         echo "BOOST_ROOT=$(boost --prefix boost@1.82)" >> $GITHUB_OUTPUT
 
     - name: Determine root

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -39,8 +39,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install boost@1.82
-        echo "BOOST_ROOT=$(boost --prefix boost@1.82)" >> $GITHUB_OUTPUT
+        brew install boost@1.83
+        echo "BOOST_ROOT=$(brew --prefix boost@1.83)" >> $GITHUB_OUTPUT
 
     - name: Determine root
       id: determine-root

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -13,14 +13,18 @@ runs:
     # The Mac runner already has OpenSSL > 3 via brew, but we need to expose its
     # install path to CMake.
     - name: Install for Mac
+      id: brew-action
       if: runner.os == 'macOS'
       shell: bash
-      run: echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
+      run: |
+        echo "OpenSSL Prefix: $(brew --prefix openssl@3)"
+        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
     # The Windows runner has an older version of OpenSSL and needs to be upgraded.
-    # Additionally it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
+    # Additionally, it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
     # the runner Github gives us.
     - name: Install for Windows
+      id: choco-action
       if: runner.os == 'Windows'
       shell: bash
       run: |
@@ -30,3 +34,19 @@ runs:
         else
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
         fi
+
+    - name: Determine root
+      id: determine-root
+      shell: bash
+      run: |
+        if [ ! -z "$ROOT_CHOCO" ]; then
+          echo "OPENSSL_ROOT_DIR=$ROOT_CHOCO" >> $GITHUB_OUTPUT
+          echo Setting OPENSSL_ROOT_DIR to "$ROOT_CHOCO"
+        elif [ ! -z "$ROOT_BREW" ]; then
+          echo "OPENSSL_ROOT_DIR=$ROOT_BREW" >> $GITHUB_OUTPUT
+          echo Setting OPENSSL_ROOT_DIR to "$ROOT_BREW"
+        fi
+
+      env:
+        ROOT_CHOCO: ${{ steps.choco-action.outputs.OPENSSL_ROOT_DIR }}
+        ROOT_BREW: ${{ steps.brew-action.outputs.OPENSSL_ROOT_DIR }}

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -1,6 +1,10 @@
 name: Install OpenSSL
 description: 'Install OpenSSL >= 3 if not already present.'
 
+outputs:
+  OPENSSL_ROOT_DIR:
+    description: The location of the installed OpenSSL.
+    value: ${{ steps.determine-root.outputs.OPENSSL_ROOT_DIR }}
 runs:
   using: composite
   steps:
@@ -18,7 +22,7 @@ runs:
       shell: bash
       run: |
         echo "OpenSSL Prefix: $(brew --prefix openssl@3)"
-        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
+        echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_OUTPUT
 
     # The Windows runner has an older version of OpenSSL and needs to be upgraded.
     # Additionally, it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
@@ -30,9 +34,9 @@ runs:
       run: |
         choco upgrade openssl --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
-          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> "$GITHUB_ENV"
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else
-          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> "$GITHUB_ENV"
+          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL" >> $GITHUB_OUTPUT
         fi
 
     - name: Determine root


### PR DESCRIPTION
In our "install OpenSSL" CI step, I hadn't properly setup the "return values" - setting the `OPENSSL_ROOT_DIR` properly. 

The builds still mostly worked, but were fragile. This is due to CMake's find modules finding them anyways. Except when they don't!