### PR TITLE
chore: remove 'release-as' from server sdk

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,8 +19,7 @@
         "CMakeLists.txt"
       ],
       "prerelease": true,
-      "bump-minor-pre-major": true,
-      "release-as": "0.1.0"
+      "bump-minor-pre-major": true
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
Noticed on the release PR that the server's version hasn't changed, which makes sense because I didn't remove `release-as` yet. This removes it.