### PR TITLE
docs: fix incorrect time unit on LDServerDataSourcePollBuilder_IntervalS

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
@@ -265,7 +265,7 @@ LDServerDataSourcePollBuilder_New();
 /**
  * Sets the interval at which the SDK will poll for feature flag updates.
  * @param b Polling method builder. Must not be NULL.
- * @param milliseconds Polling interval.
+ * @param seconds Polling interval in seconds.
  */
 LD_EXPORT(void)
 LDServerDataSourcePollBuilder_IntervalS(LDServerDataSourcePollBuilder b,


### PR DESCRIPTION
The docs said milliseconds, but the parameter is seconds.