### PR TITLE
ci: use shared lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -8,10 +8,5 @@ on:
       - synchronize
 
 jobs:
-  main:
-    name: Verify the PR title matches conventional commit spec.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  lint-pr-title:
+    uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
Use launchdarkly lint-pr-title workflow.