### PR TITLE
feat(event-processor): add C binding for context keys cache capacity

### DIFF
--- a/libs/common/include/launchdarkly/config/shared/builders/events_builder.hpp
+++ b/libs/common/include/launchdarkly/config/shared/builders/events_builder.hpp
@@ -108,6 +108,20 @@ class EventsBuilder {
     EventsBuilder& PrivateAttribute(AttributeReference attribute);
 
     /**
+     * @brief Specifies the number of unique context keys that can be remembered
+     * by the index event generation logic before needing to evict keys from
+     * memory in LRU order.
+     *
+     * After reaching capacity, it's possible
+     * that a previously-indexed context may cause generation of a redundant
+     * index event.
+     *
+     * @param capacity Maximum unique context keys to remember.
+     * @return  Reference to this builder.
+     */
+    EventsBuilder& ContextKeysCapacity(std::size_t capacity);
+
+    /**
      * Builds Events configuration, if the configuration is valid.
      * @return Events config, or error.
      */

--- a/libs/common/include/launchdarkly/config/shared/built/events.hpp
+++ b/libs/common/include/launchdarkly/config/shared/built/events.hpp
@@ -93,8 +93,8 @@ class Events final {
     [[nodiscard]] std::size_t FlushWorkers() const;
 
     /**
-     * Max number of unique context keys to hold in LRU cache used for context
-     * deduplication when generating index events.
+     * Number of unique contexts to remember when deduplicating index
+     * events.
      * @return Max, or std::nullopt if not applicable.
      */
     [[nodiscard]] std::optional<std::size_t> ContextKeysCacheCapacity() const;

--- a/libs/common/src/config/events_builder.cpp
+++ b/libs/common/src/config/events_builder.cpp
@@ -26,6 +26,13 @@ EventsBuilder<SDK>& EventsBuilder<SDK>::Capacity(std::size_t capacity) {
 }
 
 template <typename SDK>
+EventsBuilder<SDK>& EventsBuilder<SDK>::ContextKeysCapacity(
+    std::size_t capacity) {
+    config_.context_keys_cache_capacity_ = capacity;
+    return *this;
+}
+
+template <typename SDK>
 EventsBuilder<SDK>& EventsBuilder<SDK>::FlushInterval(
     std::chrono::milliseconds interval) {
     config_.flush_interval_ = interval;

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
@@ -108,6 +108,22 @@ LD_EXPORT(void)
 LDServerConfigBuilder_Events_Enabled(LDServerConfigBuilder b, bool enabled);
 
 /**
+ * Specifies the number of unique context keys that can be remembered
+ * by the index event generation logic before needing to evict keys from
+ * memory in LRU order.
+ *
+ * After reaching capacity, it's possible
+ * that a previously-indexed context may cause generation of a redundant
+ * index event.
+ * @param b Server config builder. Must not be NULL.
+ * @param context_keys_capacity Maximum unique context keys to remember. The default
+ * is 1000.
+ */
+LD_EXPORT(void)
+LDServerConfigBuilder_Events_ContextKeysCapacity(LDServerConfigBuilder b,
+                                                 size_t context_keys_capacity);
+
+/**
  * Sets the capacity of the event processor. When more events are generated
  * within the processor's flush interval than this value, events will be
  * dropped.

--- a/libs/server-sdk/src/bindings/c/builder.cpp
+++ b/libs/server-sdk/src/bindings/c/builder.cpp
@@ -141,6 +141,14 @@ LDServerConfigBuilder_Events_Capacity(LDServerConfigBuilder b,
 }
 
 LD_EXPORT(void)
+LDServerConfigBuilder_Events_ContextKeysCapacity(LDServerConfigBuilder b,
+                                                 size_t context_keys_capacity) {
+    LD_ASSERT_NOT_NULL(b);
+
+    TO_BUILDER(b)->Events().ContextKeysCapacity(context_keys_capacity);
+}
+
+LD_EXPORT(void)
 LDServerConfigBuilder_Events_FlushIntervalMs(LDServerConfigBuilder b,
                                              unsigned int milliseconds) {
     LD_ASSERT_NOT_NULL(b);
@@ -225,7 +233,7 @@ LD_EXPORT(LDServerDataSourcePollBuilder) LDServerDataSourcePollBuilder_New() {
 
 LD_EXPORT(void)
 LDServerDataSourcePollBuilder_IntervalS(LDServerDataSourcePollBuilder b,
-                                     unsigned int seconds) {
+                                        unsigned int seconds) {
     LD_ASSERT_NOT_NULL(b);
 
     TO_POLL_BUILDER(b)->PollInterval(std::chrono::seconds{seconds});


### PR DESCRIPTION
This adds a missing C binding for configuring the context key cache capacity which the Event Processor uses to deduplicate index events. 