### PR TITLE
feat: redis source 1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,11 +77,11 @@ jobs:
         os: [ ubuntu-latest, windows-2022, macos-12 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
-    if: ${{ needs.release-please.outputs.package-server-released }}
+    if: ${{ needs.release-please.outputs.package-server-redis-released }}
     outputs:
-      hashes-linux: ${{ steps.release-server.outputs.hashes-linux }}
-      hashes-windows: ${{ steps.release-server.outputs.hashes-windows }}
-      hashes-macos: ${{ steps.release-server.outputs.hashes-macos }}
+      hashes-linux: ${{ steps.release-server-redis.outputs.hashes-linux }}
+      hashes-windows: ${{ steps.release-server-redis.outputs.hashes-windows }}
+      hashes-macos: ${{ steps.release-server-redis.outputs.hashes-macos }}
     steps:
       - uses: actions/checkout@v3
       - id: release-server-redis

--- a/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_source.hpp
+++ b/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_source.hpp
@@ -63,7 +63,8 @@ class RedisDataSource final : public ISerializedDataReader {
     RedisDataSource(std::unique_ptr<sw::redis::Redis> redis,
                     std::string prefix);
 
-    std::string key_for_kind(ISerializedItemKind const& kind) const;
+    [[nodiscard]] std::string key_for_kind(
+        ISerializedItemKind const& kind) const;
 
     std::string const prefix_;
     std::string const inited_key_;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,9 +24,7 @@
       "extra-files": [
         "CMakeLists.txt"
       ],
-      "prerelease": true,
-      "release-as": "0.1.0",
-      "bump-minor-pre-major": true
+      "release-as": "1.0.0"
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
This sets `release-as: 1.0` for the Redis source.

It also fixes a copy/paste error in `release-please.yml` that caused the Redis Source to attempt to run a release when it wasn't necessary.

I've made a arbitrary but useful change in `redis_source.hpp` so it's a releasable unit.