### PR TITLE
fix: use insert_or_assign in expiration tracker

### DIFF
--- a/libs/server-sdk/src/data_components/expiration_tracker/expiration_tracker.cpp
+++ b/libs/server-sdk/src/data_components/expiration_tracker/expiration_tracker.cpp
@@ -5,7 +5,7 @@
 namespace launchdarkly::server_side::data_components {
 
 void ExpirationTracker::Add(std::string const& key, TimePoint expiration) {
-    unscoped_.insert({key, expiration});
+    unscoped_.insert_or_assign(key, expiration);
 }
 
 void ExpirationTracker::Remove(std::string const& key) {
@@ -87,8 +87,9 @@ ExpirationTracker::TrackState ExpirationTracker::State(TimePoint expiration,
 void ExpirationTracker::ScopedTtls::Set(DataKind kind,
                                         std::string const& key,
                                         TimePoint expiration) {
-    data_[static_cast<std::underlying_type_t<DataKind>>(kind)].Data().insert(
-        {key, expiration});
+    data_[static_cast<std::underlying_type_t<DataKind>>(kind)]
+        .Data()
+        .insert_or_assign(key, expiration);
 }
 
 void ExpirationTracker::ScopedTtls::Remove(DataKind kind,

--- a/libs/server-sdk/tests/expiration_tracker_test.cpp
+++ b/libs/server-sdk/tests/expiration_tracker_test.cpp
@@ -119,3 +119,17 @@ TEST(ExpirationTrackerTest, CanPrune) {
     EXPECT_EQ(ExpirationTracker::TrackState::kFresh,
               tracker.State(DataKind::kSegment, "freshSegment", Second(80)));
 }
+
+TEST(ExpirationTrackerTest, CanUpdateExistingExpiry) {
+    ExpirationTracker tracker;
+
+    for (std::size_t seconds = 1; seconds < 10; seconds++) {
+        auto const now = Second(seconds - 1);
+        auto const expiry = Second(seconds);
+
+        tracker.Add("Potato", expiry);
+        EXPECT_EQ(ExpirationTracker::TrackState::kFresh,
+                  tracker.State("Potato", now));
+        ASSERT_TRUE(tracker.Prune(now).empty());
+    }
+}


### PR DESCRIPTION
Current usage of `assign` will be a no-op if the expiry for an existing item is added.