### PR TITLE
feat: add C binding for Context::CanonicalKey()

### DIFF
--- a/libs/common/include/launchdarkly/bindings/c/context.h
+++ b/libs/common/include/launchdarkly/bindings/c/context.h
@@ -18,6 +18,14 @@ typedef struct _LDContext_PrivateAttributesIter*
     LDContext_PrivateAttributesIter;
 
 /**
+ * Get the canonical key for the context.
+ * @param context The context. Must not be NULL.
+ * @return Canonical key. Only valid for the lifetime of this context.
+ */
+LD_EXPORT(char const*)
+LDContext_CanonicalKey(LDContext context);
+
+/**
  * Check if the context is valid.
  *
  * @param context The context to check. Must not be NULL.

--- a/libs/common/src/bindings/c/context.cpp
+++ b/libs/common/src/bindings/c/context.cpp
@@ -26,6 +26,13 @@ LD_EXPORT(bool) LDContext_Valid(LDContext context) {
     return AS_CONTEXT(context)->Valid();
 }
 
+LD_EXPORT(char const*)
+LDContext_CanonicalKey(LDContext context) {
+    LD_ASSERT_NOT_NULL(context);
+
+    return AS_CONTEXT(context)->CanonicalKey().c_str();
+}
+
 LD_EXPORT(LDValue)
 LDContext_Get(LDContext context, char const* kind, char const* ref) {
     LD_ASSERT_NOT_NULL(context);

--- a/libs/common/tests/bindings/context_test.cpp
+++ b/libs/common/tests/bindings/context_test.cpp
@@ -12,6 +12,7 @@ TEST(ContextCBindingTests, CanBuildBasicContext) {
               LDValue_GetString(LDContext_Get(context, "user", "key")));
 
     EXPECT_TRUE(LDContext_Valid(context));
+    EXPECT_STREQ(LDContext_CanonicalKey(context), "user-key");
 
     LDContext_Free(context);
 }
@@ -88,6 +89,8 @@ TEST(ContextCBindingTests, CanMakeMultiKindContext) {
 
     LDContext context = LDContextBuilder_Build(builder);
 
+    EXPECT_STREQ(LDContext_CanonicalKey(context), "org:org-key:user:user-key");
+
     EXPECT_EQ(std::string("user-key"),
               LDValue_GetString(LDContext_Get(context, "user", "key")));
 
@@ -114,6 +117,7 @@ TEST(ContextCBindingTests, CanCreateInvalidContext) {
     LDContext context = LDContextBuilder_Build(builder);
 
     EXPECT_FALSE(LDContext_Valid(context));
+    EXPECT_STREQ(LDContext_CanonicalKey(context), "");
 
     EXPECT_EQ(std::string("#)(#$@*(#^@&*: \"Kind contained invalid characters. "
                           "A kind may contain ASCII letters or numbers, as "


### PR DESCRIPTION
Adds `LDContext_CanonicalKey`. Noticed this missing when writing Lua binding. 

We're also missing a way of returning `Context::Kinds`, but that would involve adding a new iterator. This gets the job done for testing.