### PR TITLE
fix: double variation was returning ints

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/sdk.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/sdk.h
@@ -303,7 +303,7 @@ LDServerSDK_IntVariationDetail(LDServerSDK sdk,
  * @return The variation for the given context, or default_value if the
  * flag is disabled in the LaunchDarkly control panel.
  */
-LD_EXPORT(int)
+LD_EXPORT(double)
 LDServerSDK_DoubleVariation(LDServerSDK sdk,
                             LDContext context,
                             char const* flag_key,
@@ -322,7 +322,7 @@ LDServerSDK_DoubleVariation(LDServerSDK sdk,
  * @return The variation for the given context, or default_value if the
  * flag is disabled in the LaunchDarkly control panel.
  */
-LD_EXPORT(int)
+LD_EXPORT(double)
 LDServerSDK_DoubleVariationDetail(LDServerSDK sdk,
                                   LDContext context,
                                   char const* flag_key,

--- a/libs/server-sdk/src/bindings/c/sdk.cpp
+++ b/libs/server-sdk/src/bindings/c/sdk.cpp
@@ -26,8 +26,7 @@ struct Detail;
 
 #define FROM_DETAIL(ptr) (reinterpret_cast<LDEvalDetail>(ptr))
 
-#define TO_DATASOURCESTATUS(ptr) \
-    (reinterpret_cast<DataSourceStatus*>(ptr))
+#define TO_DATASOURCESTATUS(ptr) (reinterpret_cast<DataSourceStatus*>(ptr))
 
 #define FROM_DATASOURCESTATUS(ptr) \
     (reinterpret_cast<LDServerDataSourceStatus>(ptr))
@@ -260,7 +259,7 @@ LDServerSDK_IntVariationDetail(LDServerSDK sdk,
     });
 }
 
-LD_EXPORT(int)
+LD_EXPORT(double)
 LDServerSDK_DoubleVariation(LDServerSDK sdk,
                             LDContext context,
                             char const* flag_key,
@@ -273,7 +272,7 @@ LDServerSDK_DoubleVariation(LDServerSDK sdk,
                                         default_value);
 }
 
-LD_EXPORT(int)
+LD_EXPORT(double)
 LDServerSDK_DoubleVariationDetail(LDServerSDK sdk,
                                   LDContext context,
                                   char const* flag_key,

--- a/libs/server-sdk/tests/client_test.cpp
+++ b/libs/server-sdk/tests/client_test.cpp
@@ -52,7 +52,8 @@ TEST_F(ClientTest, IntVariationDefaultPassesThrough) {
 
 TEST_F(ClientTest, DoubleVariationDefaultPassesThrough) {
     std::string const flag = "weight";
-    std::vector<double> values = {0.0, 12.0, 13.0, 24.0, 1000.0};
+    std::vector<double> values = {0.0,  0.0001, 0.5,  1.234,
+                                  12.0, 13.0,   24.0, 1000.0};
     for (auto const& v : values) {
         ASSERT_EQ(client_.DoubleVariation(context_, flag, v), v);
         ASSERT_EQ(*client_.DoubleVariationDetail(context_, flag, v), v);

--- a/libs/server-sdk/tests/server_c_bindings_test.cpp
+++ b/libs/server-sdk/tests/server_c_bindings_test.cpp
@@ -184,4 +184,5 @@ TEST(ClientBindings, DoubleVariationPassesThroughDefault) {
     }
 
     LDServerSDK_Free(sdk);
+    LDContext_Free(context);
 }

--- a/libs/server-sdk/tests/server_c_bindings_test.cpp
+++ b/libs/server-sdk/tests/server_c_bindings_test.cpp
@@ -159,3 +159,29 @@ TEST(ClientBindings, AllFlagsState) {
     LDContext_Free(context);
     LDServerSDK_Free(sdk);
 }
+
+TEST(ClientBindings, DoubleVariationPassesThroughDefault) {
+    LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
+
+    LDServerConfig config;
+    LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+    ASSERT_TRUE(LDStatus_Ok(status));
+
+    LDServerSDK sdk = LDServerSDK_New(config);
+
+    LDContextBuilder ctx_builder = LDContextBuilder_New();
+    LDContextBuilder_AddKind(ctx_builder, "user", "shadow");
+    LDContext context = LDContextBuilder_Build(ctx_builder);
+
+    std::string const flag = "weight";
+    std::vector<double> values = {0.0,  0.0001, 0.5,  1.234,
+                                  12.9, 13.211, 24.0, 1000.0};
+    for (auto const& v : values) {
+        ASSERT_EQ(LDServerSDK_DoubleVariation(sdk, context, "weight", v), v);
+        ASSERT_EQ(LDServerSDK_DoubleVariationDetail(sdk, context, "weight", v,
+                                                    LD_DISCARD_DETAIL),
+                  v);
+    }
+
+    LDServerSDK_Free(sdk);
+}


### PR DESCRIPTION
The C bindings for `DoubleVariation/Detail` were returning `int` instead of `double`. 

Since this is totally wrong, I'm regarding it as a bugfix rather than as a breaking change. 