### PR TITLE
docs: adding SLSA verification steps for cpp-server-sdk

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,32 @@
+## Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `OSNAME-multiple-provenance.intoto.jsonl`.
+
+To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage to verify SDK packages for Linux is included below:
+
+```
+# Ensure provenance file is downloaded along with packages for your OS
+$ ls /tmp/launchdarkly-cpp-client-3.4.0
+linux-gcc-x64-dynamic.zip              linux-gcc-x64-static.zip               linux-multiple-provenance.intoto.jsonl
+
+# Run slsa-verifier to verify provenance against package artifacts 
+$ slsa-verifier verify-artifact \
+--provenance-path linux-multiple-provenance.intoto.jsonl \
+--source-uri github.com/launchdarkly/cpp-sdks \
+linux-gcc-x64-static.zip linux-gcc-x64-dynamic.zip
+Verified signature against tlog entry index 59501683 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77ad75383b2cf5388a2587a27acf06c948205b60999c208ae5fcbe89fae6a6aae70
+Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.7.0" at commit 533d512ccf050e6bf50078d64ec97338dc03aaef
+Verifying artifact linux-gcc-x64-static.zip: PASSED
+
+Verified signature against tlog entry index 59501683 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77ad75383b2cf5388a2587a27acf06c948205b60999c208ae5fcbe89fae6a6aae70
+Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.7.0" at commit 533d512ccf050e6bf50078d64ec97338dc03aaef
+Verifying artifact linux-gcc-x64-dynamic.zip: PASSED
+
+PASSED: Verified SLSA provenance
+```
+
+Alternatively, to verify the provenance manually, he SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+
+**Note:** These instructions do not apply when building our SDKs from source. 

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -27,6 +27,6 @@ Verifying artifact linux-gcc-x64-dynamic.zip: PASSED
 PASSED: Verified SLSA provenance
 ```
 
-Alternatively, to verify the provenance manually, he SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
 
 **Note:** These instructions do not apply when building our SDKs from source. 

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -4,7 +4,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help
 
 As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `OSNAME-multiple-provenance.intoto.jsonl`.
 
-To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage to verify SDK packages for Linux is included below:
+To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying SDK packages for Linux is included below:
 
 ```
 # Ensure provenance file is downloaded along with packages for your OS

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,6 +1,6 @@
-## Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
 As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `OSNAME-multiple-provenance.intoto.jsonl`.
 

--- a/libs/client-sdk/README.md
+++ b/libs/client-sdk/README.md
@@ -108,10 +108,10 @@ Contributing
 We encourage pull requests and other contributions from the community. Read
 our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
-Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
 
 About LaunchDarkly
 -----------

--- a/libs/client-sdk/README.md
+++ b/libs/client-sdk/README.md
@@ -108,6 +108,11 @@ Contributing
 We encourage pull requests and other contributions from the community. Read
 our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
+Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+------------
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+
 About LaunchDarkly
 -----------
 

--- a/libs/client-sdk/README.md
+++ b/libs/client-sdk/README.md
@@ -111,7 +111,7 @@ our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to 
 Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](../../PROVENANCE.md). 
 
 About LaunchDarkly
 -----------

--- a/libs/server-sdk-redis-source/README.md
+++ b/libs/server-sdk-redis-source/README.md
@@ -94,7 +94,7 @@ our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to 
 Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](../../PROVENANCE.md). 
 
 About LaunchDarkly
 -----------

--- a/libs/server-sdk-redis-source/README.md
+++ b/libs/server-sdk-redis-source/README.md
@@ -91,10 +91,10 @@ Contributing
 We encourage pull requests and other contributions from the community. Read
 our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
-Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
 
 About LaunchDarkly
 -----------

--- a/libs/server-sdk-redis-source/README.md
+++ b/libs/server-sdk-redis-source/README.md
@@ -91,6 +91,11 @@ Contributing
 We encourage pull requests and other contributions from the community. Read
 our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
 
+Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+------------
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+
 About LaunchDarkly
 -----------
 

--- a/libs/server-sdk/README.md
+++ b/libs/server-sdk/README.md
@@ -105,7 +105,7 @@ behave correctly.
 Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](../../PROVENANCE.md). 
 
 Contributing
 ------------

--- a/libs/server-sdk/README.md
+++ b/libs/server-sdk/README.md
@@ -102,10 +102,10 @@ for consistency across SDKs, as well as test networking behavior in a long-runni
 method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all
 behave correctly.
 
-Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+Verifying SDK build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
 
 Contributing
 ------------

--- a/libs/server-sdk/README.md
+++ b/libs/server-sdk/README.md
@@ -102,33 +102,10 @@ for consistency across SDKs, as well as test networking behavior in a long-runni
 method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all
 behave correctly.
 
-Validating SDK packages with the SLSA framework
--------
+Verifying SDK packages with the SLSA framework (Supply-chain Levels for Software Artifacts)
+------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity of our published SDK packages. As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [Github's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. 
-
-The SLSA framework specifies some [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation. For our C/C++ SDKs, we recommend the following steps:
-- From the Github releases page for the release version, download the provenance file for the OS you're developing on (`OSNAME-multiple-provenance.intoto.jsonl`)
-- Check the provenance payload (`payload` in `OSNAME-multiple-provenance.intoto.jsonl`) to verify the authenticity of the build:
-  - The payload is wrapped in a DSEE envelope in encoded in base64. To make the provenance human readable, base64 decode the `payload` parameter, e.g.: 
-    ```cat OSNAME-multiple-provenance.intoto.jsonl | jq -r '.payload' | base64 -d | jq```
-  - Validate that the subject digests in `payload.subject` match the sha256 checksums of the SDK packages for the OS you're developing in
-  - Validate that the provenance builder in `payload.predicate.builder` corresponds to Github's generic SLSA3 provenance generator, which ensures SLSA level 3 compliance
-  - Check the source commit referenced in `payload.predicate.invocation.configSource` and `payload.predicate.invocation.environment` for:
-    - Source repository is a LaunchDarkly-owned repository
-    - Commit author is a LaunchDarkly entity
-    - (Optional) Code changes in the commit are trustworthy 
-  - Check the build workflow file referenced in `payload.predicate.invocation.configSource.entryPoint` for:
-    - Build is triggered by a LaunchDarkly-owned repository
-    - Build is executed by a LaunchDarkly-owned Github Actions workflow
-    - Build steps are trustworthy 
-- Check the provenance signature (`signatures[0].cert` in `OSNAME-multiple-provenance.intoto.jsonl`) to verify the authenticity of the build provenance:
-  - Certificate issuer is Sigstore 
-  - x509 extension field `1.3.6.1.4.1.57264.1.1` (OIDC Issuer) is `https://token.actions.githubusercontent.com`
-  - x509 extension field `1.3.6.1.4.1.57264.1.5` (GitHub Workflow Repository) is a LaunchDarkly-owned repository
-  - x509 extension field `1.3.6.1.4.1.57264.1.3` (GitHub Workflow SHA) matches the SHA of the source commit in the provenance payload
-  
-The recommendations above may be adjusted to fit your organization's needs and supply chain security policies. For additional questions, please contact [security@launchdarkly.com](mailto:security@launchdarkly.com).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
 
 Contributing
 ------------

--- a/libs/server-sdk/README.md
+++ b/libs/server-sdk/README.md
@@ -102,6 +102,34 @@ for consistency across SDKs, as well as test networking behavior in a long-runni
 method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all
 behave correctly.
 
+Validating SDK packages with the SLSA framework
+-------
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) to help developers make their supply chain more secure by ensuring the authenticity of our published SDK packages. As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [Github's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. 
+
+The SLSA framework specifies some [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation. For our C/C++ SDKs, we recommend the following steps:
+- From the Github releases page for the release version, download the provenance file for the OS you're developing on (`OSNAME-multiple-provenance.intoto.jsonl`)
+- Check the provenance payload (`payload` in `OSNAME-multiple-provenance.intoto.jsonl`) to verify the authenticity of the build:
+  - The payload is wrapped in a DSEE envelope in encoded in base64. To make the provenance human readable, base64 decode the `payload` parameter, e.g.: 
+    ```cat OSNAME-multiple-provenance.intoto.jsonl | jq -r '.payload' | base64 -d | jq```
+  - Validate that the subject digests in `payload.subject` match the sha256 checksums of the SDK packages for the OS you're developing in
+  - Validate that the provenance builder in `payload.predicate.builder` corresponds to Github's generic SLSA3 provenance generator, which ensures SLSA level 3 compliance
+  - Check the source commit referenced in `payload.predicate.invocation.configSource` and `payload.predicate.invocation.environment` for:
+    - Source repository is a LaunchDarkly-owned repository
+    - Commit author is a LaunchDarkly entity
+    - (Optional) Code changes in the commit are trustworthy 
+  - Check the build workflow file referenced in `payload.predicate.invocation.configSource.entryPoint` for:
+    - Build is triggered by a LaunchDarkly-owned repository
+    - Build is executed by a LaunchDarkly-owned Github Actions workflow
+    - Build steps are trustworthy 
+- Check the provenance signature (`signatures[0].cert` in `OSNAME-multiple-provenance.intoto.jsonl`) to verify the authenticity of the build provenance:
+  - Certificate issuer is Sigstore 
+  - x509 extension field `1.3.6.1.4.1.57264.1.1` (OIDC Issuer) is `https://token.actions.githubusercontent.com`
+  - x509 extension field `1.3.6.1.4.1.57264.1.5` (GitHub Workflow Repository) is a LaunchDarkly-owned repository
+  - x509 extension field `1.3.6.1.4.1.57264.1.3` (GitHub Workflow SHA) matches the SHA of the source commit in the provenance payload
+  
+The recommendations above may be adjusted to fit your organization's needs and supply chain security policies. For additional questions, please contact [security@launchdarkly.com](mailto:security@launchdarkly.com).
+
 Contributing
 ------------
 


### PR DESCRIPTION
Drafting up documentation for how consumers may use the SLSA framework to verify SDK packages published with provenance to improve supply chain security.