### PR TITLE
chore(deps): bump nlohmann/json from 3.11.2 to 3.11.3

### DIFF
--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -10,7 +10,7 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
 endif ()
 
 FetchContent_Declare(json
-        URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
-        )
+        URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
 
 FetchContent_MakeAvailable(json)


### PR DESCRIPTION
Resolves a longstanding cmake bug in nlohmann/json. 