### PR TITLE
refactor: improve IDataSynchronizer's interface to expose IDestination

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/data_interfaces/sources/iserialized_data_reader.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/data_interfaces/sources/iserialized_data_reader.hpp
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 namespace launchdarkly::server_side::data_interfaces {
 

--- a/libs/server-sdk/src/data_interfaces/source/idata_synchronizer.hpp
+++ b/libs/server-sdk/src/data_interfaces/source/idata_synchronizer.hpp
@@ -12,7 +12,7 @@ namespace launchdarkly::server_side::data_interfaces {
 
 /**
  * \brief IDataSynchronizer obtains data via a background synchronization
- * mechanism, updating a local cache whenever changes are made upstream.
+ * mechanism, updating an IDestination whenever changes arrive from upstream.
  */
 class IDataSynchronizer {
    public:
@@ -24,11 +24,12 @@ class IDataSynchronizer {
      * data is present in the SDK and a full synchronization must be initiated.
      *
      * If bootstrap_data is not nullptr, then it contains data obtained by the
-     * SDK out-of-band from the source's mechanism. The pointer is valid only
+     * SDK during the bootstrap process. The pointer is valid only
      * for this call.
      *
      * The data may be used to optimize the synchronization process, e.g. by
      * obtaining a diff rather than a full dataset.
+     *
      * @param destination The destination to synchronize data into. Pointer is
      * invalid after the ShutdownAsync completion handler is called.
      * @param bootstrap_data Optional bootstrap data.
@@ -46,7 +47,7 @@ class IDataSynchronizer {
     virtual void ShutdownAsync(std::function<void()> complete) = 0;
 
     /**
-     * \return Identity of the source. Used in logs.
+     * \return Identity of the synchronizer. Used in logs.
      */
     [[nodiscard]] virtual std::string const& Identity() const = 0;
 

--- a/libs/server-sdk/src/data_interfaces/source/idata_synchronizer.hpp
+++ b/libs/server-sdk/src/data_interfaces/source/idata_synchronizer.hpp
@@ -6,6 +6,8 @@
 #include <optional>
 #include <string>
 
+#include "../destination/idestination.hpp"
+
 namespace launchdarkly::server_side::data_interfaces {
 
 /**
@@ -15,18 +17,25 @@ namespace launchdarkly::server_side::data_interfaces {
 class IDataSynchronizer {
    public:
     /**
-     * \brief Initialize the source, optionally with an initial data set. Init
-     * will be called before Start.
-     * \param initial_data Initial set of SDK data.
+     * @brief Starts synchronizing data into the given IDestination.
+     *
+     *
+     * The second parameter, boostrap_data, may be nullptr meaning no bootstrap
+     * data is present in the SDK and a full synchronization must be initiated.
+     *
+     * If bootstrap_data is not nullptr, then it contains data obtained by the
+     * SDK out-of-band from the source's mechanism. The pointer is valid only
+     * for this call.
+     *
+     * The data may be used to optimize the synchronization process, e.g. by
+     * obtaining a diff rather than a full dataset.
+     * @param destination The destination to synchronize data into. Pointer is
+     * invalid after the ShutdownAsync completion handler is called.
+     * @param bootstrap_data Optional bootstrap data.
+     * Pointer is valid only for this call.
      */
-    virtual void Init(std::optional<data_model::SDKDataSet> initial_data) = 0;
-
-    /**
-     * \brief Starts the synchronization mechanism. Start will be called only
-     * once after Init; the source is responsible for maintaining a persistent
-     * connection. Start should not block.
-     */
-    virtual void StartAsync() = 0;
+    virtual void StartAsync(IDestination* destination,
+                            data_model::SDKDataSet const* bootstrap_data) = 0;
 
     /**
      * \brief Stops the synchronization mechanism. Stop will be called only once

--- a/libs/server-sdk/src/data_systems/background_sync/background_sync_system.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/background_sync_system.cpp
@@ -21,15 +21,15 @@ BackgroundSync::BackgroundSync(
                                          config::built::BackgroundSyncConfig::
                                              StreamingConfig>) {
                 synchronizer_ = std::make_shared<StreamingDataSource>(
-                    endpoints, method_config, http_properties, ioc,
-                    change_notifier_, status_manager, logger);
+                    ioc, logger, status_manager, endpoints, method_config,
+                    http_properties);
 
             } else if constexpr (std::is_same_v<
                                      T, config::built::BackgroundSyncConfig::
                                             PollingConfig>) {
                 synchronizer_ = std::make_shared<PollingDataSource>(
-                    endpoints, method_config, http_properties, ioc,
-                    change_notifier_, status_manager, logger);
+                    ioc, logger, status_manager, endpoints, method_config,
+                    http_properties);
             }
         },
         background_sync_config.synchronizer_);
@@ -43,9 +43,8 @@ BackgroundSync::BackgroundSync(
       synchronizer_(std::make_shared<NullDataSource>(ioc, status_manager)) {}
 
 void BackgroundSync::Initialize() {
-    // TODO: if there was any data from bootstrapping, then add it:
-    // synchronizer_->Init(data);
-    synchronizer_->StartAsync();
+    synchronizer_->StartAsync(&change_notifier_,
+                              nullptr /* no bootstrap data supported yet */);
 }
 
 std::string const& BackgroundSync::Identity() const {

--- a/libs/server-sdk/src/data_systems/background_sync/sources/noop/null_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/noop/null_data_source.cpp
@@ -4,15 +4,14 @@
 
 namespace launchdarkly::server_side::data_systems {
 
-void NullDataSource::StartAsync() {
+void NullDataSource::StartAsync(data_interfaces::IDestination* destination,
+                                data_model::SDKDataSet const* initial_data) {
     status_manager_.SetState(DataSourceStatus::DataSourceState::kValid);
 }
 
 void NullDataSource::ShutdownAsync(std::function<void()> complete) {
     boost::asio::post(exec_, complete);
 }
-
-void NullDataSource::Init(std::optional<data_model::SDKDataSet> initial_data) {}
 
 std::string const& NullDataSource::Identity() const {
     static std::string const identity = "no-op data source";

--- a/libs/server-sdk/src/data_systems/background_sync/sources/noop/null_data_source.hpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/noop/null_data_source.hpp
@@ -13,8 +13,8 @@ class NullDataSource : public data_interfaces::IDataSynchronizer {
         boost::asio::any_io_executor exec,
         data_components::DataSourceStatusManager& status_manager);
 
-    void Init(std::optional<data_model::SDKDataSet> initial_data) override;
-    void StartAsync() override;
+    void StartAsync(data_interfaces::IDestination* destination,
+                    data_model::SDKDataSet const* initial_data) override;
     void ShutdownAsync(std::function<void()>) override;
 
     [[nodiscard]] std::string const& Identity() const override;

--- a/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.hpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.hpp
@@ -43,7 +43,7 @@ class PollingDataSource
     // Status manager is used to report the status of the data source. It must
     // outlive the source. This source performs asynchronous
     // operations, so a completion handler might invoke the status manager after
-    // the it has been destroyed.
+    // it has been destroyed.
     data_components::DataSourceStatusManager& status_manager_;
 
     // Responsible for performing HTTP requests using boost::asio.

--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
@@ -50,7 +50,7 @@ StreamingDataSource::StreamingDataSource(
 void StreamingDataSource::StartAsync(
     data_interfaces::IDestination* dest,
     data_model::SDKDataSet const* bootstrap_data) {
-    boost::movelib::ignore(bootstrap_data);
+    boost::ignore_unused(bootstrap_data);
 
     event_handler_.emplace(*dest, logger_, status_manager_);
 


### PR DESCRIPTION
This refactors `IDataSynchronizer` to take an `IDestination`  and bootstrap data in its `StartAsync` method, rather than having an independent `Init` function.

The addition of `IDestination` makes the interface's purpose clearer.

Before the destination was hidden - you'd only see it when constructing an implementation. Now it's clear that the `IDataSynchronizer` puts data into the `IDestination`; no hidden dependency.

It also doesn't make sense to "Init" an `IDataSynchronizer` with an SDKDataSet. 

The purpose of that call is to allow the synchronizer to inspect any existing data in possession by the SDK. The result of that inspection might mean an optimized fetch of initial data is possible (e.g. if there was an etag present in the initial data.)

