### PR TITLE
feat!: RedisDataSource::Create should return unique_ptr instead of shared_ptr

### DIFF
--- a/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_source.hpp
+++ b/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_source.hpp
@@ -16,7 +16,6 @@ class Redis;
 }
 
 namespace launchdarkly::server_side::integrations {
-
 /**
  * @brief RedisDataSource represents a data source for the Server-Side SDK
  * backed by Redis. It is meant to be used in place of the standard
@@ -47,7 +46,7 @@ class RedisDataSource final : public ISerializedDataReader {
      *
      * @return A RedisDataSource, or an error if construction failed.
      */
-    static tl::expected<std::shared_ptr<RedisDataSource>, std::string> Create(
+    static tl::expected<std::unique_ptr<RedisDataSource>, std::string> Create(
         std::string uri,
         std::string prefix);
 
@@ -56,8 +55,6 @@ class RedisDataSource final : public ISerializedDataReader {
     [[nodiscard]] AllResult All(ISerializedItemKind const& kind) const override;
     [[nodiscard]] std::string const& Identity() const override;
     [[nodiscard]] bool Initialized() const override;
-
-    ~RedisDataSource();
 
    private:
     RedisDataSource(std::unique_ptr<sw::redis::Redis> redis,
@@ -70,5 +67,4 @@ class RedisDataSource final : public ISerializedDataReader {
     std::string const inited_key_;
     std::unique_ptr<sw::redis::Redis> redis_;
 };
-
 }  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk-redis-source/tests/redis_source_test.cpp
+++ b/libs/server-sdk-redis-source/tests/redis_source_test.cpp
@@ -405,6 +405,13 @@ TEST_F(RedisTests, FlagAndSegmentCanCoexistWithSameKey) {
               serialize(boost::json::value_from(segment_in)));
 }
 
+TEST_F(RedisTests, CanConvertRedisDataSourceToDataReader) {
+    auto maybe_source = RedisDataSource::Create("tcp://foobar:1000", "prefix");
+    ASSERT_TRUE(maybe_source);
+
+    std::shared_ptr<ISerializedDataReader> reader = std::move(*maybe_source);
+}
+
 TEST(RedisErrorTests, InvalidURIs) {
     std::vector<std::string> const uris = {"nope, not a redis URI",
                                            "http://foo",
@@ -433,11 +440,11 @@ TEST(RedisErrorTests, ValidURIs) {
 }
 
 TEST(RedisErrorTests, GetReturnsErrorAndNoExceptionThrown) {
-    auto const maybe_source = RedisDataSource::Create(
+    auto maybe_source = RedisDataSource::Create(
         "tcp://foobar:1000" /* no redis service here */, "prefix");
     ASSERT_TRUE(maybe_source);
 
-    auto const source = *maybe_source;
+    auto const source = std::move(*maybe_source);
 
     auto const get_initialized = source->Initialized();
     ASSERT_FALSE(get_initialized);


### PR DESCRIPTION
Previously, `RedisDataSource::Create` returned an `expected<shared_ptr<RedisDataSource>, error>`.

The idea was that `DataSystem` config accepts a `shared_ptr` (in theory, so that they don't have to give up management of the source's lifetime. TBD if this turns out to be helpful or not.)

We don't need to force the user into shared ownership in the factory function though - instead, return a `unique_ptr` and let them make the transformation.

Motivation is that`shared_ptr` is painful with the C bindings. We get back a stack-allocated `shared_ptr` from the factory, and then need to heap allocate one so we cast it to the opaque type. This is not necessary if we just return a `unique_ptr`, since we can call `.release()` and then pass the unmanaged pointer around. 