### PR TITLE
refactor: remove deprecated usage of OpenSSL SHA1_ and SHA256_ functions

### DIFF
--- a/libs/internal/src/encoding/sha_1.cpp
+++ b/libs/internal/src/encoding/sha_1.cpp
@@ -8,10 +8,9 @@ std::array<unsigned char, SHA_DIGEST_LENGTH> Sha1String(
     std::string const& input) {
     std::array<unsigned char, SHA_DIGEST_LENGTH> hash{};
 
-    SHA_CTX sha;
-    SHA1_Init(&sha);
-    SHA1_Update(&sha, input.c_str(), input.size());
-    SHA1_Final(hash.data(), &sha);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    SHA1(reinterpret_cast<unsigned char const*>(input.c_str()), input.size(),
+         hash.data());
 
     return hash;
 }

--- a/libs/internal/src/encoding/sha_1.cpp
+++ b/libs/internal/src/encoding/sha_1.cpp
@@ -9,7 +9,7 @@ std::array<unsigned char, SHA_DIGEST_LENGTH> Sha1String(
     std::array<unsigned char, SHA_DIGEST_LENGTH> hash{};
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    SHA1(reinterpret_cast<unsigned char const*>(input.c_str()), input.size(),
+    SHA1(reinterpret_cast<unsigned char const*>(input.data()), input.size(),
          hash.data());
 
     return hash;

--- a/libs/internal/src/encoding/sha_256.cpp
+++ b/libs/internal/src/encoding/sha_256.cpp
@@ -9,7 +9,7 @@ std::array<unsigned char, SHA256_DIGEST_LENGTH> Sha256String(
     std::array<unsigned char, SHA256_DIGEST_LENGTH> hash{};
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    SHA256(reinterpret_cast<unsigned char const*>(input.c_str()), input.size(),
+    SHA256(reinterpret_cast<unsigned char const*>(input.data()), input.size(),
            hash.data());
 
     return hash;

--- a/libs/internal/src/encoding/sha_256.cpp
+++ b/libs/internal/src/encoding/sha_256.cpp
@@ -8,10 +8,9 @@ std::array<unsigned char, SHA256_DIGEST_LENGTH> Sha256String(
     std::string const& input) {
     std::array<unsigned char, SHA256_DIGEST_LENGTH> hash{};
 
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, input.c_str(), input.size());
-    SHA256_Final(hash.data(), &sha256);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    SHA256(reinterpret_cast<unsigned char const*>(input.c_str()), input.size(),
+           hash.data());
 
     return hash;
 }


### PR DESCRIPTION
The `SHA1_*` family of functions were [deprecated](https://www.openssl.org/docs/man3.1/man3/SHA1_Init.html) in OpenSSL 3.0, but plain old `SHA1` is not.

I don't see a reason to _not_ use these functions - we aren't incrementally hashing something, so the 3 step process doesn't seem to benefit us.