### PR TITLE
refactor: remove redundant namespacing in streaming event_handler

### DIFF
--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.cpp
@@ -142,7 +142,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             status_manager_.SetError(
                 DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
                 kErrorParsingPut);
-            return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+            return MessageStatus::kInvalidMessage;
         }
         auto res =
             boost::json::value_to<tl::expected<std::optional<Put>, JsonError>>(
@@ -153,16 +153,16 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             status_manager_.SetError(
                 DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
                 kErrorPutInvalid);
-            return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+            return MessageStatus::kInvalidMessage;
         }
 
         // Check the inner optional.
         if (res->has_value()) {
             handler_.Init(std::move((*res)->data));
             status_manager_.SetState(DataSourceStatus::DataSourceState::kValid);
-            return DataSourceEventHandler::MessageStatus::kMessageHandled;
+            return MessageStatus::kMessageHandled;
         }
-        return DataSourceEventHandler::MessageStatus::kMessageHandled;
+        return MessageStatus::kMessageHandled;
     }
     if (type == "patch") {
         boost::json::error_code error_code;
@@ -172,7 +172,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             status_manager_.SetError(
                 DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
                 kErrorParsingPatch);
-            return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+            return MessageStatus::kInvalidMessage;
         }
 
         auto res = boost::json::value_to<
@@ -182,7 +182,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             status_manager_.SetError(
                 DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
                 kErrorPatchInvalid);
-            return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+            return MessageStatus::kInvalidMessage;
         }
 
         // This references the optional inside the expected.
@@ -191,10 +191,10 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             auto const& key = patch.key;
             std::visit([this, &key](auto&& arg) { handler_.Upsert(key, arg); },
                        patch.data);
-            return DataSourceEventHandler::MessageStatus::kMessageHandled;
+            return MessageStatus::kMessageHandled;
         }
         // We didn't recognize the type of the patch. So we ignore it.
-        return DataSourceEventHandler::MessageStatus::kMessageHandled;
+        return MessageStatus::kMessageHandled;
     }
     if (type == "delete") {
         boost::json::error_code error_code;
@@ -204,7 +204,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
             status_manager_.SetError(
                 DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
                 kErrorParsingDelete);
-            return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+            return MessageStatus::kInvalidMessage;
         }
 
         auto res =
@@ -215,14 +215,12 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
                 case data_components::DataKind::kFlag: {
                     handler_.Upsert(res->key,
                                     data_model::FlagDescriptor(res->version));
-                    return DataSourceEventHandler::MessageStatus::
-                        kMessageHandled;
+                    return MessageStatus::kMessageHandled;
                 }
                 case data_components::DataKind::kSegment: {
                     handler_.Upsert(
                         res->key, data_model::SegmentDescriptor(res->version));
-                    return DataSourceEventHandler::MessageStatus::
-                        kMessageHandled;
+                    return MessageStatus::kMessageHandled;
                 }
                 default: {
                 } break;
@@ -232,10 +230,10 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
         status_manager_.SetError(
             DataSourceStatus::ErrorInfo::ErrorKind::kInvalidData,
             kErrorDeleteInvalid);
-        return DataSourceEventHandler::MessageStatus::kInvalidMessage;
+        return MessageStatus::kInvalidMessage;
     }
 
-    return DataSourceEventHandler::MessageStatus::kUnhandledVerb;
+    return MessageStatus::kUnhandledVerb;
 }
 
 }  // namespace launchdarkly::server_side::data_systems

--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.hpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.hpp
@@ -68,7 +68,7 @@ struct StreamingDataKinds {
 
 /**
  * This class handles LaunchDarkly events, parses them, and then uses
- * a IDataSourceUpdateSink to process the parsed events.
+ * a IDestination to process the parsed events.
  *
  * This is only used for streaming. For server polling the shape of the poll
  * response is different than the put, so there is limited utility in


### PR DESCRIPTION
Just removes a verbose namespace prefix that isn't necessary.