### PR TITLE
feat: data system config builders [3]

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/all_builders.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/all_builders.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <launchdarkly/config/shared/builders/app_info_builder.hpp>
+#include <launchdarkly/config/shared/builders/endpoints_builder.hpp>
+#include <launchdarkly/config/shared/builders/events_builder.hpp>
+#include <launchdarkly/config/shared/builders/http_properties_builder.hpp>
+#include <launchdarkly/config/shared/builders/logging_builder.hpp>
+
+#include <launchdarkly/server_side/config/builders/data_system/background_sync_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/bootstrap_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/data_destination_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+using SDK = launchdarkly::config::shared::ServerSDK;
+using EndpointsBuilder =
+    launchdarkly::config::shared::builders::EndpointsBuilder<SDK>;
+using HttpPropertiesBuilder =
+    launchdarkly::config::shared::builders::HttpPropertiesBuilder<SDK>;
+using AppInfoBuilder = launchdarkly::config::shared::builders::AppInfoBuilder;
+using EventsBuilder =
+    launchdarkly::config::shared::builders::EventsBuilder<SDK>;
+using LoggingBuilder = launchdarkly::config::shared::builders::LoggingBuilder;
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/background_sync_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/background_sync_builder.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/builders/data_system/bootstrap_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/data_destination_builder.hpp>
+#include <launchdarkly/server_side/config/built/data_system/background_sync_config.hpp>
+
+#include <launchdarkly/config/shared/builders/data_source_builder.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+struct BackgroundSyncBuilder {
+    using Streaming =
+        launchdarkly::config::shared::builders::StreamingBuilder<launchdarkly::config::shared::ServerSDK>;
+    using Polling = launchdarkly::config::shared::builders::PollingBuilder<launchdarkly::config::shared::ServerSDK>;
+
+    BackgroundSyncBuilder();
+
+    BootstrapBuilder& Bootstrapper();
+
+    BackgroundSyncBuilder& Synchronizer(Streaming source);
+    BackgroundSyncBuilder& Synchronizer(Polling source);
+
+    BackgroundSyncBuilder& Destination(DataDestinationBuilder destination);
+
+    [[nodiscard]] built::BackgroundSyncConfig Build() const;
+
+   private:
+    BootstrapBuilder bootstrap_builder_;
+    built::BackgroundSyncConfig config_;
+};
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/bootstrap_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/bootstrap_builder.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/built/data_system/bootstrap_config.hpp>
+
+#include <optional>
+
+namespace launchdarkly::server_side::config::builders {
+
+class BootstrapBuilder {
+   public:
+    BootstrapBuilder();
+
+    [[nodiscard]] std::optional<built::BootstrapConfig> Build() const;
+
+   private:
+    std::optional<built::BootstrapConfig> config_;
+};
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_destination_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_destination_builder.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/built/data_system/data_destination_config.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+struct DataDestinationBuilder {
+    DataDestinationBuilder();
+
+    [[nodiscard]] built::DataDestinationConfig Build() const;
+
+   private:
+    built::DataDestinationConfig config_;
+};
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/builders/data_system/background_sync_builder.hpp>
+#include <launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_system_config.hpp>
+
+#include <launchdarkly/error.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+class DataSystemBuilder {
+   public:
+    DataSystemBuilder();
+    using BackgroundSync = BackgroundSyncBuilder;
+    using LazyLoad = LazyLoadBuilder;
+
+    DataSystemBuilder& Disabled(bool disabled);
+
+    DataSystemBuilder& Method(BackgroundSync bg_sync);
+    DataSystemBuilder& Method(LazyLoad lazy_load);
+
+    [[nodiscard]] tl::expected<built::DataSystemConfig, Error> Build() const;
+
+   private:
+    std::optional<std::variant<BackgroundSync, LazyLoad>> method_builder_;
+    built::DataSystemConfig config_;
+};
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp>
+#include <launchdarkly/server_side/data_interfaces/sources/iserialized_pull_source.hpp>
+
+#include <launchdarkly/error.hpp>
+
+#include <chrono>
+#include <memory>
+
+namespace launchdarkly::server_side::config::builders {
+
+/**
+ * \brief LazyLoadBuilder allows for specifying the configuration of
+ * the Lazy Load data system, which is appropriate when a LaunchDarkly
+ * environment should be stored external to the SDK (such as in Redis.)
+ *
+ * In the Lazy Load system, flag and segment data is fetched on-demand from the
+ * database and stored in an in-memory cache for a specific duration. This
+ * allows the SDK to maintain a working set of data that may be a specific
+ * subset of the entire environment.
+ *
+ * The database is read-only from the perspective of the SDK. To populate the
+ * database with flag and segment data, an external process (e.g. Relay Proxy or
+ * another SDK) is necessary.
+ */
+struct LazyLoadBuilder {
+    using SourcePtr =
+        std::shared_ptr<data_interfaces::ISerializedDataPullSource>;
+    using EvictionPolicy = built::LazyLoadConfig::EvictionPolicy;
+    /**
+     * \brief Constructs a new LazyLoadBuilder.
+     */
+    LazyLoadBuilder();
+
+    /**
+     * \brief Specify the source of the data.
+     * \param source Component implementing ISerializedDataPullSource.
+     * \return Reference to this.
+     */
+    LazyLoadBuilder& Source(SourcePtr source);
+
+    /**
+     * \brief
+     * \param ttl Specify the duration data items should be live in-memory
+     * before being refreshed from the database. The chosen \ref EvictionPolicy
+     * affects usage of this TTL. \return Reference to this.
+     */
+    LazyLoadBuilder& CacheTTL(std::chrono::milliseconds ttl);
+
+    /**
+     * \brief Specify the eviction policy when a data item's TTL expires.
+     * At this time, only EvictionPolicy::Disabled is supported (the default),
+     * which leaves stale items in the cache until they can be refreshed. \param
+     * policy The EvictionPolicy. \return Reference to this.
+     */
+    LazyLoadBuilder& CacheEviction(EvictionPolicy policy);
+
+    [[nodiscard]] tl::expected<built::LazyLoadConfig, Error> Build() const;
+
+   private:
+    built::LazyLoadConfig config_;
+};
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/all_built.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/all_built.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <launchdarkly/config/shared/built/events.hpp>
+#include <launchdarkly/config/shared/built/http_properties.hpp>
+#include <launchdarkly/config/shared/built/logging.hpp>
+#include <launchdarkly/config/shared/built/service_endpoints.hpp>
+
+#include <launchdarkly/server_side/config/built/data_system/bootstrap_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_destination_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_system_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/background_sync_config.hpp>
+
+namespace launchdarkly::server_side::config::built {
+
+using Events = launchdarkly::config::shared::built::Events;
+using HttpProperties = launchdarkly::config::shared::built::HttpProperties;
+using Logging = launchdarkly::config::shared::built::Logging;
+using ServiceEndpoints = launchdarkly::config::shared::built::ServiceEndpoints;
+
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/background_sync_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/background_sync_config.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <launchdarkly/config/shared/built/data_source_config.hpp>
+#include <launchdarkly/config/shared/sdks.hpp>
+#include <launchdarkly/server_side/config/built/data_system/bootstrap_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_destination_config.hpp>
+
+#include <optional>
+#include <variant>
+
+namespace launchdarkly::server_side::config::built {
+
+
+struct BackgroundSyncConfig {
+    using StreamingConfig = launchdarkly::config::shared::built::StreamingConfig<launchdarkly::config::shared::ServerSDK>;
+    using PollingConfig = launchdarkly::config::shared::built::PollingConfig<launchdarkly::config::shared::ServerSDK>;
+
+
+    std::optional<BootstrapConfig> bootstrap_;
+    std::variant<StreamingConfig, PollingConfig> synchronizer_;
+    std::optional<DataDestinationConfig> destination_;
+};
+
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/bootstrap_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/bootstrap_config.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <launchdarkly/config/shared/sdks.hpp>
+
+namespace launchdarkly::server_side::config::built {
+
+struct BootstrapConfig {};
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/data_destination_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/data_destination_config.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <launchdarkly/config/shared/sdks.hpp>
+
+namespace launchdarkly::server_side::config::built {
+
+struct DataDestinationConfig {};
+
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/data_system_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/data_system_config.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <launchdarkly/server_side/config/built/data_system/background_sync_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp>
+
+#include <variant>
+
+namespace launchdarkly::server_side::config::built {
+
+struct DataSystemConfig {
+    bool disabled;
+    std::variant<LazyLoadConfig, BackgroundSyncConfig> system_;
+};
+
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <launchdarkly/server_side/data_interfaces/sources/iserialized_pull_source.hpp>
+
+#include <chrono>
+#include <memory>
+
+namespace launchdarkly::server_side::config::built {
+
+struct LazyLoadConfig {
+    /**
+     * \brief Specifies the action taken when a data item's TTL expires.
+     */
+    enum class EvictionPolicy {
+        /* No action taken; eviction is disabled. Stale items will be used
+         * in evaluations if they cannot be refreshed. */
+        Disabled = 0
+    };
+
+    EvictionPolicy eviction_policy;
+    std::chrono::milliseconds eviction_ttl;
+    std::shared_ptr<server_side::data_interfaces::ISerializedDataPullSource>
+        source;
+};
+}  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/config.hpp
@@ -1,57 +1,43 @@
 #pragma once
 
-#include <launchdarkly/config/shared/builders/endpoints_builder.hpp>
-#include <launchdarkly/config/shared/builders/events_builder.hpp>
-#include <launchdarkly/config/shared/built/data_source_config.hpp>
-#include <launchdarkly/config/shared/built/events.hpp>
-#include <launchdarkly/config/shared/built/http_properties.hpp>
-#include <launchdarkly/config/shared/built/logging.hpp>
-#include <launchdarkly/config/shared/built/persistence.hpp>
-#include <launchdarkly/config/shared/built/service_endpoints.hpp>
-#include <launchdarkly/config/shared/sdks.hpp>
+#include <launchdarkly/server_side/config/built/all_built.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_system_config.hpp>
 
 namespace launchdarkly::server_side {
-
-using SDK = config::shared::ServerSDK;
 
 struct Config {
    public:
     Config(std::string sdk_key,
-           bool offline,
-           config::shared::built::Logging logging,
-           config::shared::built::ServiceEndpoints endpoints,
-           config::shared::built::Events events,
+           config::built::Logging logging,
+           config::built::ServiceEndpoints endpoints,
+           config::built::Events events,
            std::optional<std::string> application_tag,
-           config::shared::built::DataSourceConfig<SDK> data_source_config,
-           config::shared::built::HttpProperties http_properties);
+           config::built::DataSystemConfig data_system_config,
+           config::built::HttpProperties http_properties);
 
     [[nodiscard]] std::string const& SdkKey() const;
 
-    [[nodiscard]] config::shared::built::ServiceEndpoints const&
-    ServiceEndpoints() const;
+    [[nodiscard]] config::built::ServiceEndpoints const& ServiceEndpoints()
+        const;
 
-    [[nodiscard]] config::shared::built::Events const& Events() const;
+    [[nodiscard]] config::built::Events const& Events() const;
 
     [[nodiscard]] std::optional<std::string> const& ApplicationTag() const;
 
-    config::shared::built::DataSourceConfig<SDK> const& DataSourceConfig()
-        const;
+    config::built::DataSystemConfig const& DataSystemConfig() const;
 
-    [[nodiscard]] config::shared::built::HttpProperties const& HttpProperties()
-        const;
+    [[nodiscard]] config::built::HttpProperties const& HttpProperties() const;
 
-    [[nodiscard]] bool Offline() const;
-
-    [[nodiscard]] config::shared::built::Logging const& Logging() const;
+    [[nodiscard]] config::built::Logging const& Logging() const;
 
    private:
     std::string sdk_key_;
     bool offline_;
-    config::shared::built::Logging logging_;
-    config::shared::built::ServiceEndpoints service_endpoints_;
+    config::built::Logging logging_;
+    config::built::ServiceEndpoints service_endpoints_;
     std::optional<std::string> application_tag_;
-    config::shared::built::Events events_;
-    config::shared::built::DataSourceConfig<SDK> data_source_config_;
-    config::shared::built::HttpProperties http_properties_;
+    config::built::Events events_;
+    config::built::DataSystemConfig data_system_config_;
+    config::built::HttpProperties http_properties_;
 };
 }  // namespace launchdarkly::server_side

--- a/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
@@ -1,11 +1,7 @@
 #pragma once
-#include <launchdarkly/config/server_builders.hpp>
+
+#include <launchdarkly/server_side/config/builders/all_builders.hpp>
 #include <launchdarkly/server_side/config/config.hpp>
-#include "launchdarkly/config/shared/builders/app_info_builder.hpp"
-#include "launchdarkly/config/shared/builders/data_source_builder.hpp"
-#include "launchdarkly/config/shared/builders/http_properties_builder.hpp"
-#include "launchdarkly/config/shared/builders/logging_builder.hpp"
-#include "launchdarkly/config/shared/defaults.hpp"
 
 namespace launchdarkly::server_side {
 
@@ -24,7 +20,7 @@ class ConfigBuilder {
      * @param builder An EndpointsBuilder.
      * @return Reference to an EndpointsBuilder.
      */
-    EndpointsBuilder& ServiceEndpoints();
+    config::builders::EndpointsBuilder& ServiceEndpoints();
 
     /**
      * To include metadata about the application that is utilizing the SDK,
@@ -32,15 +28,7 @@ class ConfigBuilder {
      * @param builder An AppInfoBuilder.
      * @return Reference to an AppInfoBuilder.
      */
-    AppInfoBuilder& AppInfo();
-
-    /**
-     * Enables or disables "Offline" mode. True means
-     * Offline mode is enabled.
-     * @param offline True if the SDK should operate in Offline mode.
-     * @return Reference to this builder.
-     */
-    ConfigBuilder& Offline(bool offline);
+    config::builders::AppInfoBuilder& AppInfo();
 
     /**
      * To tune settings related to event generation and delivery, pass an
@@ -48,15 +36,15 @@ class ConfigBuilder {
      * @param builder An EventsBuilder.
      * @return Reference to an EventsBuilder.
      */
-    EventsBuilder& Events();
+    config::builders::EventsBuilder& Events();
 
     /**
-     * Sets the configuration of the component that receives feature flag data
-     * from LaunchDarkly.
-     * @param builder A DataSourceConfig builder.
-     * @return Reference to a DataSourceBuilder.
+     * Sets the configuration of the component that receives and stores feature
+     * flag data from LaunchDarkly.
+     * @param builder A DataSystemBuilder.
+     * @return Reference to a DataSystemBuilder.
      */
-    DataSourceBuilder& DataSource();
+    config::builders::DataSystemBuilder& DataSystem();
 
     /**
      * Sets the SDK's networking configuration, using an HttpPropertiesBuilder.
@@ -64,14 +52,14 @@ class ConfigBuilder {
      * @param builder A HttpPropertiesBuilder builder.
      * @return Reference to an HttpPropertiesBuilder.
      */
-    HttpPropertiesBuilder& HttpProperties();
+    config::builders::HttpPropertiesBuilder& HttpProperties();
 
     /**
      * Sets the logging configuration for the SDK.
      * @param builder A Logging builder.
      * @return Reference to a LoggingBuilder.
      */
-    LoggingBuilder& Logging();
+    config::builders::LoggingBuilder& Logging();
 
     /**
      * Builds a Configuration, suitable for passing into an instance of Client.
@@ -83,11 +71,11 @@ class ConfigBuilder {
     std::string sdk_key_;
     std::optional<bool> offline_;
 
-    EndpointsBuilder service_endpoints_builder_;
-    AppInfoBuilder app_info_builder_;
-    EventsBuilder events_builder_;
-    DataSourceBuilder data_source_builder_;
-    HttpPropertiesBuilder http_properties_builder_;
-    LoggingBuilder logging_config_builder_;
+    config::builders::EndpointsBuilder service_endpoints_builder_;
+    config::builders::AppInfoBuilder app_info_builder_;
+    config::builders::EventsBuilder events_builder_;
+    config::builders::DataSystemBuilder data_system_builder_;
+    config::builders::HttpPropertiesBuilder http_properties_builder_;
+    config::builders::LoggingBuilder logging_config_builder_;
 };
 }  // namespace launchdarkly::server_side

--- a/libs/server-sdk/include/launchdarkly/server_side/config/defaults.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/defaults.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace launchdarkly::server_side::config {
+
+struct Defaults {
+
+
+};
+
+}  // namespace launchdarkly::server_side::config

--- a/libs/server-sdk/src/config/builders/data_system/background_sync_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/background_sync_builder.cpp
@@ -1,0 +1,35 @@
+#include <launchdarkly/server_side/config/builders/data_system/background_sync_builder.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+BackgroundSyncBuilder::BackgroundSyncBuilder()
+    : bootstrap_builder_(), config_() {}
+
+BootstrapBuilder& BackgroundSyncBuilder::Bootstrapper() {
+    return bootstrap_builder_;
+}
+
+BackgroundSyncBuilder& BackgroundSyncBuilder::Synchronizer(Streaming source) {
+    config_.source_.method = source.Build();
+    return *this;
+}
+
+BackgroundSyncBuilder& BackgroundSyncBuilder::Synchronizer(Polling source) {
+    config_.source_.method = source.Build();
+    return *this;
+}
+
+BackgroundSyncBuilder& BackgroundSyncBuilder::Destination(
+    DataDestinationBuilder destination) {
+    config_.destination_ = destination.Build();
+    return *this;
+}
+
+[[nodiscard]] built::BackgroundSyncConfig BackgroundSyncBuilder::Build() const {
+    auto const bootstrap_cfg = bootstrap_builder_.Build();
+    auto copy = config_;
+    copy.bootstrap_ = bootstrap_cfg;
+    return copy;
+}
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/src/config/builders/data_system/bootstrap_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/bootstrap_builder.cpp
@@ -1,0 +1,12 @@
+#include <launchdarkly/server_side/config/builders/data_system/bootstrap_builder.hpp>
+
+#include "defaults.hpp"
+
+namespace launchdarkly::server_side::config::builders {
+
+BootstrapBuilder::BootstrapBuilder() : config_(Defaults::BootstrapConfig()) {}
+
+std::optional<built::BootstrapConfig> BootstrapBuilder::Build() const {
+    return config_;
+}
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/src/config/builders/data_system/data_destination_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/data_destination_builder.cpp
@@ -1,0 +1,12 @@
+#include <launchdarkly/server_side/config/builders/data_system/data_destination_builder.hpp>
+
+namespace launchdarkly::server_side::config::builders {
+
+DataDestinationBuilder::DataDestinationBuilder() : config_() {}
+
+[[nodiscard]] built::DataDestinationConfig DataDestinationBuilder::Build()
+    const {
+    return config_;
+}
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/src/config/builders/data_system/data_system_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/data_system_builder.cpp
@@ -1,0 +1,50 @@
+#include <launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp>
+#include "defaults.hpp"
+
+namespace launchdarkly::server_side::config::builders {
+
+DataSystemBuilder::DataSystemBuilder()
+    : method_builder_(std::nullopt), config_(Defaults::DataSystemConfig()) {}
+
+DataSystemBuilder& DataSystemBuilder::Method(BackgroundSync bg_sync) {
+    method_builder_ = std::move(bg_sync);
+    return *this;
+}
+
+DataSystemBuilder& DataSystemBuilder::Method(LazyLoad lazy_load) {
+    method_builder_ = std::move(lazy_load);
+    return *this;
+}
+
+DataSystemBuilder& DataSystemBuilder::Disabled(bool const disabled) {
+    config_.disabled = disabled;
+    return *this;
+}
+
+tl::expected<built::DataSystemConfig, Error> DataSystemBuilder::Build() const {
+    if (method_builder_) {
+        auto lazy_or_background_cfg = std::visit(
+            [](auto&& arg)
+                -> tl::expected<std::variant<built::LazyLoadConfig,
+                                             built::BackgroundSyncConfig>,
+                                Error> {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, BackgroundSync>) {
+                    return arg.Build();  // -> built::BackgroundSyncConfig
+                } else if constexpr (std::is_same_v<T, LazyLoad>) {
+                    return arg
+                        .Build();  // -> tl::expected<built::LazyLoadConfig,
+                                   // Error>
+                }
+            },
+            *method_builder_);
+        if (!lazy_or_background_cfg) {
+            return tl::make_unexpected(lazy_or_background_cfg.error());
+        }
+        return built::DataSystemConfig{config_.disabled,
+                                       std::move(*lazy_or_background_cfg)};
+    }
+    return config_;
+}
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/src/config/builders/data_system/defaults.hpp
+++ b/libs/server-sdk/src/config/builders/data_system/defaults.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <launchdarkly/server_side/config/built/data_system/background_sync_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_destination_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/data_system_config.hpp>
+#include <launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp>
+
+namespace launchdarkly::server_side::config {
+
+struct Defaults {
+    // No bootstrap phase yet in server-sdk; instead full
+    // sync is done when polling/streaming source initializes.
+    static auto BootstrapConfig() -> std::optional<built::BootstrapConfig> {
+        return std::nullopt;
+    }
+
+    // Data isn't mirrored anywhere by default.
+    static auto DataDestinationConfig()
+        -> std::optional<built::DataDestinationConfig> {
+        return std::nullopt;
+    }
+
+    static auto BackgroundSyncConfig() -> built::BackgroundSyncConfig {
+        return {BootstrapConfig(), DataSourceConfig(), DataDestinationConfig()};
+    }
+
+    static auto LazyLoadConfig() -> built::LazyLoadConfig {
+        return {built::LazyLoadConfig::EvictionPolicy::Disabled,
+                std::chrono::minutes{5}, nullptr};
+    }
+
+    static auto DataSystemConfig() -> built::DataSystemConfig {
+        return {false, BackgroundSyncConfig()};
+    }
+};
+}  // namespace launchdarkly::server_side::config

--- a/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
@@ -1,0 +1,33 @@
+#include <launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp>
+
+#include "defaults.hpp"
+
+namespace launchdarkly::server_side::config::builders {
+
+LazyLoadBuilder::LazyLoadBuilder() : config_(Defaults::LazyLoadConfig()) {}
+
+LazyLoadBuilder& LazyLoadBuilder::CacheTTL(
+    std::chrono::milliseconds const ttl) {
+    config_.eviction_ttl = ttl;
+    return *this;
+}
+
+LazyLoadBuilder& LazyLoadBuilder::CacheEviction(EvictionPolicy const policy) {
+    config_.eviction_policy = policy;
+    return *this;
+}
+
+LazyLoadBuilder& LazyLoadBuilder::Source(SourcePtr source) {
+    config_.source = source;
+    return *this;
+}
+
+tl::expected<built::LazyLoadConfig, Error> LazyLoadBuilder::Build() const {
+    if (!config_.source) {
+        return tl::make_unexpected(
+            Error::kConfig_DataSystem_LazyLoad_MissingSource);
+    }
+    return config_;
+}
+
+}  // namespace launchdarkly::server_side::config::builders

--- a/libs/server-sdk/src/config/config.cpp
+++ b/libs/server-sdk/src/config/config.cpp
@@ -2,33 +2,33 @@
 
 namespace launchdarkly::server_side {
 
+using namespace launchdarkly::config::shared;
+
 Config::Config(std::string sdk_key,
-               bool offline,
-               config::shared::built::Logging logging,
-               config::shared::built::ServiceEndpoints service_endpoints,
-               config::shared::built::Events events,
+               built::Logging logging,
+               built::ServiceEndpoints service_endpoints,
+               built::Events events,
                std::optional<std::string> application_tag,
-               config::shared::built::DataSourceConfig<SDK> data_source_config,
-               config::shared::built::HttpProperties http_properties)
+               launchdarkly::server_side::config::built::DataSystemConfig
+                   data_system_config,
+               built::HttpProperties http_properties)
     : sdk_key_(std::move(sdk_key)),
       logging_(std::move(logging)),
-      offline_(offline),
       service_endpoints_(std::move(service_endpoints)),
       events_(std::move(events)),
       application_tag_(std::move(application_tag)),
-      data_source_config_(std::move(data_source_config)),
+      data_system_config_(std::move(data_system_config)),
       http_properties_(std::move(http_properties)) {}
 
 std::string const& Config::SdkKey() const {
     return sdk_key_;
 }
 
-config::shared::built::ServiceEndpoints const& Config::ServiceEndpoints()
-    const {
+built::ServiceEndpoints const& Config::ServiceEndpoints() const {
     return service_endpoints_;
 }
 
-config::shared::built::Events const& Config::Events() const {
+built::Events const& Config::Events() const {
     return events_;
 }
 
@@ -36,20 +36,16 @@ std::optional<std::string> const& Config::ApplicationTag() const {
     return application_tag_;
 }
 
-config::shared::built::DataSourceConfig<config::shared::ServerSDK> const&
-Config::DataSourceConfig() const {
-    return data_source_config_;
+launchdarkly::server_side::config::built::DataSystemConfig const&
+Config::DataSystemConfig() const {
+    return data_system_config_;
 }
 
-config::shared::built::HttpProperties const& Config::HttpProperties() const {
+built::HttpProperties const& Config::HttpProperties() const {
     return http_properties_;
 }
 
-bool Config::Offline() const {
-    return offline_;
-}
-
-config::shared::built::Logging const& Config::Logging() const {
+built::Logging const& Config::Logging() const {
     return logging_;
 }
 

--- a/libs/server-sdk/src/config/config_builder.cpp
+++ b/libs/server-sdk/src/config/config_builder.cpp
@@ -1,37 +1,31 @@
 #include <launchdarkly/server_side/config/config_builder.hpp>
-#include "launchdarkly/config/shared/defaults.hpp"
 
 namespace launchdarkly::server_side {
 
 ConfigBuilder::ConfigBuilder(std::string sdk_key)
     : sdk_key_(std::move(sdk_key)) {}
 
-EndpointsBuilder& ConfigBuilder::ServiceEndpoints() {
+config::builders::EndpointsBuilder& ConfigBuilder::ServiceEndpoints() {
     return service_endpoints_builder_;
 }
 
-EventsBuilder& ConfigBuilder::Events() {
+config::builders::EventsBuilder& ConfigBuilder::Events() {
     return events_builder_;
 }
 
-AppInfoBuilder& ConfigBuilder::AppInfo() {
+config::builders::AppInfoBuilder& ConfigBuilder::AppInfo() {
     return app_info_builder_;
 }
 
-ConfigBuilder& ConfigBuilder::Offline(bool offline) {
-    offline_ = offline;
-    return *this;
+config::builders::DataSystemBuilder& ConfigBuilder::DataSystem() {
+    return data_system_builder_;
 }
 
-DataSourceBuilder& ConfigBuilder::DataSource() {
-    return data_source_builder_;
-}
-
-HttpPropertiesBuilder& ConfigBuilder::HttpProperties() {
+config::builders::HttpPropertiesBuilder& ConfigBuilder::HttpProperties() {
     return http_properties_builder_;
 }
 
-LoggingBuilder& ConfigBuilder::Logging() {
+config::builders::LoggingBuilder& ConfigBuilder::Logging() {
     return logging_config_builder_;
 }
 
@@ -40,7 +34,7 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
     if (sdk_key.empty()) {
         return tl::make_unexpected(Error::kConfig_SDKKey_Empty);
     }
-    auto offline = offline_.value_or(Defaults::Offline());
+
     auto endpoints_config = service_endpoints_builder_.Build();
     if (!endpoints_config) {
         return tl::make_unexpected(endpoints_config.error());
@@ -52,7 +46,10 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
 
     std::optional<std::string> app_tag = app_info_builder_.Build();
 
-    auto data_source_config = data_source_builder_.Build();
+    auto data_system_config = data_system_builder_.Build();
+    if (!data_system_config) {
+        return tl::make_unexpected(data_system_config.error());
+    }
 
     auto http_properties = http_properties_builder_.Build();
 
@@ -60,12 +57,11 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
 
     return {tl::in_place,
             sdk_key,
-            offline,
             logging,
             *endpoints_config,
             *events_config,
             app_tag,
-            std::move(data_source_config),
+            std::move(*data_system_config),
             std::move(http_properties)};
 }
 


### PR DESCRIPTION
This introduces a set of configuration objects & builders for the server-side Data System.

These are defined in `libs/server-sdk` rather than in common, since they don't apply to the client at the moment. In a future client major version, we could attempt to unify them. 