### PR TITLE
ci: remove 'release-as' from server and server-redis-source

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,14 +17,12 @@
         "tests/server_c_bindings_test.cpp",
         "tests/client_test.cpp",
         "CMakeLists.txt"
-      ],
-      "release-as": "3.0.0"
+      ]
     },
     "libs/server-sdk-redis-source": {
       "extra-files": [
         "CMakeLists.txt"
-      ],
-      "release-as": "1.0.0"
+      ]
     },
     "libs/server-sent-events": {
       "initial-version": "0.1.0"


### PR DESCRIPTION
Now that both server 3.0 and redis-source 1.0 are released, these fields should be removed.