### PR TITLE
feat: allow LDStatus to carry an arbitrary string message

### DIFF
--- a/libs/common/include/launchdarkly/bindings/c/status.h
+++ b/libs/common/include/launchdarkly/bindings/c/status.h
@@ -7,37 +7,38 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {  // only need to export C interface if
+extern "C" {
+// only need to export C interface if
 // used by C++ source code
 #endif
 
 typedef struct _LDStatus* LDStatus;
 
 /**
- * Returns a string representing the error stored in an LDStatus, or
- * NULL if the result indicates success.
- * @param error Result to inspect.
- * @return String or NULL. The returned string is valid only while the LDStatus
+ * Returns a string describing the error reported by the LDStatus, or
+ * NULL if the status indicates success.
+ * @param status Status to inspect.
+ * @return String or NULL. The string is valid only while the LDStatus
  * is alive.
  */
-LD_EXPORT(char const*) LDStatus_Error(LDStatus res);
+LD_EXPORT(char const*) LDStatus_Error(LDStatus status);
 
 /**
- * Checks if a result indicates success.
- * @param result Result to inspect.
- * @return True if the result indicates success.
+ * Checks if the status indicates successful operation.
+ * @param status Status to inspect.
+ * @return True if the status indicates success.
  */
-LD_EXPORT(bool) LDStatus_Ok(LDStatus res);
+LD_EXPORT(bool) LDStatus_Ok(LDStatus status);
 
 /**
- * Frees an LDStatus. It is only necessary to call LDStatus_Free if LDStatus_Ok
+ * Frees an LDStatus. You must call LDStatus_Free if LDStatus_Ok
  * returns false.
- * @param res Result to free.
+ * @param status Status to free.
  */
-LD_EXPORT(void) LDStatus_Free(LDStatus res);
+LD_EXPORT(void) LDStatus_Free(LDStatus status);
 
 /**
- * Returns a status representing success.
+ * Creates a status representing successful operation.
  * @return Successful status.
  */
 LD_EXPORT(LDStatus) LDStatus_Success(void);

--- a/libs/common/include/launchdarkly/detail/c_binding_helpers.hpp
+++ b/libs/common/include/launchdarkly/detail/c_binding_helpers.hpp
@@ -9,21 +9,25 @@
 
 namespace launchdarkly::detail {
 template <typename T, typename = void>
-struct has_result_type : std::false_type {};
+struct has_result_type : std::false_type {
+};
 
 template <typename T>
-struct has_result_type<T, std::void_t<typename T::Result>> : std::true_type {};
+struct has_result_type<T, std::void_t<typename T::Result>> : std::true_type {
+};
 
 template <typename T, typename ReturnType, typename = void>
-struct has_build_method : std::false_type {};
+struct has_build_method : std::false_type {
+};
 
 template <typename T, typename ReturnType>
 struct has_build_method<T,
                         ReturnType,
                         std::void_t<decltype(std::declval<T>().Build())>>
     : std::integral_constant<
-          bool,
-          std::is_same_v<decltype(std::declval<T>().Build()), ReturnType>> {};
+        bool,
+        std::is_same_v<decltype(std::declval<T>().Build()), ReturnType>> {
+};
 
 // NOLINTBEGIN cppcoreguidelines-pro-type-reinterpret-cast
 
@@ -39,7 +43,7 @@ template <typename Builder, typename OpaqueBuilder, typename OpaqueResult>
 LDStatus ConsumeBuilder(OpaqueBuilder opaque_builder,
                         OpaqueResult* out_result) {
     using ReturnType =
-        tl::expected<typename Builder::Result, launchdarkly::Error>;
+        tl::expected<typename Builder::Result, Error>;
 
     static_assert(has_result_type<Builder>::value,
                   "Builder must have an associated type named Result");
@@ -51,14 +55,14 @@ LDStatus ConsumeBuilder(OpaqueBuilder opaque_builder,
 
     auto builder = reinterpret_cast<Builder*>(opaque_builder);
 
-    tl::expected<typename Builder::Result, launchdarkly::Error> res =
+    tl::expected<typename Builder::Result, Error> res =
         builder->Build();
 
     delete builder;
 
     if (!res) {
         *out_result = nullptr;
-        return reinterpret_cast<LDStatus>(new launchdarkly::Error(res.error()));
+        return reinterpret_cast<LDStatus>(new Error(res.error()));
     }
 
     *out_result = reinterpret_cast<OpaqueResult>(
@@ -105,6 +109,5 @@ bool OptReturnReinterpretCast(std::optional<OptType>& opt,
 #endif
 
 #define LD_ASSERT_NOT_NULL(param) LD_ASSERT(param != nullptr)
-
-}  // namespace launchdarkly::detail
+} // namespace launchdarkly::detail
 // NOLINTEND cppcoreguidelines-pro-type-reinterpret-cast

--- a/libs/common/include/launchdarkly/error.hpp
+++ b/libs/common/include/launchdarkly/error.hpp
@@ -3,10 +3,11 @@
 #include <cstdint>
 #include <limits>
 #include <ostream>
+#include <variant>
+#include <string>
 
 namespace launchdarkly {
-
-enum class Error : std::uint32_t {
+enum class ErrorCode : std::uint32_t {
     KReserved1 = 0,
     KReserved2 = 1,
     /* Common lib errors: 2-9999 */
@@ -27,7 +28,11 @@ enum class Error : std::uint32_t {
     kMax = std::numeric_limits<std::uint32_t>::max()
 };
 
-char const* ErrorToString(Error err);
-std::ostream& operator<<(std::ostream& os, Error const& err);
+using Error = std::variant<ErrorCode, std::string>;
 
-}  // namespace launchdarkly
+bool operator==(Error const& lhs, ErrorCode const& rhs);
+
+
+char const* ErrorToString(Error const& err);
+std::ostream& operator<<(std::ostream& os, Error const& err);
+} // namespace launchdarkly

--- a/libs/common/src/bindings/c/status.cpp
+++ b/libs/common/src/bindings/c/status.cpp
@@ -7,27 +7,27 @@
 
 using namespace launchdarkly;
 
-#define TO_ERROR(ptr) (reinterpret_cast<Error*>(ptr))
+#define TO_STATUS(ptr) (reinterpret_cast<Error*>(ptr))
 
-LD_EXPORT(char const*) LDStatus_Error(LDStatus res) {
-    if (Error* e = TO_ERROR(res)) {
+LD_EXPORT(char const*) LDStatus_Error(LDStatus const status) {
+    if (Error const* e = TO_STATUS(status)) {
         return ErrorToString(*e);
     }
     return nullptr;
 }
 
-LD_EXPORT(bool) LDStatus_Ok(LDStatus res) {
-    if (TO_ERROR(res) == nullptr) {
+LD_EXPORT(bool) LDStatus_Ok(LDStatus const status) {
+    if (TO_STATUS(status) == nullptr) {
         return true;
     }
     return false;
 }
 
-LD_EXPORT(void) LDStatus_Free(LDStatus error) {
-    delete TO_ERROR(error);
+LD_EXPORT(void) LDStatus_Free(LDStatus const error) {
+    delete TO_STATUS(error);
 }
 
-LD_EXPORT(LDStatus) LDStatus_Success(void) {
+LD_EXPORT(LDStatus) LDStatus_Success() {
     return nullptr;
 }
 

--- a/libs/common/src/config/app_info_builder.cpp
+++ b/libs/common/src/config/app_info_builder.cpp
@@ -6,12 +6,12 @@
 #include <cctype>
 
 namespace launchdarkly::config::shared::builders {
-
 // Defines the maximum character length for an Application Tag value.
 constexpr std::size_t kMaxTagValueLength = 64;
 
 AppInfoBuilder::Tag::Tag(std::string key, std::string value)
-    : key(std::move(key)), value(std::move(value)) {}
+    : key(std::move(key)), value(std::move(value)) {
+}
 
 tl::expected<std::string, Error> AppInfoBuilder::Tag::Build() const {
     if (auto err = IsValidTag(key, value)) {
@@ -33,16 +33,16 @@ bool ValidChar(char c) {
 std::optional<Error> IsValidTag(std::string const& key,
                                 std::string const& value) {
     if (value.empty() || key.empty()) {
-        return Error::kConfig_ApplicationInfo_EmptyKeyOrValue;
+        return ErrorCode::kConfig_ApplicationInfo_EmptyKeyOrValue;
     }
     if (value.length() > kMaxTagValueLength) {
-        return Error::kConfig_ApplicationInfo_ValueTooLong;
+        return ErrorCode::kConfig_ApplicationInfo_ValueTooLong;
     }
     if (!std::all_of(key.begin(), key.end(), ValidChar)) {
-        return Error::kConfig_ApplicationInfo_InvalidKeyCharacters;
+        return ErrorCode::kConfig_ApplicationInfo_InvalidKeyCharacters;
     }
     if (!std::all_of(value.begin(), value.end(), ValidChar)) {
-        return Error::kConfig_ApplicationInfo_InvalidValueCharacters;
+        return ErrorCode::kConfig_ApplicationInfo_InvalidValueCharacters;
     }
     return std::nullopt;
 }
@@ -51,6 +51,7 @@ AppInfoBuilder& AppInfoBuilder::AddTag(std::string key, std::string value) {
     tags_.emplace_back(std::move(key), std::move(value));
     return *this;
 }
+
 AppInfoBuilder& AppInfoBuilder::Identifier(std::string app_id) {
     return AddTag("application-id", std::move(app_id));
 }
@@ -96,5 +97,4 @@ std::optional<std::string> AppInfoBuilder::Build() const {
     // Concatenate with space as the delimiter.
     return boost::algorithm::join(validated, " ");
 }
-
-}  // namespace launchdarkly::config::shared::builders
+} // namespace launchdarkly::config::shared::builders

--- a/libs/common/src/config/config_builder.cpp
+++ b/libs/common/src/config/config_builder.cpp
@@ -56,7 +56,7 @@ template <typename SDK>
 ConfigBuilder<SDK>::Build() const {
     auto sdk_key = sdk_key_;
     if (sdk_key.empty()) {
-        return tl::make_unexpected(Error::kConfig_SDKKey_Empty);
+        return tl::make_unexpected(ErrorCode::kConfig_SDKKey_Empty);
     }
     auto offline = offline_.value_or(Defaults<SDK>::Offline());
     auto endpoints_config = service_endpoints_builder_.Build();

--- a/libs/common/src/config/endpoints_builder.cpp
+++ b/libs/common/src/config/endpoints_builder.cpp
@@ -4,18 +4,19 @@
 #include <utility>
 
 namespace launchdarkly::config::shared::builders {
-
 template <typename SDK>
 EndpointsBuilder<SDK>& EndpointsBuilder<SDK>::PollingBaseUrl(std::string url) {
     polling_base_url_ = std::move(url);
     return *this;
 }
+
 template <typename SDK>
 EndpointsBuilder<SDK>& EndpointsBuilder<SDK>::StreamingBaseUrl(
     std::string url) {
     streaming_base_url_ = std::move(url);
     return *this;
 }
+
 template <typename SDK>
 EndpointsBuilder<SDK>& EndpointsBuilder<SDK>::EventsBaseUrl(std::string url) {
     events_base_url_ = std::move(url);
@@ -44,11 +45,11 @@ bool empty_string(std::optional<std::string> const& opt_string) {
 
 template <typename SDK>
 tl::expected<built::ServiceEndpoints, Error> EndpointsBuilder<SDK>::Build()
-    const {
+const {
     // Empty URLs are not allowed.
     if (empty_string(polling_base_url_) || empty_string(streaming_base_url_) ||
         empty_string(events_base_url_)) {
-        return tl::unexpected(Error::kConfig_Endpoints_EmptyURL);
+        return tl::unexpected(ErrorCode::kConfig_Endpoints_EmptyURL);
     }
 
     // If no URLs were set, return the default endpoints for this SDK.
@@ -69,7 +70,7 @@ tl::expected<built::ServiceEndpoints, Error> EndpointsBuilder<SDK>::Build()
     }
 
     // Otherwise if a subset of URLs were set, this is an error.
-    return tl::unexpected(Error::kConfig_Endpoints_AllURLsMustBeSet);
+    return tl::unexpected(ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 }
 
 template <typename SDK>
@@ -88,5 +89,4 @@ template bool operator==(EndpointsBuilder<config::shared::ClientSDK> const&,
 
 template bool operator==(EndpointsBuilder<config::shared::ServerSDK> const&,
                          EndpointsBuilder<config::shared::ServerSDK> const&);
-
-}  // namespace launchdarkly::config::shared::builders
+} // namespace launchdarkly::config::shared::builders

--- a/libs/common/src/config/events_builder.cpp
+++ b/libs/common/src/config/events_builder.cpp
@@ -55,7 +55,7 @@ EventsBuilder<SDK>& EventsBuilder<SDK>::PrivateAttribute(
 template <typename SDK>
 tl::expected<built::Events, Error> EventsBuilder<SDK>::Build() const {
     if (config_.Capacity() == 0) {
-        return tl::unexpected(Error::kConfig_Events_ZeroCapacity);
+        return tl::unexpected(ErrorCode::kConfig_Events_ZeroCapacity);
     }
     return config_;
 }

--- a/libs/common/src/error.cpp
+++ b/libs/common/src/error.cpp
@@ -1,40 +1,65 @@
 #include <launchdarkly/error.hpp>
 
 namespace launchdarkly {
-
 std::ostream& operator<<(std::ostream& os, Error const& err) {
     os << ErrorToString(err);
     return os;
 }
 
-char const* ErrorToString(Error err) {
+char const* ErrorCodeToString(ErrorCode const& err);
+
+template <class>
+inline constexpr bool always_false_v = false;
+
+char const* ErrorToString(Error const& err) {
+    return std::visit(
+        [](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, ErrorCode>) {
+                return ErrorCodeToString(arg);
+            } else if constexpr (std::is_same_v<T, std::string>) {
+                return arg.c_str();
+            } else {
+                static_assert(always_false_v<T>, "non-exhaustive visitor!");
+            }
+        }, err);
+}
+
+char const* ErrorCodeToString(ErrorCode const& err) {
     switch (err) {
-        case Error::KReserved1:
+        case ErrorCode::KReserved1:
             return "reserved1";
-        case Error::KReserved2:
+        case ErrorCode::KReserved2:
             return "reserved2";
-        case Error::kConfig_Endpoints_EmptyURL:
+        case ErrorCode::kConfig_Endpoints_EmptyURL:
             return "endpoints: cannot specify empty URL";
-        case Error::kConfig_Endpoints_AllURLsMustBeSet:
+        case ErrorCode::kConfig_Endpoints_AllURLsMustBeSet:
             return "endpoints: if any endpoint is specified, then all "
-                   "endpoints must be specified";
-        case Error::kConfig_ApplicationInfo_EmptyKeyOrValue:
+                "endpoints must be specified";
+        case ErrorCode::kConfig_ApplicationInfo_EmptyKeyOrValue:
             return "application info: cannot specify an empty key or value";
-        case Error::kConfig_ApplicationInfo_ValueTooLong:
+        case ErrorCode::kConfig_ApplicationInfo_ValueTooLong:
             return "application info: the specified value is too long";
-        case Error::kConfig_ApplicationInfo_InvalidKeyCharacters:
+        case ErrorCode::kConfig_ApplicationInfo_InvalidKeyCharacters:
             return "application info: the key contains invalid characters";
-        case Error::kConfig_ApplicationInfo_InvalidValueCharacters:
+        case ErrorCode::kConfig_ApplicationInfo_InvalidValueCharacters:
             return "application info: the value contains invalid characters";
-        case Error::kConfig_Events_ZeroCapacity:
+        case ErrorCode::kConfig_Events_ZeroCapacity:
             return "events: capacity must be non-zero";
-        case Error::kConfig_SDKKey_Empty:
+        case ErrorCode::kConfig_SDKKey_Empty:
             return "sdk key: cannot be empty";
-        case Error::kConfig_DataSystem_LazyLoad_MissingSource:
+        case ErrorCode::kConfig_DataSystem_LazyLoad_MissingSource:
             return "data system: lazy load config requires a source";
-        case Error::kMax:
+        case ErrorCode::kMax:
             break;
     }
     return "unknown";
 }
-}  // namespace launchdarkly
+
+bool operator==(Error const& lhs, ErrorCode const& rhs) {
+    if (auto const* err = std::get_if<ErrorCode>(&lhs)) {
+        return *err == rhs;
+    }
+    return false;
+}
+} // namespace launchdarkly

--- a/libs/common/tests/application_tags_test.cpp
+++ b/libs/common/tests/application_tags_test.cpp
@@ -8,47 +8,51 @@
 #include <launchdarkly/logging/null_logger.hpp>
 
 using launchdarkly::Error;
+using launchdarkly::ErrorCode;
 using launchdarkly::Logger;
 using launchdarkly::LogLevel;
 
 struct TagValidity {
     std::string key;
     std::string value;
-    std::optional<launchdarkly::Error> error;
+    std::optional<Error> error;
 };
 
-class TagValidityFixture : public ::testing::TestWithParam<TagValidity> {};
+class TagValidityFixture : public ::testing::TestWithParam<TagValidity> {
+};
 
 INSTANTIATE_TEST_SUITE_P(
     AppTagsTest,
     TagValidityFixture,
     testing::Values(
-        TagValidity{"", "abc", Error::kConfig_ApplicationInfo_EmptyKeyOrValue},
+        TagValidity{"", "abc", ErrorCode::
+        kConfig_ApplicationInfo_EmptyKeyOrValue},
         TagValidity{" ", "abc",
-                    Error::kConfig_ApplicationInfo_InvalidKeyCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidKeyCharacters},
         TagValidity{"/", "abc",
-                    Error::kConfig_ApplicationInfo_InvalidKeyCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidKeyCharacters},
         TagValidity{":", "abc",
-                    Error::kConfig_ApplicationInfo_InvalidKeyCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidKeyCharacters},
         TagValidity{"abcABC123.-_", "abc", std::nullopt},
-        TagValidity{"abc", "", Error::kConfig_ApplicationInfo_EmptyKeyOrValue},
+        TagValidity{"abc", "", ErrorCode::
+        kConfig_ApplicationInfo_EmptyKeyOrValue},
         TagValidity{"abc", " ",
-                    Error::kConfig_ApplicationInfo_InvalidValueCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidValueCharacters},
         TagValidity{"abc", "/",
-                    Error::kConfig_ApplicationInfo_InvalidValueCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidValueCharacters},
         TagValidity{"abc", ":",
-                    Error::kConfig_ApplicationInfo_InvalidValueCharacters},
+        ErrorCode::kConfig_ApplicationInfo_InvalidValueCharacters},
         TagValidity{"abc", "abcABC123.-_", std::nullopt},
         TagValidity{
-            "abc",
-            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl",
-            std::nullopt,
+        "abc",
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl",
+        std::nullopt,
         },
         TagValidity{
-            "abc",
-            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"
-            "klm",  // > 64 chars
-            Error::kConfig_ApplicationInfo_ValueTooLong}));
+        "abc",
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij"
+        "klm", // > 64 chars
+        ErrorCode::kConfig_ApplicationInfo_ValueTooLong}));
 
 TEST_P(TagValidityFixture, ValidTagValues) {
     using namespace launchdarkly::config::shared::builders;
@@ -65,7 +69,8 @@ struct TagBuild {
     std::string name;
 };
 
-class TagBuildFixture : public ::testing::TestWithParam<TagBuild> {};
+class TagBuildFixture : public ::testing::TestWithParam<TagBuild> {
+};
 
 auto const kInvalidTag = "!*@!#";
 
@@ -74,27 +79,27 @@ INSTANTIATE_TEST_SUITE_P(
     TagBuildFixture,
     testing::Values(
         TagBuild{std::nullopt, std::nullopt, std::nullopt,
-                 "no tags means no output"},
+        "no tags means no output"},
         TagBuild{"microservice-a", "1.0",
-                 "application-id/microservice-a application-version/1.0",
-                 "multiple tags are ordered correctly"},
+        "application-id/microservice-a application-version/1.0",
+        "multiple tags are ordered correctly"},
         TagBuild{"microservice-a", std::nullopt,
-                 "application-id/microservice-a",
-                 "single app id tag is output"},
+        "application-id/microservice-a",
+        "single app id tag is output"},
         TagBuild{std::nullopt, "1.0", "application-version/1.0",
-                 "single app version tag is output"},
+        "single app version tag is output"},
         TagBuild{kInvalidTag, std::nullopt, std::nullopt,
-                 "invalid tag is not output"},
+        "invalid tag is not output"},
         TagBuild{kInvalidTag, kInvalidTag, std::nullopt,
-                 "two invalid tags are not output"},
+        "two invalid tags are not output"},
         TagBuild{"microservice-a", kInvalidTag, "application-id/microservice-a",
-                 "presence of invalid tag does not prevent valid tag from "
-                 "being output"}),
+        "presence of invalid tag does not prevent valid tag from "
+        "being output"}),
     [](testing::TestParamInfo<TagBuild> const& info) {
-        std::string name = info.param.name;
-        std::replace_if(
-            name.begin(), name.end(), [](char c) { return c == ' '; }, '_');
-        return "test" + std::to_string(info.index) + "_" + name;
+    std::string name = info.param.name;
+    std::replace_if(
+        name.begin(), name.end(), [](char c) { return c == ' '; }, '_');
+    return "test" + std::to_string(info.index) + "_" + name;
     });
 
 TEST_P(TagBuildFixture, BuiltTags) {

--- a/libs/common/tests/bindings/status_test.cpp
+++ b/libs/common/tests/bindings/status_test.cpp
@@ -5,6 +5,7 @@
 #include "launchdarkly/bindings/c/status.h"
 
 // NOLINTBEGIN cppcoreguidelines-pro-type-reinterpret-cast
+using namespace launchdarkly;
 
 TEST(StatusBindingTests, StatusOk) {
     LDStatus status = LDStatus_Success();
@@ -13,15 +14,23 @@ TEST(StatusBindingTests, StatusOk) {
     LDStatus_Free(status);
 }
 
-TEST(StatusBindingTests, StatusError) {
-    using namespace launchdarkly;
-
-    Error err = Error::kConfig_SDKKey_Empty;
+TEST(StatusBindingTests, StatusErrorCode) {
+    Error err = ErrorCode::kConfig_SDKKey_Empty;
 
     auto status = reinterpret_cast<LDStatus>(new Error(err));
     ASSERT_FALSE(LDStatus_Ok(status));
     ASSERT_TRUE(LDStatus_Error(status));
     ASSERT_STREQ(LDStatus_Error(status), ErrorToString(err));
+    LDStatus_Free(status);
+}
+
+TEST(StatusBindingTests, StatusErrorString) {
+    auto status = reinterpret_cast<LDStatus>(new Error(
+        "this is an arbitrary error"));
+    ASSERT_FALSE(LDStatus_Ok(status));
+    ASSERT_TRUE(LDStatus_Error(status));
+    ASSERT_STRCASEEQ(LDStatus_Error(status),
+                     "this is an arbitrary error");
     LDStatus_Free(status);
 }
 

--- a/libs/common/tests/service_endpoints_test.cpp
+++ b/libs/common/tests/service_endpoints_test.cpp
@@ -20,15 +20,15 @@ TEST(ServiceEndpointTest, DefaultClientBuilderURLs) {
 TEST(ServiceEndpointTest, ModifySingleURLCausesError) {
     auto result = client_side::EndpointsBuilder().PollingBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 
     result = client_side::EndpointsBuilder().StreamingBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 
     result = client_side::EndpointsBuilder().EventsBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 }
 
 TEST(ServiceEndpointsTest, RelaySetsAllURLS) {
@@ -66,7 +66,7 @@ TEST(ServiceEndpointsTest, TrimsTrailingSlashes) {
 TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
     auto result = client_side::EndpointsBuilder().RelayProxyBaseURL("").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = client_side::EndpointsBuilder()
                  .StreamingBaseUrl("")
@@ -74,7 +74,7 @@ TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
                  .PollingBaseUrl("bar")
                  .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = client_side::EndpointsBuilder()
                  .StreamingBaseUrl("foo")
@@ -82,7 +82,7 @@ TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
                  .PollingBaseUrl("bar")
                  .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = client_side::EndpointsBuilder()
                  .StreamingBaseUrl("foo")
@@ -90,5 +90,5 @@ TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
                  .PollingBaseUrl("")
                  .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 }

--- a/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_primitives.hpp
@@ -10,7 +10,6 @@
 #include <unordered_map>
 
 namespace launchdarkly {
-
 template <typename T>
 tl::expected<std::optional<std::vector<T>>, JsonError> tag_invoke(
     boost::json::value_to_tag<
@@ -68,7 +67,7 @@ template <typename K, typename V>
 tl::expected<std::optional<std::unordered_map<K, V>>, JsonError> tag_invoke(
     boost::json::value_to_tag<
         tl::expected<std::optional<std::unordered_map<K, V>>, JsonError>> const&
-        unused,
+    unused,
     boost::json::value const& json_value) {
     boost::ignore_unused(unused);
 
@@ -117,5 +116,4 @@ tl::expected<T, JsonError> tag_invoke(
     }
     return maybe_val.value().value_or(T());
 }
-
-}  // namespace launchdarkly
+} // namespace launchdarkly

--- a/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
+++ b/libs/server-sdk/src/config/builders/data_system/lazy_load_builder.cpp
@@ -25,7 +25,7 @@ LazyLoadBuilder& LazyLoadBuilder::Source(SourcePtr source) {
 tl::expected<built::LazyLoadConfig, Error> LazyLoadBuilder::Build() const {
     if (!config_.source) {
         return tl::make_unexpected(
-            Error::kConfig_DataSystem_LazyLoad_MissingSource);
+            ErrorCode::kConfig_DataSystem_LazyLoad_MissingSource);
     }
     return config_;
 }

--- a/libs/server-sdk/src/config/config_builder.cpp
+++ b/libs/server-sdk/src/config/config_builder.cpp
@@ -37,7 +37,7 @@ ConfigBuilder& ConfigBuilder::Offline(bool const offline) {
 tl::expected<Config, Error> ConfigBuilder::Build() const {
     auto sdk_key = sdk_key_;
     if (sdk_key.empty()) {
-        return tl::make_unexpected(Error::kConfig_SDKKey_Empty);
+        return tl::make_unexpected(ErrorCode::kConfig_SDKKey_Empty);
     }
 
     auto endpoints_config = service_endpoints_builder_.Build();

--- a/libs/server-sdk/tests/service_endpoint_builders_test.cpp
+++ b/libs/server-sdk/tests/service_endpoint_builders_test.cpp
@@ -4,7 +4,9 @@
 #include <launchdarkly/server_side/config/builders/all_builders.hpp>
 
 using namespace launchdarkly::server_side::config::builders;
-using Error = launchdarkly::Error;
+
+using launchdarkly::Error;
+using launchdarkly::ErrorCode;
 
 TEST(ServiceEndpointTest, DefaultServerBuilderURLs) {
     EndpointsBuilder builder;
@@ -18,15 +20,15 @@ TEST(ServiceEndpointTest, DefaultServerBuilderURLs) {
 TEST(ServiceEndpointTest, ModifySingleURLCausesError) {
     auto result = EndpointsBuilder().PollingBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 
     result = EndpointsBuilder().StreamingBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 
     result = EndpointsBuilder().EventsBaseUrl("foo").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_AllURLsMustBeSet);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_AllURLsMustBeSet);
 }
 
 TEST(ServiceEndpointsTest, RelaySetsAllURLS) {
@@ -60,29 +62,29 @@ TEST(ServiceEndpointsTest, TrimsTrailingSlashes) {
 TEST(ServiceEndpointsTest, EmptyURLsAreInvalid) {
     auto result = EndpointsBuilder().RelayProxyBaseURL("").Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = EndpointsBuilder()
-                 .StreamingBaseUrl("")
-                 .EventsBaseUrl("foo")
-                 .PollingBaseUrl("bar")
-                 .Build();
+             .StreamingBaseUrl("")
+             .EventsBaseUrl("foo")
+             .PollingBaseUrl("bar")
+             .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = EndpointsBuilder()
-                 .StreamingBaseUrl("foo")
-                 .EventsBaseUrl("")
-                 .PollingBaseUrl("bar")
-                 .Build();
+             .StreamingBaseUrl("foo")
+             .EventsBaseUrl("")
+             .PollingBaseUrl("bar")
+             .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 
     result = EndpointsBuilder()
-                 .StreamingBaseUrl("foo")
-                 .EventsBaseUrl("bar")
-                 .PollingBaseUrl("")
-                 .Build();
+             .StreamingBaseUrl("foo")
+             .EventsBaseUrl("bar")
+             .PollingBaseUrl("")
+             .Build();
     ASSERT_FALSE(result);
-    ASSERT_EQ(result.error(), Error::kConfig_Endpoints_EmptyURL);
+    ASSERT_EQ(result.error(), ErrorCode::kConfig_Endpoints_EmptyURL);
 }


### PR DESCRIPTION
Our C bindings return `LDStatus`, which wraps an `Error` enum. This is an opaque type so that we could modify how the error was represented.

That time has come, and I've modified the underlying `Error` type to be a `variant<ErrorCode, string>`. This supports reporting arbitrary string messages. The immediate use case is reporting errors from the Redis integration, which doesn't use status codes.
