### PR TITLE
feat: implement additional data system config builders

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
@@ -84,8 +84,14 @@ LDServerConfigBuilder_AppInfo_Version(LDServerConfigBuilder b,
                                       char const* app_version);
 
 /**
- * Enables or disables "Offline" mode. True means
- * Offline mode is enabled.
+ * If true, equivalent to setting LDServerConfigBuilder_Events_Enabled(false)
+ * and LDServerConfigBuilder_DataSystem_Enabled(false).
+ *
+ * The effect is that all evaluations will return
+ * application-provided default values, and no network calls will be made.
+ *
+ * This overrides specific configuration of events and/or data system, if
+ * present.
  * @param b Server config builder. Must not be NULL.
  * @param offline True if offline.
  */
@@ -160,36 +166,53 @@ LDServerConfigBuilder_Events_PrivateAttribute(LDServerConfigBuilder b,
                                               char const* attribute_reference);
 
 /**
- * Set the streaming configuration for the builder.
+ * Configures the Background Sync data system with a Streaming synchronizer.
  *
- * A data source may either be streaming or polling. Setting a streaming
- * builder indicates the data source will use streaming. Setting a polling
- * builder will indicate the use of polling.
+ * This is the default data system configuration for the SDK.
+ *
+ * In this mode, the SDK maintains a persistent, streaming data connection
+ * with LaunchDarkly. The application is able to evaluate using the most
+ * recent flag configurations, since any changes are streamed from LaunchDarkly
+ * in the background.
  *
  * @param b Server config builder. Must not be NULL.
  * @param stream_builder The streaming builder. The builder is consumed; do not
  * free it.
  */
 LD_EXPORT(void)
-LDServerConfigBuilder_DataSource_MethodStream(
+LDServerConfigBuilder_DataSystem_BackgroundSync_Streaming(
     LDServerConfigBuilder b,
     LDServerDataSourceStreamBuilder stream_builder);
 
 /**
- * Set the polling configuration for the builder.
+ * Configures the Background Sync data system with a Polling synchronizer.
  *
- * A data source may either be streaming or polling. Setting a stream
- * builder indicates the data source will use streaming. Setting a polling
- * builder will indicate the use of polling.
+ * This synchronizer may be chosen to override the default Streaming mode.
+ *
+ * In this mode, the SDK makes periodic network requests to LaunchDarkly.
+ * Between requests, flag data may be stale to some degree. This mode may be
+ * advantageous if a streaming connection cannot be maintained.
  *
  * @param b Server config builder. Must not be NULL.
  * @param poll_builder The polling builder. The builder is consumed; do not free
  * it.
  */
 LD_EXPORT(void)
-LDServerConfigBuilder_DataSource_MethodPoll(
+LDServerConfigBuilder_DataSystem_BackgroundSync_Polling(
     LDServerConfigBuilder b,
     LDServerDataSourcePollBuilder poll_builder);
+
+/**
+ * Specify if the SDK's data system should be enabled or not.
+ *
+ * If disabled, the SDK won't be able to obtain flag configuration
+ * and will instead serve application-provided default values.
+ *
+ * @param b Server config builder. Must not be NULL.
+ * @param enabled True to enable the data system, false to disable it.
+ */
+LD_EXPORT(void)
+LDServerConfigBuilder_DataSystem_Enabled(LDServerConfigBuilder b, bool enabled);
 
 /**
  * Creates a new DataSource builder for the Streaming method.

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp
@@ -14,9 +14,36 @@ class DataSystemBuilder {
     using BackgroundSync = BackgroundSyncBuilder;
     using LazyLoad = LazyLoadBuilder;
 
-    DataSystemBuilder& Disabled(bool disabled);
+    /**
+     * @brief Alias for Enabled(false).
+     * @return Reference to this.
+     */
+    DataSystemBuilder& Disable();
 
+    /**
+     * @brief Specifies if the data system is enabled or disabled.
+     * If disabled, the configured method won't be used. Defaults to true.
+     * @param enabled If the data system is enabled.
+     * @return Reference to this.
+     */
+    DataSystemBuilder& Enabled(bool enabled);
+
+    /**
+     * @brief Configures the Background Sync data system. In this system,
+     * the SDK periodically receives updates from LaunchDarkly servers and
+     * stores them in an in-memory cache. This is the default data system.
+     * @param bg_sync Background Sync configuration.
+     * @return Reference to this.
+     */
     DataSystemBuilder& Method(BackgroundSync bg_sync);
+
+    /**
+     * @brief Configures the Lazy Load data system. In this system, the SDK
+     * pulls data on demand from a configured source, caching responses in
+     * memory for a configurable duration.
+     * @param lazy_load Lazy Load configuration.
+     * @return Reference to this.
+     */
     DataSystemBuilder& Method(LazyLoad lazy_load);
 
     [[nodiscard]] tl::expected<built::DataSystemConfig, Error> Build() const;

--- a/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/built/data_system/lazy_load_config.hpp
@@ -18,7 +18,7 @@ struct LazyLoadConfig {
     };
 
     EvictionPolicy eviction_policy;
-    std::chrono::milliseconds eviction_ttl;
+    std::chrono::milliseconds refresh_ttl;
     std::shared_ptr<data_interfaces::ISerializedDataReader> source;
 };
 }  // namespace launchdarkly::server_side::config::built

--- a/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
@@ -62,6 +62,18 @@ class ConfigBuilder {
     config::builders::LoggingBuilder& Logging();
 
     /**
+     * @brief If true, equivalent to setting Events().Disable() and
+     * DataSystem().Disable(). The effect is that all evaluations will return
+     * application-provided default values, and no network calls will be made.
+     *
+     * This overrides specific configuration of events and/or data system, if
+     * present.
+     *
+     * @return Reference to this.
+     */
+    ConfigBuilder& Offline(bool offline);
+
+    /**
      * Builds a Configuration, suitable for passing into an instance of Client.
      * @return
      */
@@ -69,7 +81,7 @@ class ConfigBuilder {
 
    private:
     std::string sdk_key_;
-    std::optional<bool> offline_;
+    bool offline_;
 
     config::builders::EndpointsBuilder service_endpoints_builder_;
     config::builders::AppInfoBuilder app_info_builder_;

--- a/libs/server-sdk/src/bindings/c/builder.cpp
+++ b/libs/server-sdk/src/bindings/c/builder.cpp
@@ -119,10 +119,10 @@ LDServerConfigBuilder_AppInfo_Version(LDServerConfigBuilder b,
 }
 
 LD_EXPORT(void)
-LDServerConfigBuilder_Offline(LDServerConfigBuilder b, bool offline) {
+LDServerConfigBuilder_Offline(LDServerConfigBuilder b, bool const offline) {
     LD_ASSERT_NOT_NULL(b);
 
-    // TO_BUILDER(b)->Offline(offline);
+    TO_BUILDER(b)->Offline(offline);
 }
 
 LD_EXPORT(void)
@@ -166,7 +166,7 @@ LDServerConfigBuilder_Events_PrivateAttribute(LDServerConfigBuilder b,
 }
 
 LD_EXPORT(void)
-LDServerConfigBuilder_DataSource_MethodStream(
+LDServerConfigBuilder_DataSystem_BackgroundSync_Streaming(
     LDServerConfigBuilder b,
     LDServerDataSourceStreamBuilder stream_builder) {
     LD_ASSERT_NOT_NULL(b);
@@ -179,7 +179,7 @@ LDServerConfigBuilder_DataSource_MethodStream(
 }
 
 LD_EXPORT(void)
-LDServerConfigBuilder_DataSource_MethodPoll(
+LDServerConfigBuilder_DataSystem_BackgroundSync_Polling(
     LDServerConfigBuilder b,
     LDServerDataSourcePollBuilder poll_builder) {
     LD_ASSERT_NOT_NULL(b);
@@ -191,9 +191,17 @@ LDServerConfigBuilder_DataSource_MethodPoll(
     LDServerDataSourcePollBuilder_Free(poll_builder);
 }
 
+LD_EXPORT(void)
+LDServerConfigBuilder_DataSystem_Enabled(LDServerConfigBuilder b,
+                                         bool const enabled) {
+    LD_ASSERT_NOT_NULL(b);
+    TO_BUILDER(b)->DataSystem().Enabled(enabled);
+}
+
 LD_EXPORT(LDServerDataSourceStreamBuilder)
 LDServerDataSourceStreamBuilder_New() {
-    return FROM_STREAM_BUILDER(new BackgroundSyncBuilder::Streaming());
+    return FROM_STREAM_BUILDER(
+        new DataSystemBuilder::BackgroundSync::Streaming());
 }
 
 LD_EXPORT(void)
@@ -212,12 +220,12 @@ LDServerDataSourceStreamBuilder_Free(LDServerDataSourceStreamBuilder b) {
 }
 
 LD_EXPORT(LDServerDataSourcePollBuilder) LDServerDataSourcePollBuilder_New() {
-    return FROM_POLL_BUILDER(new BackgroundSyncBuilder::Polling());
+    return FROM_POLL_BUILDER(new DataSystemBuilder::BackgroundSync::Polling());
 }
 
 LD_EXPORT(void)
 LDServerDataSourcePollBuilder_IntervalS(LDServerDataSourcePollBuilder b,
-                                        unsigned int seconds) {
+                                     unsigned int seconds) {
     LD_ASSERT_NOT_NULL(b);
 
     TO_POLL_BUILDER(b)->PollInterval(std::chrono::seconds{seconds});

--- a/libs/server-sdk/src/bindings/c/sdk.cpp
+++ b/libs/server-sdk/src/bindings/c/sdk.cpp
@@ -27,7 +27,7 @@ struct Detail;
 #define FROM_DETAIL(ptr) (reinterpret_cast<LDEvalDetail>(ptr))
 
 #define TO_DATASOURCESTATUS(ptr) \
-    (reinterpret_cast<launchdarkly::server_side::DataSourceStatus*>(ptr))
+    (reinterpret_cast<DataSourceStatus*>(ptr))
 
 #define FROM_DATASOURCESTATUS(ptr) \
     (reinterpret_cast<LDServerDataSourceStatus>(ptr))

--- a/libs/server-sdk/src/config/builders/data_system/data_system_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/data_system_builder.cpp
@@ -16,9 +16,13 @@ DataSystemBuilder& DataSystemBuilder::Method(LazyLoad lazy_load) {
     return *this;
 }
 
-DataSystemBuilder& DataSystemBuilder::Disabled(bool const disabled) {
-    config_.disabled = disabled;
+DataSystemBuilder& DataSystemBuilder::Enabled(bool const enabled) {
+    config_.disabled = !enabled;
     return *this;
+}
+
+DataSystemBuilder& DataSystemBuilder::Disable() {
+    return Enabled(false);
 }
 
 tl::expected<built::DataSystemConfig, Error> DataSystemBuilder::Build() const {

--- a/libs/server-sdk/src/config/builders/data_system/defaults.hpp
+++ b/libs/server-sdk/src/config/builders/data_system/defaults.hpp
@@ -20,12 +20,13 @@ struct Defaults {
     }
 
     static auto SynchronizerConfig()
-       -> built::BackgroundSyncConfig::StreamingConfig {
+        -> built::BackgroundSyncConfig::StreamingConfig {
         return {std::chrono::seconds(1), "/all"};
     }
 
     static auto BackgroundSyncConfig() -> built::BackgroundSyncConfig {
-        return {BootstrapConfig(), SynchronizerConfig(), DataDestinationConfig()};
+        return {BootstrapConfig(), SynchronizerConfig(),
+                DataDestinationConfig()};
     }
 
     static auto LazyLoadConfig() -> built::LazyLoadConfig {

--- a/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
@@ -8,7 +8,7 @@ LazyLoadBuilder::LazyLoadBuilder() : config_(Defaults::LazyLoadConfig()) {}
 
 LazyLoadBuilder& LazyLoadBuilder::CacheRefresh(
     std::chrono::milliseconds const ttl) {
-    config_.eviction_ttl = ttl;
+    config_.refresh_ttl = ttl;
     return *this;
 }
 

--- a/libs/server-sdk/src/config/config.cpp
+++ b/libs/server-sdk/src/config/config.cpp
@@ -9,8 +9,7 @@ Config::Config(std::string sdk_key,
                built::ServiceEndpoints service_endpoints,
                built::Events events,
                std::optional<std::string> application_tag,
-               launchdarkly::server_side::config::built::DataSystemConfig
-                   data_system_config,
+               config::built::DataSystemConfig data_system_config,
                built::HttpProperties http_properties)
     : sdk_key_(std::move(sdk_key)),
       logging_(std::move(logging)),
@@ -36,8 +35,7 @@ std::optional<std::string> const& Config::ApplicationTag() const {
     return application_tag_;
 }
 
-launchdarkly::server_side::config::built::DataSystemConfig const&
-Config::DataSystemConfig() const {
+config::built::DataSystemConfig const& Config::DataSystemConfig() const {
     return data_system_config_;
 }
 

--- a/libs/server-sdk/src/config/config_builder.cpp
+++ b/libs/server-sdk/src/config/config_builder.cpp
@@ -3,7 +3,7 @@
 namespace launchdarkly::server_side {
 
 ConfigBuilder::ConfigBuilder(std::string sdk_key)
-    : sdk_key_(std::move(sdk_key)) {}
+    : sdk_key_(std::move(sdk_key)), offline_(false) {}
 
 config::builders::EndpointsBuilder& ConfigBuilder::ServiceEndpoints() {
     return service_endpoints_builder_;
@@ -29,6 +29,11 @@ config::builders::LoggingBuilder& ConfigBuilder::Logging() {
     return logging_config_builder_;
 }
 
+ConfigBuilder& ConfigBuilder::Offline(bool const offline) {
+    offline_ = offline;
+    return *this;
+}
+
 tl::expected<Config, Error> ConfigBuilder::Build() const {
     auto sdk_key = sdk_key_;
     if (sdk_key.empty()) {
@@ -39,14 +44,23 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
     if (!endpoints_config) {
         return tl::make_unexpected(endpoints_config.error());
     }
-    auto events_config = events_builder_.Build();
+
+    auto events_builder = events_builder_;
+    if (offline_) {
+        events_builder.Disable();
+    }
+    auto events_config = events_builder.Build();
     if (!events_config) {
         return tl::make_unexpected(events_config.error());
     }
 
     std::optional<std::string> app_tag = app_info_builder_.Build();
 
-    auto data_system_config = data_system_builder_.Build();
+    auto data_system_builder = data_system_builder_;
+    if (offline_) {
+        data_system_builder.Disable();
+    }
+    auto data_system_config = data_system_builder.Build();
     if (!data_system_config) {
         return tl::make_unexpected(data_system_config.error());
     }

--- a/libs/server-sdk/tests/config_builder_test.cpp
+++ b/libs/server-sdk/tests/config_builder_test.cpp
@@ -81,11 +81,16 @@ TEST_F(ConfigBuilderTest, DefaultConstruction_EventDefaultsAreUsed) {
 TEST_F(ConfigBuilderTest, CanDisableDataSystem) {
     ConfigBuilder builder("sdk-123");
 
-    // First establish that the data system is enabled.
+    // First establish that the data system is enabled,
+    // to detect if defaults are misconfigured.
     auto const cfg1 = builder.Build();
     EXPECT_FALSE(cfg1->DataSystemConfig().disabled);
 
-    builder.DataSystem().Disabled(true);
+    builder.DataSystem().Disable();
     auto const cfg2 = builder.Build();
     EXPECT_TRUE(cfg2->DataSystemConfig().disabled);
+
+    builder.DataSystem().Enabled(true);
+    auto const cfg3 = builder.Build();
+    EXPECT_FALSE(cfg3->DataSystemConfig().disabled);
 }

--- a/libs/server-sdk/tests/server_c_bindings_test.cpp
+++ b/libs/server-sdk/tests/server_c_bindings_test.cpp
@@ -1,14 +1,15 @@
 #include <gtest/gtest.h>
 
+#include <launchdarkly/bindings/c/context_builder.h>
 #include <launchdarkly/server_side/bindings/c/config/builder.h>
 #include <launchdarkly/server_side/bindings/c/sdk.h>
 #include <launchdarkly/server_side/data_source_status.hpp>
 
-#include <launchdarkly/bindings/c/context_builder.h>
-
 #include <boost/json/parse.hpp>
 
 #include <chrono>
+
+using namespace launchdarkly::server_side;
 
 TEST(ClientBindings, MinimalInstantiation) {
     LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
@@ -43,7 +44,7 @@ TEST(ClientBindings, RegisterDataSourceStatusChangeListener) {
 
     LDServerSDK sdk = LDServerSDK_New(config);
 
-    struct LDServerDataSourceStatusListener listener {};
+    LDServerDataSourceStatusListener listener{};
     LDServerDataSourceStatusListener_Init(&listener);
 
     listener.UserData = const_cast<char*>("Potato");

--- a/libs/server-sdk/tests/server_c_bindings_test.cpp
+++ b/libs/server-sdk/tests/server_c_bindings_test.cpp
@@ -1,15 +1,14 @@
 #include <gtest/gtest.h>
 
-#include <launchdarkly/bindings/c/context_builder.h>
 #include <launchdarkly/server_side/bindings/c/config/builder.h>
 #include <launchdarkly/server_side/bindings/c/sdk.h>
 #include <launchdarkly/server_side/data_source_status.hpp>
 
+#include <launchdarkly/bindings/c/context_builder.h>
+
 #include <boost/json/parse.hpp>
 
 #include <chrono>
-
-using namespace launchdarkly::server_side;
 
 TEST(ClientBindings, MinimalInstantiation) {
     LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
@@ -44,7 +43,7 @@ TEST(ClientBindings, RegisterDataSourceStatusChangeListener) {
 
     LDServerSDK sdk = LDServerSDK_New(config);
 
-    LDServerDataSourceStatusListener listener{};
+    struct LDServerDataSourceStatusListener listener {};
     LDServerDataSourceStatusListener_Init(&listener);
 
     listener.UserData = const_cast<char*>("Potato");

--- a/libs/server-sdk/tests/service_endpoint_builders_test.cpp
+++ b/libs/server-sdk/tests/service_endpoint_builders_test.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <launchdarkly/error.hpp>
+#include <launchdarkly/server_side/config/builders/all_builders.hpp>
+
+using namespace launchdarkly::server_side::config::builders;
+using Error = launchdarkly::Error;
+
+TEST(ServiceEndpointTest, DefaultServerBuilderURLs) {
+    EndpointsBuilder builder;
+    auto eps = builder.Build();
+    ASSERT_TRUE(eps);
+    ASSERT_EQ(eps->PollingBaseUrl(), "https://sdk.launchdarkly.com");
+    ASSERT_EQ(eps->StreamingBaseUrl(), "https://stream.launchdarkly.com");
+    ASSERT_EQ(eps->EventsBaseUrl(), "https://events.launchdarkly.com");
+}
+
+TEST(ServiceEndpointTest, ModifySingleURLCausesError) {
+    auto result = EndpointsBuilder().PollingBaseUrl("foo").Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+
+    result = EndpointsBuilder().StreamingBaseUrl("foo").Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+
+    result = EndpointsBuilder().EventsBaseUrl("foo").Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+}
+
+TEST(ServiceEndpointsTest, RelaySetsAllURLS) {
+    auto eps = EndpointsBuilder().RelayProxyBaseURL("foo").Build();
+    ASSERT_TRUE(eps);
+    ASSERT_EQ(eps->StreamingBaseUrl(), "foo");
+    ASSERT_EQ(eps->PollingBaseUrl(), "foo");
+    ASSERT_EQ(eps->EventsBaseUrl(), "foo");
+}
+
+TEST(ServiceEndpointsTest, TrimsTrailingSlashes) {
+    {
+        auto eps = EndpointsBuilder().RelayProxyBaseURL("foo/").Build();
+        ASSERT_TRUE(eps);
+        ASSERT_EQ(eps->StreamingBaseUrl(), "foo");
+    }
+
+    {
+        auto eps = EndpointsBuilder().RelayProxyBaseURL("foo////////").Build();
+        ASSERT_TRUE(eps);
+        ASSERT_EQ(eps->StreamingBaseUrl(), "foo");
+    }
+
+    {
+        auto eps = EndpointsBuilder().RelayProxyBaseURL("/").Build();
+        ASSERT_TRUE(eps);
+        ASSERT_EQ(eps->StreamingBaseUrl(), "");
+    }
+}
+
+TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
+    auto result = EndpointsBuilder().RelayProxyBaseURL("").Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+
+    result = EndpointsBuilder()
+                 .StreamingBaseUrl("")
+                 .EventsBaseUrl("foo")
+                 .PollingBaseUrl("bar")
+                 .Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+
+    result = EndpointsBuilder()
+                 .StreamingBaseUrl("foo")
+                 .EventsBaseUrl("")
+                 .PollingBaseUrl("bar")
+                 .Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+
+    result = EndpointsBuilder()
+                 .StreamingBaseUrl("foo")
+                 .EventsBaseUrl("bar")
+                 .PollingBaseUrl("")
+                 .Build();
+    ASSERT_FALSE(result);
+    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+}


### PR DESCRIPTION
This adds in some missing top-level Data System builder methods, as well as additional documentation. 

Some config tests that I previously removed from the `common` lib are added back into the server. 

I've also re-added Offline mode configuration, which modifies Data System and Events configuration.