### PR TITLE
feat: omit empty items from data model JSON serialization

### DIFF
--- a/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
+++ b/libs/internal/include/launchdarkly/serialization/value_mapping.hpp
@@ -166,6 +166,25 @@ void WriteMinimal(boost::json::object& obj,
     }
 }
 
+template <typename T>
+void WriteMinimal(boost::json::object& obj,
+                  std::string const& key,
+                  std::vector<T> const& val) {
+    if (!val.empty()) {
+        obj.emplace(key, boost::json::value_from(val));
+    }
+}
+
+template <typename T>
+void WriteMinimal(boost::json::object& obj,
+                  std::string const& key,
+                  T const& val,
+                  std::function<bool()> const& predicate) {
+    if (predicate()) {
+        obj.emplace(key, boost::json::value_from(val));
+    }
+}
+
 void WriteMinimal(boost::json::object& obj,
                   std::string const& key,  // No copy when not used.
                   bool val);

--- a/libs/internal/src/serialization/json_segment.cpp
+++ b/libs/internal/src/serialization/json_segment.cpp
@@ -114,13 +114,11 @@ void tag_invoke(boost::json::value_from_tag const& unused,
     WriteMinimal(obj, "unboundedContextKind", segment.unboundedContextKind);
     WriteMinimal(obj, "unbounded", segment.unbounded);
 
-    obj.emplace("rules", boost::json::value_from(segment.rules));
-    obj.emplace("excluded", boost::json::value_from(segment.excluded));
-    obj.emplace("excludedContexts",
-                boost::json::value_from(segment.excludedContexts));
-    obj.emplace("included", boost::json::value_from(segment.included));
-    obj.emplace("includedContexts",
-                boost::json::value_from(segment.includedContexts));
+    WriteMinimal(obj, "rules", segment.rules);
+    WriteMinimal(obj, "excluded", segment.excluded);
+    WriteMinimal(obj, "excludedContexts", segment.excludedContexts);
+    WriteMinimal(obj, "included", segment.included);
+    WriteMinimal(obj, "includedContexts", segment.includedContexts);
 }
 
 void tag_invoke(boost::json::value_from_tag const& unused,

--- a/libs/internal/tests/data_model_serialization_test.cpp
+++ b/libs/internal/tests/data_model_serialization_test.cpp
@@ -600,9 +600,13 @@ TEST(FlagTests, SerializeAll) {
           },
           24,
           ContextKind("bob")}},  // contextTargets
-        {},                      // rules
-        84,                      // offVariation
-        true,                    // clientSide
+        {data_model::Flag::Rule{{data_model::Clause{data_model::Clause::Op::kIn,
+                                                    {"bob"},
+                                                    false,
+                                                    ContextKind{"user"},
+                                                    "name"}}}},  // rules
+        84,                                                      // offVariation
+        true,                                                    // clientSide
         data_model::Flag::ClientSideAvailability{true, true},
         "4242",  // salt
         true,    // trackEvents
@@ -623,7 +627,7 @@ TEST(FlagTests, SerializeAll) {
             "key":"the-key",
             "version":21,
             "variations":["a","b"],
-            "rules":[],
+            "rules":[{"clauses":[{"op":"in","values":["bob"],"contextKind":"user","attribute":"name"}]}],
             "prerequisites":[{"key":"prereqA","variation":2},
                 {"key":"prereqB","variation":3}],
             "fallthrough":{"variation":42},
@@ -739,12 +743,7 @@ TEST(SegmentTests, SerializeUnbounded) {
         R"({
             "key": "my-segment",
             "version": 87,
-            "included": [],
-            "excluded": [],
-            "includedContexts": [],
-            "excludedContexts": [],
             "salt": "salty",
-            "rules":[],
             "unbounded": true,
             "unboundedContextKind": "company",
             "generation": 12


### PR DESCRIPTION
The server-side SDK is able to treat missing JSON fields as empty ones in-memory. 

For example, in a segment if `included` was missing then the SDK infers it's an empty array. 

This change makes the SDK write out data using that same logic. If an in-memory field is conceptually empty, then omit it from the written data. 

This is an optimization, so I haven't audited all data models to enforce this behavior - the places I've updated are things I'm using in unit tests where I'd like to omit missing (irrelevant for the test) fields. 