### PR TITLE
ci: pin boost 1.81 on Windows CI

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -31,7 +31,7 @@ runs:
       id: boost-download
       shell: bash
       run: |
-        choco install boost-msvc-14.3 -y
+        choco install boost-msvc-14.3 --version 1.81.0 -y
         echo "BOOST_ROOT=C:\local\boost_1_82_0" >> $GITHUB_OUTPUT
 
     - name: Install boost using homebrew

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: |
         choco install boost-msvc-14.3 --version 1.81.0 -y
-        echo "BOOST_ROOT=C:\local\boost_1_82_0" >> $GITHUB_OUTPUT
+        echo "BOOST_ROOT=C:\local\boost_1_81_0" >> $GITHUB_OUTPUT
 
     - name: Install boost using homebrew
       id: brew-action


### PR DESCRIPTION
The current boost version for Windows is floating, and it recently updated to Boost 1.84. That's a problem because our boost download path is hardcoded since there isn't an easy way to obtain it from `choco`. 

This pins to 1.81 just like the Linux build.