### PR TITLE
ci: pin OpenSSL to 3.1.1 on Windows

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -31,7 +31,7 @@ runs:
       id: boost-download
       shell: bash
       run: |
-        choco install boost-msvc-14.3 --version 1.81.0 -y
+        choco install boost-msvc-14.3 --version 1.81.0 -y --no-progress
         echo "BOOST_ROOT=C:\local\boost_1_81_0" >> $GITHUB_OUTPUT
 
     - name: Install boost using homebrew

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco upgrade openssl --no-progress
+        choco install openssl --version 3.1.1 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
It appears the OpenSSL 3.2 release removed some functionality that was in 3.1, which Boost.Asio relied on. 

Not sure if it's actually OpenSSL 3.2 that did it, or the chocolatey packaging process. 

In any case, CI will fail on Windows until either this is pinned to 3.1.1 or we bump Boost (which may have a fix 🤷‍♂️ ).

```
error LNK2019: unresolved external symbol EVP_PKEY_is_a referenced in function "public: class boost::system::error_code __cdecl boost::asio::ssl::context::use_rsa_private_key(class boost::asio::const_buffer const &,enum boost::asio::ssl::context_base::file_format,class boost::system::error_code &)" (?use_rsa_private_key@context@ssl@asio@boost@@QEAA?AVerror_code@system@4@AEBVconst_buffer@34@W4file_format@context_base@234@AEAV564@@Z)

launchdarkly-cpp-server.lib(asio.cpp.obj) : error LNK2019: unresolved external symbol SSL_CTX_set0_tmp_dh_pkey referenced in function "private: class boost::system::error_code __cdecl boost::asio::ssl::context::do_use_tmp_dh(struct bio_st *,class boost::system::error_code &)" (?do_use_tmp_dh@context@ssl@asio@boost@@AEAA?AVerror_code@system@4@PEAUbio_st@@AEAV564@@Z)

gtest_launchdarkly-cpp-server.exe : fatal error LNK1120: 2 unresolved externals
```