### PR TITLE
refactor: various client SDK lints

### DIFF
--- a/contract-tests/client-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/client-contract-tests/src/entity_manager.cpp
@@ -1,9 +1,10 @@
 #include "entity_manager.hpp"
-#include <boost/json/parse.hpp>
 
 #include <launchdarkly/config/client.hpp>
 #include <launchdarkly/context_builder.hpp>
 #include <launchdarkly/serialization/json_context.hpp>
+
+#include <boost/json.hpp>
 
 using launchdarkly::LogLevel;
 using namespace launchdarkly::client_side;

--- a/libs/client-sdk/src/client_impl.cpp
+++ b/libs/client-sdk/src/client_impl.cpp
@@ -6,6 +6,7 @@
 #include <launchdarkly/events/asio_event_processor.hpp>
 #include <launchdarkly/events/null_event_processor.hpp>
 
+#include <launchdarkly/detail/c_binding_helpers.hpp>
 #include <launchdarkly/encoding/sha_256.hpp>
 #include <launchdarkly/logging/console_backend.hpp>
 #include <launchdarkly/logging/null_logger.hpp>
@@ -80,24 +81,24 @@ static std::shared_ptr<IPersistence> MakePersistence(Config const& config) {
     return persistence.implementation;
 }
 
-ClientImpl::ClientImpl(Config config,
+ClientImpl::ClientImpl(Config in_cfg,
                        Context context,
                        std::string const& version)
-    : config_(config),
+    : config_(std::move(in_cfg)), /* caution: do not use in_cfg (moved from!) */
       http_properties_(
-          HttpPropertiesBuilder(config.HttpProperties())
+          HttpPropertiesBuilder(config_.HttpProperties())
               .Header("user-agent", "CPPClient/" + version)
-              .Header("authorization", config.SdkKey())
-              .Header("x-launchdarkly-tags", config.ApplicationTag())
+              .Header("authorization", config_.SdkKey())
+              .Header("x-launchdarkly-tags", config_.ApplicationTag())
               .Build()),
-      logger_(MakeLogger(config.Logging())),
+      logger_(MakeLogger(config_.Logging())),
       ioc_(kAsioConcurrencyHint),
       work_(boost::asio::make_work_guard(ioc_)),
       context_(std::move(context)),
-      flag_manager_(config.SdkKey(),
+      flag_manager_(config_.SdkKey(),
                     logger_,
-                    config.Persistence().max_contexts_,
-                    MakePersistence(config)),
+                    config_.Persistence().max_contexts_,
+                    MakePersistence(config_)),
       data_source_factory_([this]() {
           return MakeDataSource(http_properties_, config_, context_,
                                 ioc_.get_executor(), flag_manager_.Updater(),
@@ -105,14 +106,14 @@ ClientImpl::ClientImpl(Config config,
       }),
       data_source_(nullptr),
       event_processor_(nullptr),
-      eval_reasons_available_(config.DataSourceConfig().with_reasons) {
+      eval_reasons_available_(config_.DataSourceConfig().with_reasons) {
     flag_manager_.LoadCache(context_);
 
-    if (config.Events().Enabled() && !config.Offline()) {
+    if (config_.Events().Enabled() && !config_.Offline()) {
         event_processor_ =
             std::make_unique<events::AsioEventProcessor<ClientSDK>>(
-                ioc_.get_executor(), config.ServiceEndpoints(), config.Events(),
-                http_properties_, logger_);
+                ioc_.get_executor(), config_.ServiceEndpoints(),
+                config_.Events(), http_properties_, logger_);
     } else {
         event_processor_ = std::make_unique<events::NullEventProcessor>();
     }
@@ -160,14 +161,14 @@ void ClientImpl::RestartDataSource() {
 
 std::future<bool> ClientImpl::StartAsyncInternal(
     std::function<bool(DataSourceStatus::DataSourceState)> result_predicate) {
-    auto pr = std::make_shared<std::promise<bool>>();
-    auto fut = pr->get_future();
+    auto init_promise = std::make_shared<std::promise<bool>>();
+    auto init_future = init_promise->get_future();
 
     status_manager_.OnDataSourceStatusChangeEx(
-        [result_predicate, pr](data_sources::DataSourceStatus status) {
-            auto state = status.State();
-            if (IsInitialized(state)) {
-                pr->set_value(result_predicate(status.State()));
+        [result = std::move(result_predicate),
+         init_promise](data_sources::DataSourceStatus const& status) {
+            if (auto const state = status.State(); IsInitialized(state)) {
+                init_promise->set_value(result(status.State()));
                 return true; /* delete this change listener since the desired
                                 state was reached */
             }
@@ -176,7 +177,7 @@ std::future<bool> ClientImpl::StartAsyncInternal(
 
     RestartDataSource();
 
-    return fut;
+    return init_future;
 }
 
 std::future<bool> ClientImpl::StartAsync() {
@@ -272,14 +273,15 @@ EvaluationDetail<T> ClientImpl::VariationInternal(FlagKey const& key,
         event_processor_->SendAsync(std::move(event));
         return EvaluationDetail<T>(default_value, std::nullopt,
                                    std::move(error_reason));
+    }
 
-    } else if (!Initialized()) {
+    if (!Initialized()) {
         LD_LOG(logger_, LogLevel::kInfo)
             << "LaunchDarkly client has not yet been initialized. "
                "Returning cached value";
     }
 
-    assert(desc->item);
+    LD_ASSERT(desc->item);
 
     auto const& flag = *(desc->item);
     auto const& detail = flag.Detail();

--- a/libs/client-sdk/src/client_impl.cpp
+++ b/libs/client-sdk/src/client_impl.cpp
@@ -30,14 +30,14 @@ using launchdarkly::client_side::data_sources::DataSourceStatus;
 using launchdarkly::config::shared::built::DataSourceConfig;
 using launchdarkly::config::shared::built::HttpProperties;
 
-static std::shared_ptr<::launchdarkly::data_sources::IDataSource>
-MakeDataSource(HttpProperties const& http_properties,
-               Config const& config,
-               Context const& context,
-               boost::asio::any_io_executor const& executor,
-               IDataSourceUpdateSink& flag_updater,
-               data_sources::DataSourceStatusManager& status_manager,
-               Logger& logger) {
+static std::shared_ptr<data_sources::IDataSource> MakeDataSource(
+    HttpProperties const& http_properties,
+    Config const& config,
+    Context const& context,
+    boost::asio::any_io_executor const& executor,
+    IDataSourceUpdateSink& flag_updater,
+    data_sources::DataSourceStatusManager& status_manager,
+    Logger& logger) {
     if (config.Offline()) {
         return std::make_shared<data_sources::NullDataSource>(executor,
                                                               status_manager);

--- a/libs/client-sdk/src/client_impl.hpp
+++ b/libs/client-sdk/src/client_impl.hpp
@@ -1,7 +1,24 @@
 #pragma once
 
+#include "data_sources/data_source.hpp"
+#include "data_sources/data_source_status_manager.hpp"
+#include "flag_manager/flag_manager.hpp"
+
+#include <launchdarkly/client_side/client.hpp>
+#include <launchdarkly/client_side/data_source_status.hpp>
+#include <launchdarkly/client_side/flag_notifier.hpp>
+#include <launchdarkly/config/client.hpp>
+#include <launchdarkly/context.hpp>
+#include <launchdarkly/data/evaluation_detail.hpp>
+#include <launchdarkly/error.hpp>
+#include <launchdarkly/events/event_processor_interface.hpp>
+#include <launchdarkly/logging/logger.hpp>
+#include <launchdarkly/value.hpp>
+
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
+
+#include <tl/expected.hpp>
 
 #include <condition_variable>
 #include <cstdint>
@@ -10,24 +27,6 @@
 #include <shared_mutex>
 #include <thread>
 #include <tuple>
-
-#include <tl/expected.hpp>
-
-#include <launchdarkly/client_side/client.hpp>
-#include <launchdarkly/client_side/data_source_status.hpp>
-#include <launchdarkly/client_side/flag_notifier.hpp>
-#include <launchdarkly/config/client.hpp>
-#include <launchdarkly/context.hpp>
-#include <launchdarkly/data/evaluation_detail.hpp>
-#include <launchdarkly/data_sources/data_source.hpp>
-#include <launchdarkly/error.hpp>
-#include <launchdarkly/logging/logger.hpp>
-#include <launchdarkly/value.hpp>
-
-#include <launchdarkly/events/event_processor_interface.hpp>
-
-#include "data_sources/data_source_status_manager.hpp"
-#include "flag_manager/flag_manager.hpp"
 
 namespace launchdarkly::client_side {
 class ClientImpl : public IClient {
@@ -130,10 +129,10 @@ class ClientImpl : public IClient {
     mutable std::shared_mutex context_mutex_;
 
     flag_manager::FlagManager flag_manager_;
-    std::function<std::shared_ptr<::launchdarkly::data_sources::IDataSource>()>
+    std::function<std::shared_ptr<data_sources::IDataSource>()>
         data_source_factory_;
 
-    std::shared_ptr<::launchdarkly::data_sources::IDataSource> data_source_;
+    std::shared_ptr<data_sources::IDataSource> data_source_;
 
     std::unique_ptr<events::IEventProcessor> event_processor_;
 

--- a/libs/client-sdk/src/client_impl.hpp
+++ b/libs/client-sdk/src/client_impl.hpp
@@ -18,15 +18,12 @@
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 
-#include <tl/expected.hpp>
-
 #include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <shared_mutex>
 #include <thread>
-#include <tuple>
 
 namespace launchdarkly::client_side {
 class ClientImpl : public IClient {

--- a/libs/client-sdk/src/data_sources/data_source.hpp
+++ b/libs/client-sdk/src/data_sources/data_source.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <future>
+
+namespace launchdarkly::client_side::data_sources {
+
+class IDataSource {
+   public:
+    virtual void Start() = 0;
+    virtual void ShutdownAsync(std::function<void()>) = 0;
+    virtual ~IDataSource() = default;
+    IDataSource(IDataSource const& item) = delete;
+    IDataSource(IDataSource&& item) = delete;
+    IDataSource& operator=(IDataSource const&) = delete;
+    IDataSource& operator=(IDataSource&&) = delete;
+
+   protected:
+    IDataSource() = default;
+};
+
+}  // namespace launchdarkly::client_side::data_sources

--- a/libs/client-sdk/src/data_sources/data_source_event_handler.hpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.hpp
@@ -8,7 +8,6 @@
 #include <launchdarkly/config/shared/built/service_endpoints.hpp>
 #include <launchdarkly/context.hpp>
 #include <launchdarkly/data/evaluation_result.hpp>
-#include <launchdarkly/data_sources/data_source.hpp>
 #include <launchdarkly/logging/logger.hpp>
 
 namespace launchdarkly::client_side::data_sources {

--- a/libs/client-sdk/src/data_sources/null_data_source.hpp
+++ b/libs/client-sdk/src/data_sources/null_data_source.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <boost/asio/any_io_executor.hpp>
-
+#include "data_source.hpp"
 #include "data_source_status_manager.hpp"
 
-#include <launchdarkly/data_sources/data_source.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 namespace launchdarkly::client_side::data_sources {
 
-class NullDataSource : public ::launchdarkly::data_sources::IDataSource {
+class NullDataSource : public IDataSource {
    public:
     explicit NullDataSource(boost::asio::any_io_executor exec,
                             DataSourceStatusManager& status_manager);

--- a/libs/client-sdk/src/data_sources/polling_data_source.hpp
+++ b/libs/client-sdk/src/data_sources/polling_data_source.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <chrono>
-
-#include <boost/asio/any_io_executor.hpp>
-
+#include "data_source.hpp"
 #include "data_source_event_handler.hpp"
 #include "data_source_status_manager.hpp"
 #include "data_source_update_sink.hpp"
@@ -11,14 +8,17 @@
 #include <launchdarkly/config/shared/built/data_source_config.hpp>
 #include <launchdarkly/config/shared/built/http_properties.hpp>
 #include <launchdarkly/config/shared/built/service_endpoints.hpp>
-#include <launchdarkly/data_sources/data_source.hpp>
 #include <launchdarkly/logging/logger.hpp>
 #include <launchdarkly/network/asio_requester.hpp>
+
+#include <chrono>
+
+#include <boost/asio/any_io_executor.hpp>
 
 namespace launchdarkly::client_side::data_sources {
 
 class PollingDataSource
-    : public ::launchdarkly::data_sources::IDataSource,
+    : public IDataSource,
       public std::enable_shared_from_this<PollingDataSource> {
    public:
     PollingDataSource(

--- a/libs/client-sdk/src/data_sources/streaming_data_source.hpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <chrono>
-using namespace std::chrono_literals;
-
 #include <boost/asio/any_io_executor.hpp>
 
+#include "data_source.hpp"
 #include "data_source_event_handler.hpp"
 #include "data_source_status_manager.hpp"
 #include "data_source_update_sink.hpp"
@@ -15,14 +13,15 @@ using namespace std::chrono_literals;
 #include <launchdarkly/config/shared/built/service_endpoints.hpp>
 #include <launchdarkly/context.hpp>
 #include <launchdarkly/data/evaluation_result.hpp>
-#include <launchdarkly/data_sources/data_source.hpp>
 #include <launchdarkly/logging/logger.hpp>
 #include <launchdarkly/sse/client.hpp>
+
+#include <chrono>
 
 namespace launchdarkly::client_side::data_sources {
 
 class StreamingDataSource final
-    : public ::launchdarkly::data_sources::IDataSource,
+    : public IDataSource,
       public std::enable_shared_from_this<StreamingDataSource> {
    public:
     StreamingDataSource(


### PR DESCRIPTION
This is a mostly removing a bunch of redundant namespace qualifiers + formatting changes in the client SDK, which I addressed while building the Redis integration.

We can merge these directly to main instead to make the Redis PR cleaner.

