### PR TITLE
feat: add C bindings for getting log levels

### DIFF
--- a/libs/common/include/launchdarkly/bindings/c/config/logging_builder.h
+++ b/libs/common/include/launchdarkly/bindings/c/config/logging_builder.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <launchdarkly/bindings/c/logging/log_level.h>
+
 #include <launchdarkly/bindings/c/export.h>
 #include <launchdarkly/bindings/c/status.h>
 
@@ -16,17 +18,6 @@ extern "C" {  // only need to export C interface if
 
 typedef struct _LDLoggingBasicBuilder* LDLoggingBasicBuilder;
 typedef struct _LDLoggingCustomBuilder* LDLoggingCustomBuilder;
-
-/**
- * Defines the log levels used with the SDK's default logger, or a user-provided
- * custom logger.
- */
-enum LDLogLevel {
-    LD_LOG_DEBUG = 0,
-    LD_LOG_INFO = 1,
-    LD_LOG_WARN = 2,
-    LD_LOG_ERROR = 3,
-};
 
 typedef bool (*EnabledFn)(enum LDLogLevel level, void* user_data);
 typedef void (*WriteFn)(enum LDLogLevel level,

--- a/libs/common/include/launchdarkly/bindings/c/logging/log_level.h
+++ b/libs/common/include/launchdarkly/bindings/c/logging/log_level.h
@@ -1,0 +1,34 @@
+/** @file */
+// NOLINTBEGIN modernize-use-using
+
+#pragma once
+
+#include <launchdarkly/bindings/c/export.h>
+#include <launchdarkly/bindings/c/status.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {  // only need to export C interface if
+// used by C++ source code
+#endif
+
+/**
+ * Defines the log levels used with the SDK's default logger, or a user-provided
+ * custom logger.
+ */
+enum LDLogLevel {
+    LD_LOG_DEBUG = 0,
+    LD_LOG_INFO = 1,
+    LD_LOG_WARN = 2,
+    LD_LOG_ERROR = 3,
+};
+
+LD_EXPORT(char const*) LDLogLevel_Name(enum LDLogLevel level);
+
+#ifdef __cplusplus
+}
+#endif
+
+// NOLINTEND modernize-use-using

--- a/libs/common/include/launchdarkly/bindings/c/logging/log_level.h
+++ b/libs/common/include/launchdarkly/bindings/c/logging/log_level.h
@@ -25,7 +25,25 @@ enum LDLogLevel {
     LD_LOG_ERROR = 3,
 };
 
-LD_EXPORT(char const*) LDLogLevel_Name(enum LDLogLevel level);
+/**
+ * Lookup the name of a LDLogLevel.
+ * @param level Target level.
+ * @param level_if_unknown Default name to return if the level wasn't
+ * recognized.
+ * @return Name of the level as a string, or level_if_unknown if not recognized.
+ */
+LD_EXPORT(char const*)
+LDLogLevel_Name(enum LDLogLevel level, char const* level_if_unknown);
+
+/**
+ * Lookup a LDLogLevel by name.
+ * @param level Name of level.
+ * @param level_if_unknown Default level to return if the level wasn't
+ * recognized.
+ * @return LDLogLevel matching the name, or level_if_unknown if not recognized.
+ */
+LD_EXPORT(enum LDLogLevel)
+LDLogLevel_Enum(char const* level, enum LDLogLevel level_if_unknown);
 
 #ifdef __cplusplus
 }

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${LIBNAME} OBJECT
         bindings/c/flag_listener.cpp
         bindings/c/memory_routines.cpp
         bindings/c/data_source/error_info.cpp
+        bindings/c/logging/log_level.cpp
         log_level.cpp
         config/persistence_builder.cpp
         config/logging_builder.cpp

--- a/libs/common/src/bindings/c/logging/log_level.cpp
+++ b/libs/common/src/bindings/c/logging/log_level.cpp
@@ -2,7 +2,14 @@
 
 #include <launchdarkly/logging/log_level.hpp>
 
-LD_EXPORT(char const*) LDLogLevel_Name(enum LDLogLevel level) {
+LD_EXPORT(char const*)
+LDLogLevel_Name(LDLogLevel level, char const* name_if_unknown) {
     return GetLogLevelName(static_cast<launchdarkly::LogLevel>(level),
-                           "unknown");
+                           name_if_unknown);
+}
+
+LD_EXPORT(LDLogLevel)
+LDLogLevel_Enum(char const* level, LDLogLevel level_if_unknown) {
+    return static_cast<LDLogLevel>(GetLogLevelEnum(
+        level, static_cast<launchdarkly::LogLevel>(level_if_unknown)));
 }

--- a/libs/common/src/bindings/c/logging/log_level.cpp
+++ b/libs/common/src/bindings/c/logging/log_level.cpp
@@ -1,0 +1,8 @@
+#include <launchdarkly/bindings/c/logging/log_level.h>
+
+#include <launchdarkly/logging/log_level.hpp>
+
+LD_EXPORT(char const*) LDLogLevel_Name(enum LDLogLevel level) {
+    return GetLogLevelName(static_cast<launchdarkly::LogLevel>(level),
+                           "unknown");
+}


### PR DESCRIPTION
This adds bindings for retrieving the log level name or enum value from a string. It was already present in C++ but missing in C.

Needed for Lua bindings.