### PR TITLE
ci: run daily at midnight PST

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '**.md' #Do not need to run CI for markdown changes.
+      - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ main, "feat/**" ]
+    branches: [ "main", "feat/**" ]
     paths-ignore:
       - '**.md'
+  schedule:
+    # Run daily at midnight PST
+    - cron: '0 8 * * *'
 
 jobs:
   contract-tests:

--- a/.github/workflows/server-redis.yml
+++ b/.github/workflows/server-redis.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '**.md' #Do not need to run CI for markdown changes.
+      - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
     branches: [ "main", "feat/**" ]
     paths-ignore:
       - '**.md'
+  schedule:
+    # Run daily at midnight PST
+    - cron: '0 8 * * *'
 
 jobs:
   build-test-redis:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '**.md' #Do not need to run CI for markdown changes.
+      - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
     branches: [ "main", "feat/**" ]
     paths-ignore:
       - '**.md'
+  schedule:
+    # Run daily at midnight PST
+    - cron: '0 8 * * *'
 
 jobs:
   contract-tests:


### PR DESCRIPTION
If all dependencies of the build were pinned, then it probably wouldn't be necessary to regularly test the build and release process.

Since we don't live in that world - e.g. github runner often changes its packages - we should build every day to get ahead of any issues. 