### PR TITLE
docs: fix a bunch of broken Doxygen links

### DIFF
--- a/libs/common/include/launchdarkly/bindings/c/array_builder.h
+++ b/libs/common/include/launchdarkly/bindings/c/array_builder.h
@@ -18,40 +18,44 @@ typedef struct _LDArrayBuilder* LDArrayBuilder;
  * @return The new array builder.
  *
  */
-LD_EXPORT(LDArrayBuilder) LDArrayBuilder_New();
+LD_EXPORT(LDArrayBuilder)
+LDArrayBuilder_New();
 
 /**
  * Free an array builder. This should only be done for a builder which
- * has not been built. Calling LDArrayBuilder_Build on an array builder
- * transfers consumes the array builder.
+ * has not been built. Calling @ref LDArrayBuilder_Build on an array builder
+ * consumes the array builder.
  *
  * @param array_builder The builder to free.
  */
-LD_EXPORT(void) LDArrayBuilder_Free(LDArrayBuilder array_builder);
+LD_EXPORT(void)
+LDArrayBuilder_Free(LDArrayBuilder array_builder);
 
 /**
  * Add a value to an array builder.
  *
- * After calling this method the provider LDValue is consumed. It should not
- * be accessed, and the caller doesn't need to call LDValue_Free.
+ * After calling this method the provider @ref LDValue is consumed. It should
+ * not be accessed, and the caller doesn't need to call @ref LDValue_Free.
  *
  * @param array_builder The array builder to add the value to.  Must not be
  * NULL.
  * @param val The value to add. Must not be NULL.
  */
-LD_EXPORT(void) LDArrayBuilder_Add(LDArrayBuilder array_builder, LDValue val);
+LD_EXPORT(void)
+LDArrayBuilder_Add(LDArrayBuilder array_builder, LDValue val);
 
 /**
- * Construct an LDValue from an array builder.
+ * Construct an @ref LDValue from an array builder.
  *
  * After calling this method the array builder is consumed. It should not be
- * used and the caller does not need to call LDArrayBuilder_Free.
+ * used and the caller does not need to call @ref LDArrayBuilder_Free.
  *
  * @param array_builder The array builder to build an LDValue from. Must not be
  * NULL.
  * @return The built LDValue. Must not be NULL.
  */
-LD_EXPORT(LDValue) LDArrayBuilder_Build(LDArrayBuilder array_builder);
+LD_EXPORT(LDValue)
+LDArrayBuilder_Build(LDArrayBuilder array_builder);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/config/logging_builder.h
+++ b/libs/common/include/launchdarkly/bindings/c/config/logging_builder.h
@@ -54,7 +54,8 @@ struct LDLogBackend {
  * backend into configuration.
  * @param backend Backend to initialize.
  */
-LD_EXPORT(void) LDLogBackend_Init(struct LDLogBackend* backend);
+LD_EXPORT(void)
+LDLogBackend_Init(struct LDLogBackend* backend);
 
 /**
  * Creates a new builder for LaunchDarkly's default logger.
@@ -63,14 +64,16 @@ LD_EXPORT(void) LDLogBackend_Init(struct LDLogBackend* backend);
  * builder, must be manually freed with LDLoggingBasicBuilder_Free.
  * @return New builder.
  */
-LD_EXPORT(LDLoggingBasicBuilder) LDLoggingBasicBuilder_New();
+LD_EXPORT(LDLoggingBasicBuilder)
+LDLoggingBasicBuilder_New();
 
 /**
  * Frees a basic logging builder. Do not call if the builder was consumed by
  * the config builder.
  * @param b Builder to free.
  */
-LD_EXPORT(void) LDLoggingBasicBuilder_Free(LDLoggingBasicBuilder b);
+LD_EXPORT(void)
+LDLoggingBasicBuilder_Free(LDLoggingBasicBuilder b);
 
 /**
  * Sets the enabled log level. The default level is LD_LOG_INFO.
@@ -99,14 +102,16 @@ LDLoggingBasicBuilder_Tag(LDLoggingBasicBuilder b, char const* tag);
  * builder, must be manually freed with LDLoggingCustomBuilder_Free.
  * @return New builder.
  */
-LD_EXPORT(LDLoggingCustomBuilder) LDLoggingCustomBuilder_New();
+LD_EXPORT(LDLoggingCustomBuilder)
+LDLoggingCustomBuilder_New();
 
 /**
  * Frees a custom logging builder. Do not call if the builder was consumed by
  * the config builder.
  * @param b Builder to free.
  */
-LD_EXPORT(void) LDLoggingCustomBuilder_Free(LDLoggingCustomBuilder b);
+LD_EXPORT(void)
+LDLoggingCustomBuilder_Free(LDLoggingCustomBuilder b);
 
 /**
  * Sets a custom log backend.

--- a/libs/common/include/launchdarkly/bindings/c/context.h
+++ b/libs/common/include/launchdarkly/bindings/c/context.h
@@ -31,14 +31,16 @@ LDContext_CanonicalKey(LDContext context);
  * @param context The context to check. Must not be NULL.
  * @return True if the context is valid.
  */
-LD_EXPORT(bool) LDContext_Valid(LDContext context);
+LD_EXPORT(bool)
+LDContext_Valid(LDContext context);
 
 /**
  * Free the context.
  *
  * @param context The context to free.
  */
-LD_EXPORT(void) LDContext_Free(LDContext context);
+LD_EXPORT(void)
+LDContext_Free(LDContext context);
 
 /**
  * Get an attribute value by kind and attribute reference. If the kind is
@@ -68,7 +70,8 @@ LDContext_Get(LDContext context, char const* kind, char const* ref);
  * @param context The context to check for validity. Must not be NULL.
  * @return A string explaining why the context is not valid.
  */
-LD_EXPORT(char const*) LDContext_Errors(LDContext context);
+LD_EXPORT(char const*)
+LDContext_Errors(LDContext context);
 
 /**
  * Create an iterator which iterates over the private attributes for the

--- a/libs/common/include/launchdarkly/bindings/c/context_builder.h
+++ b/libs/common/include/launchdarkly/bindings/c/context_builder.h
@@ -20,28 +20,31 @@ typedef struct _LDContextBuilder* LDContextBuilder;
  * Create a new context builder.
  * @return A new context builder instance.
  */
-LD_EXPORT(LDContextBuilder) LDContextBuilder_New();
+LD_EXPORT(LDContextBuilder)
+LDContextBuilder_New();
 
 /**
  * Free a context builder.
  *
  * This method only needs to be used when not building
- * the context. If you use LDContextBuilder_Build, then the builder will
- * be consumed, and you do not need to call LDContextBuilder_Free.
+ * the context. If you use @ref LDContextBuilder_Build, then the builder will
+ * be consumed, and you do not need to call @ref LDContextBuilder_Free.
  * @param builder The builder to free.
  */
-LD_EXPORT(void) LDContextBuilder_Free(LDContextBuilder builder);
+LD_EXPORT(void)
+LDContextBuilder_Free(LDContextBuilder builder);
 
 /**
  * Construct a context from a context builder.
  *
- * When building a context using LDContextBuilder_Build the builder will be
- * consumed and you do not need to call LDContextBuilder_Free.
+ * When building a context using @ref LDContextBuilder_Build the builder will be
+ * consumed and you do not need to call @ref LDContextBuilder_Free.
  *
  * @param builder The builder to build a context from. Must not be NULL.
  * @return The built context.
  */
-LD_EXPORT(LDContext) LDContextBuilder_Build(LDContextBuilder builder);
+LD_EXPORT(LDContext)
+LDContextBuilder_Build(LDContextBuilder builder);
 
 /**
  * Add a kind instance to the context builder. The kind will have the specified
@@ -52,7 +55,7 @@ LD_EXPORT(LDContext) LDContextBuilder_Build(LDContextBuilder builder);
  *
  * You must first add the kind to the context builder before setting attributes.
  *
- * If you call LDContextBuilder_AddKind a second time, with an already specified
+ * If you call this a second time, with an already specified
  * kind, but a different key, then the key for that kind will be updated.
  *
  * @param builder The builder to add the kind to. Must not be NULL.
@@ -67,11 +70,11 @@ LDContextBuilder_AddKind(LDContextBuilder builder,
 /**
  * Add or update a top-level attribute in the specified kind.
  *
- * Adding a LDValue to the builder will consume that value.
+ * Adding a @ref LDValue to the builder will consume that value.
  * You should not access the value after adding it to the builder, and you
- * do not need to call LDValue_Free on the value.
+ * do not need to call @ref LDValue_Free on the value.
  *
- * @param builder. The builder. Must not be NULL.
+ * @param builder The builder. Must not be NULL.
  * @param kind The kind to add the attribute to. Must not be NULL.
  * @param attr_name The name of the attribute to add. Must not be NULL.
  * @param val The value of the attribute to add. Must not be NULL.
@@ -84,18 +87,20 @@ LDContextBuilder_Attributes_Set(LDContextBuilder builder,
 
 /**
  * Add or update a private attribute. Once an attribute has been set as private
- * using LDContextBuilder_Attributes_SetPrivate it will remain private.
- * A subsequent call to LDContextBuilder_Attributes_Set, for the same attribute,
- * will not remove the private status.
+ * using this method it will remain private.
  *
- * This method cannot be used to set the key, kind, name, or anonymous
+ * A subsequent call to @ref LDContextBuilder_Attributes_Set, for the same
+ * attribute, will not remove the private status.
+ *
+ * This method cannot be used to set the `key`, `kind`, `name`, or `anonymous`
  * property of a context.
  *
- * Adding a LDValue to the builder will consume that value.
+ * Adding a @ref LDValue to the builder will consume that value.
+ *
  * You should not access the value after adding it to the builder, and you
- * do not need to call LDValue_Free on the value. This method is just a
+ * do not need to call @ref LDValue_Free on the value. This method is just a
  * convenience which also adds the attribute to the private attributes list,
- * as if using LDContextBuilder_Attributes_AddPrivateAttribute.
+ * as if using @ref LDContextBuilder_Attributes_AddPrivateAttribute.
  *
  * @param builder The builder. Must not be NULL.
  * @param kind The kind to set the private attribute for. Must not be NULL.
@@ -111,7 +116,7 @@ LDContextBuilder_Attributes_SetPrivate(LDContextBuilder builder,
 /**
  * Set the name attribute for the specified kind.
  *
- * You can search for contexts on the Contexts page by name.
+ * You can search for contexts on the LaunchDarkly Contexts page by name.
  *
  * This method will make a copy of the name string, and the caller remains
  * responsible for the original name string.
@@ -164,8 +169,12 @@ LDContextBuilder_Attributes_SetAnonymous(LDContextBuilder builder,
  * This action only affects analytics events that involve this particular
  * context. To mark some (or all) context attributes as private for all
  * contexts, use the overall configuration for the SDK. See
- * LDClientConfigBuilder_Events_AllAttributesPrivate and
- * LDClientConfigBuilder_Events_PrivateAttribute.
+ * - @ref LDServerConfigBuilder_Events_AllAttributesPrivate
+ * - @ref LDClientConfigBuilder_Events_AllAttributesPrivate
+ *
+ * and
+ * - @ref LDServerConfigBuilder_Events_PrivateAttribute
+ * - @ref LDClientConfigBuilder_Events_PrivateAttribute
  *
  * The attributes "kind" and "key", and the "_meta" attributes cannot be
  * made private.

--- a/libs/common/include/launchdarkly/bindings/c/flag_listener.h
+++ b/libs/common/include/launchdarkly/bindings/c/flag_listener.h
@@ -47,15 +47,16 @@ struct LDFlagListener {
 
 /**
  * Initializes a flag listener. Must be called before passing the listener
- * to LDClientSDK_FlagNotifier_OnFlagChange.
+ * to @ref LDClientSDK_FlagNotifier_OnFlagChange.
  *
  * Create the struct, initialize the struct, set the FlagChanged handler
  * and optionally UserData, and then pass the struct to
- * LDClientSDK_FlagNotifier_OnFlagChange.
+ * @ref LDClientSDK_FlagNotifier_OnFlagChange.
  *
  * @param listener Listener to initialize.
  */
-LD_EXPORT(void) LDFlagListener_Init(struct LDFlagListener* listener);
+LD_EXPORT(void)
+LDFlagListener_Init(struct LDFlagListener* listener);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/listener_connection.h
+++ b/libs/common/include/launchdarkly/bindings/c/listener_connection.h
@@ -36,7 +36,8 @@ LDListenerConnection_Disconnect(LDListenerConnection connection);
  *
  * @param connection The LDListenerConnection to free.
  */
-LD_EXPORT(void) LDListenerConnection_Free(LDListenerConnection connection);
+LD_EXPORT(void)
+LDListenerConnection_Free(LDListenerConnection connection);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/memory_routines.h
+++ b/libs/common/include/launchdarkly/bindings/c/memory_routines.h
@@ -11,6 +11,11 @@ extern "C" {  // only need to export C interface if
 // used by C++ source code
 #endif
 
+/**
+ * Frees a string returned from the SDK.
+ * @param string The string to free.
+ * @return void
+ */
 LD_EXPORT(void)
 LDMemory_FreeString(char* string);
 

--- a/libs/common/include/launchdarkly/bindings/c/object_builder.h
+++ b/libs/common/include/launchdarkly/bindings/c/object_builder.h
@@ -18,23 +18,25 @@ typedef struct _LDObjectBuilder* LDObjectBuilder;
  * @return The new object builder.
  *
  */
-LD_EXPORT(LDObjectBuilder) LDObjectBuilder_New();
+LD_EXPORT(LDObjectBuilder)
+LDObjectBuilder_New();
 
 /**
  * Free an object builder. This should only be done for a builder which
- * has not been built. Calling LDArrayBuilder_Build on an array builder
- * consumes the array builder.
+ * has not been built. Calling @ref LDObjectBuilder_Build on an object builder
+ * consumes the object builder.
  *
  * @param builder The builder to free.
  */
-LD_EXPORT(void) LDObjectBuilder_Free(LDObjectBuilder builder);
+LD_EXPORT(void)
+LDObjectBuilder_Free(LDObjectBuilder builder);
 
 /**
  * Add a key-value pair to the object builder.
  *
- * After calling this method the provider LDValue is consumed. It should not
- * be accessed, and the caller doesn't need to call LDValue_Free. The key will
- * be copied.
+ * After calling this method the provider @ref LDValue is consumed. It should
+ * not be accessed, and the caller doesn't need to call @ref LDValue_Free. The
+ * key will be copied.
  *
  * @param builder The object builder to add the value to.
  * @param key The key for the value being added. Must not be NULL.
@@ -44,15 +46,16 @@ LD_EXPORT(void)
 LDObjectBuilder_Add(LDObjectBuilder builder, char const* key, LDValue val);
 
 /**
- * Construct an LDValue from an object builder.
+ * Construct an @ref LDValue from an object builder.
  *
  * After calling this method the object builder is consumed. It should not be
- * used and the caller does not need to call LDObjectBuilder_Free.
+ * used and the caller does not need to call @ref LDObjectBuilder_Free.
  *
  * @param builder The object builder to build an LDValue from. Must not be NULL.
  * @return The built LDValue.
  */
-LD_EXPORT(LDValue) LDObjectBuilder_Build(LDObjectBuilder builder);
+LD_EXPORT(LDValue)
+LDObjectBuilder_Build(LDObjectBuilder builder);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/status.h
+++ b/libs/common/include/launchdarkly/bindings/c/status.h
@@ -16,31 +16,35 @@ typedef struct _LDStatus* LDStatus;
 /**
  * Returns a string representing the error stored in an LDStatus, or
  * NULL if the result indicates success.
- * @param error Result to inspect.
+ * @param res Result to inspect.
  * @return String or NULL. The returned string is valid only while the LDStatus
  * is alive.
  */
-LD_EXPORT(char const*) LDStatus_Error(LDStatus res);
+LD_EXPORT(char const*)
+LDStatus_Error(LDStatus res);
 
 /**
  * Checks if a result indicates success.
- * @param result Result to inspect.
+ * @param res Result to inspect.
  * @return True if the result indicates success.
  */
-LD_EXPORT(bool) LDStatus_Ok(LDStatus res);
+LD_EXPORT(bool)
+LDStatus_Ok(LDStatus res);
 
 /**
- * Frees an LDStatus. It is only necessary to call LDStatus_Free if LDStatus_Ok
- * returns false.
+ * Frees an LDStatus. It is only necessary to call if
+ * @ref LDStatus_Ok returns false.
  * @param res Result to free.
  */
-LD_EXPORT(void) LDStatus_Free(LDStatus res);
+LD_EXPORT(void)
+LDStatus_Free(LDStatus res);
 
 /**
  * Returns a status representing success.
  * @return Successful status.
  */
-LD_EXPORT(LDStatus) LDStatus_Success(void);
+LD_EXPORT(LDStatus)
+LDStatus_Success(void);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/value.h
+++ b/libs/common/include/launchdarkly/bindings/c/value.h
@@ -52,8 +52,8 @@ enum LDValueType {
  * A basic LDValue types can be created directly using the LDValue_New* methods.
  * This includes: null-type, boolean-type, number-type, and string-type.
  *
- * An array-type or object-type LDValue must be created using LDArrayBuilder or
- * LDObjectBuilder.
+ * An array-type or object-type LDValue must be created using @ref
+ * LDArrayBuilder_New() or LDObjectBuilder_New().
  *
  * Basic LDValue types can be converted to raw types using the LDValue_Get*
  * methods.
@@ -64,131 +64,144 @@ enum LDValueType {
 typedef struct _LDValue* LDValue;
 
 /**
- * LDValue_ObjectIter is a handle to an iterator, bound to an LDValue.
- * It can be used to obtain the keys and values of an LDObject.
+ * LDValue_ObjectIter is a handle to an iterator, bound to an @ref LDValue.
+ * It can be used to obtain the keys and values of an object.
  *
- * The iterator must be destroyed after use. An iterator for an LDValue
- * that has been freed should not be used.
+ * The iterator must be destroyed after use using @ref LDValue_ObjectIter_Free.
+ * An iterator for an LDValue that has been freed should not be used.
  */
 typedef struct _LDValue_ObjectIter* LDValue_ObjectIter;
 
 /**
- * LDValue_ArrayIter is a handle to an iterator, bound to an LDValue.
- * It can be used to obtain the values of an LDArray.
+ * LDValue_ArrayIter is a handle to an iterator, bound to an @ref LDValue.
+ * It can be used to obtain the values of an array.
  *
- * The iterator must be destroyed after use. An iterator for an LDValue
- * that has been freed should not be used.
+ * The iterator must be destroyed after use using @ref LDValue_ArrayIter_Free.
+ * An iterator for an LDValue that has been freed should not be used.
  */
 typedef struct _LDValue_ArrayIter* LDValue_ArrayIter;
 
 /**
- * Allocates a new null-type LDValue.
- * Note that a NULL pointer is not a valid LDValue; to represent null (the JSON
- * type), use this constructor.
+ * Allocates a new null-type @ref LDValue.
+ * *WARNING!* A `NULL` pointer is not a valid LDValue; to represent null (the
+ * JSON type), use this constructor.
  *
  * @return New LDValue.
  */
-LD_EXPORT(LDValue) LDValue_NewNull();
+LD_EXPORT(LDValue)
+LDValue_NewNull();
 
 /**
- * Allocates a new boolean-type LDValue.
- * @param val LDBooleanTrue or LDBooleanFalse.
+ * Allocates a new boolean-type @ref LDValue.
+ * @param val Boolean.
  * @return New LDValue.
  */
-LD_EXPORT(LDValue) LDValue_NewBool(bool val);
+LD_EXPORT(LDValue)
+LDValue_NewBool(bool val);
 
 /**
- * Allocates a new number-type LDValue.
+ * Allocates a new number-type @ref LDValue.
  * @param val Double value.
  * @return New LDValue.
  */
-LD_EXPORT(LDValue) LDValue_NewNumber(double val);
+LD_EXPORT(LDValue)
+LDValue_NewNumber(double val);
 
 /**
- * Allocates a new string-type LDValue.
+ * Allocates a new string-type @ref LDValue.
  *
- * The input string will be copied. To avoid the copy, see
- * LDValue_ConstantString.
+ * The input string will be copied.
  *
  * @param val Constant reference to a string. The string is copied. Must not be
  * NULL.
  * @return New LDValue.
  */
-LD_EXPORT(LDValue) LDValue_NewString(char const* val);
+LD_EXPORT(LDValue)
+LDValue_NewString(char const* val);
 
 /**
- * Allocates an LDValue by cloning an existing LDValue.
+ * Allocates an @ref LDValue by cloning an existing LDValue.
  *
- * @param source Source LDValue. Must not be NULL.
+ * @param val The source value. Must not be NULL.
  * @return New LDValue.
  */
-LD_EXPORT(LDValue) LDValue_NewValue(LDValue val);
+LD_EXPORT(LDValue)
+LDValue_NewValue(LDValue val);
 
 /**
- * Frees an LDValue.
+ * Frees an @ref LDValue.
  *
  * An LDValue should only be freed when directly owned by the caller, i.e.,
- * it was never moved into an LDArray or LDObject.
+ * it was never moved into an array or object builder.
  *
- * @param value LDValue to free.
+ * @param val LDValue to free.
  */
-LD_EXPORT(void) LDValue_Free(LDValue val);
+LD_EXPORT(void)
+LDValue_Free(LDValue val);
 
 /**
- * Returns the type of an LDValue.
+ * Returns the type of an @ref LDValue.
  * @param val LDValue to inspect. Must not be NULL.
- * @return Type of the LDValue, or LDValueType_Unrecognized if the type is
+ * @return Type of the LDValue, or @ref LDValueType_Unrecognized if the type is
  * unrecognized.
  */
-LD_EXPORT(enum LDValueType) LDValue_Type(LDValue val);
+LD_EXPORT(enum LDValueType)
+LDValue_Type(LDValue val);
 
 /**
- * Obtain value of a boolean-type LDValue, otherwise returns LDBooleanFalse.
+ * Obtain value of a boolean-type @ref LDValue, otherwise returns false.
  *
- * @param value Target LDValue. Must not be NULL.
+ * @param val Target LDValue. Must not be NULL.
  * @return Boolean value, or false if not boolean-type.
  */
-LD_EXPORT(bool) LDValue_GetBool(LDValue val);
+LD_EXPORT(bool)
+LDValue_GetBool(LDValue val);
 
 /**
- * Obtain value of a number-type LDValue, otherwise return 0.
- * @param value Target LDValue. Must not be NULL.
+ * Obtain value of a number-type @ref LDValue, otherwise return 0.
+ * @param val Target LDValue. Must not be NULL.
  * @return Number value, or 0 if not number-type.
  */
-LD_EXPORT(double) LDValue_GetNumber(LDValue val);
+LD_EXPORT(double)
+LDValue_GetNumber(LDValue val);
 
 /**
- * Obtain value of a string-type LDValue, otherwise returns pointer
- * to an empty string. The returned string is only valid for the lifetime of
+ * Obtain value of a string-type @ref LDValue, otherwise returns pointer
+ * to an empty string.
+ *
+ * The returned string is only valid for the lifetime of
  * the LDValue. If you need the string outside this lifetime, then a copy
  * should be made.
  *
- * @param value Target LDValue. Must not be NULL.
+ * @param val Target LDValue. Must not be NULL.
  * @return String value, or empty string if not string-type.
  */
-LD_EXPORT(char const*) LDValue_GetString(LDValue val);
+LD_EXPORT(char const*)
+LDValue_GetString(LDValue val);
 
 /**
- * Obtain number of LDValue elements stored in an array-type LDValue, or number
- * of key/LDValue pairs stored in an object-type LDValue.
+ * Obtain number of @ref LDValue elements stored in an array-type LDValue, or
+ * number of key/LDValue pairs stored in an object-type LDValue.
  *
  * If not an array-type or object-type, returns 0.
  *
- * @param value Target LDValue. Must not be NULL.
+ * @param val Target LDValue. Must not be NULL.
  * @return Count of LDValue elements, or 0 if not array-type/object-type.
  */
-LD_EXPORT(unsigned int) LDValue_Count(LDValue val);
+LD_EXPORT(unsigned int)
+LDValue_Count(LDValue val);
 
 /**
- * Obtain iterator over an array-type LDValue, otherwise NULL.
+ * Obtain iterator over an array-type @ref LDValue, otherwise NULL.
  *
  * The iterator starts at the first element.
  *
- * @param value Target LDValue. Must not be NULL.
+ * @param val Target LDValue. Must not be NULL.
  * @return Iterator, or NULL if not an array-type. The iterator
- * must should be destroyed with LDValue_ArrayIter_Free.
+ * must should be destroyed with LDValue_ArrayIter_Free().
  */
-LD_EXPORT(LDValue_ArrayIter) LDValue_ArrayIter_New(LDValue val);
+LD_EXPORT(LDValue_ArrayIter)
+LDValue_ArrayIter_New(LDValue val);
 
 /**
  * Move the array-type iterator to the next item. Should only be done for an
@@ -196,7 +209,8 @@ LD_EXPORT(LDValue_ArrayIter) LDValue_ArrayIter_New(LDValue val);
  *
  * @param iter The iterator to advance. Must not be NULL.
  */
-LD_EXPORT(void) LDValue_ArrayIter_Next(LDValue_ArrayIter iter);
+LD_EXPORT(void)
+LDValue_ArrayIter_Next(LDValue_ArrayIter iter);
 
 /**
  * Check if an array-type iterator is at the end.
@@ -204,34 +218,38 @@ LD_EXPORT(void) LDValue_ArrayIter_Next(LDValue_ArrayIter iter);
  * @param iter The iterator to check. Must not be NULL.
  * @return True if the iterator is at the end.
  */
-LD_EXPORT(bool) LDValue_ArrayIter_End(LDValue_ArrayIter iter);
+LD_EXPORT(bool)
+LDValue_ArrayIter_End(LDValue_ArrayIter iter);
 
 /**
  * Get the value for the array-type iterator. The value's lifetime is valid
  * only for as long as the iterator. To obtain a copy, call @ref
- * LDValue_NewValue.
+ * LDValue_NewValue with the result.
  *
  * @param iter The iterator to get a value for. Must not be NULL.
- * @return The value.
+ * @return The value reference.
  */
-LD_EXPORT(LDValue) LDValue_ArrayIter_Value(LDValue_ArrayIter iter);
+LD_EXPORT(LDValue)
+LDValue_ArrayIter_Value(LDValue_ArrayIter iter);
 
 /**
  * Destroy an array iterator.
  * @param iter The iterator to destroy.
  */
-LD_EXPORT(void) LDValue_ArrayIter_Free(LDValue_ArrayIter iter);
+LD_EXPORT(void)
+LDValue_ArrayIter_Free(LDValue_ArrayIter iter);
 
 /**
- * Obtain iterator over an object-type LDValue, otherwise NULL.
+ * Obtain iterator over an object-type @ref LDValue, otherwise NULL.
  *
  * The iterator starts at the first element.
  *
- * @param value Target LDValue. Must not be NULL.
+ * @param val Target LDValue. Must not be NULL.
  * @return Iterator, or NULL if not an object-type. The iterator
- * must should be destroyed with LDValue_ObjectIter_Free.
+ * must should be destroyed with LDValue_ObjectIter_Free().
  */
-LD_EXPORT(LDValue_ObjectIter) LDValue_ObjectIter_New(LDValue val);
+LD_EXPORT(LDValue_ObjectIter)
+LDValue_ObjectIter_New(LDValue val);
 
 /**
  * Move the object-type iterator to the next item. Should only be done for an
@@ -239,7 +257,8 @@ LD_EXPORT(LDValue_ObjectIter) LDValue_ObjectIter_New(LDValue val);
  *
  * @param iter The iterator to advance. Must not be NULL.
  */
-LD_EXPORT(void) LDValue_ObjectIter_Next(LDValue_ObjectIter iter);
+LD_EXPORT(void)
+LDValue_ObjectIter_Next(LDValue_ObjectIter iter);
 
 /**
  * Check if an object-type iterator is at the end.
@@ -247,7 +266,8 @@ LD_EXPORT(void) LDValue_ObjectIter_Next(LDValue_ObjectIter iter);
  * @param iter The iterator to check. Must not be NULL.
  * @return True if the iterator is at the end.
  */
-LD_EXPORT(bool) LDValue_ObjectIter_End(LDValue_ObjectIter iter);
+LD_EXPORT(bool)
+LDValue_ObjectIter_End(LDValue_ObjectIter iter);
 
 /**
  * Get the value for an object-type iterator. The value's lifetime is valid
@@ -257,23 +277,26 @@ LD_EXPORT(bool) LDValue_ObjectIter_End(LDValue_ObjectIter iter);
  * @param iter The iterator to get a value for. Must not be NULL.
  * @return The value.
  */
-LD_EXPORT(LDValue) LDValue_ObjectIter_Value(LDValue_ObjectIter iter);
+LD_EXPORT(LDValue)
+LDValue_ObjectIter_Value(LDValue_ObjectIter iter);
 
 /**
  * Get the key for an object-type iterator.
  *
- * The returned key has a lifetime attached to that of the LDValue.
+ * The returned key has a lifetime attached to that of the @ref LDValue.
  *
  * @param iter The iterator to get a key for. Must not be NULL.
  * @return The key.
  */
-LD_EXPORT(char const*) LDValue_ObjectIter_Key(LDValue_ObjectIter iter);
+LD_EXPORT(char const*)
+LDValue_ObjectIter_Key(LDValue_ObjectIter iter);
 
 /**
  * Destroy an object iterator.
  * @param iter The iterator to destroy.
  */
-LD_EXPORT(void) LDValue_ObjectIter_Free(LDValue_ObjectIter iter);
+LD_EXPORT(void)
+LDValue_ObjectIter_Free(LDValue_ObjectIter iter);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Doxygen has issues when we've got an `LD_EXPORT` on the same line as the function name. 

I fixed a bunch of those, and then also update a bunch of doc references to use autogenerated links. More work can be done on an as-needed basis.