### PR TITLE
fix: add missing <cstdint> in various headers

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
@@ -3,10 +3,10 @@
 #include <launchdarkly/data/evaluation_reason.hpp>
 #include <launchdarkly/value.hpp>
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <cstdint>
 
 namespace launchdarkly::server_side {
 
@@ -154,8 +154,8 @@ class AllFlagsState {
 
    private:
     bool const valid_;
-    const std::unordered_map<std::string, class State> flags_state_;
-    const std::unordered_map<std::string, Value> evaluations_;
+    std::unordered_map<std::string, class State> const flags_state_;
+    std::unordered_map<std::string, Value> const evaluations_;
 };
 
 void operator|=(AllFlagsState::Options& lhs, AllFlagsState::Options rhs);

--- a/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace launchdarkly::server_side {
 

--- a/libs/server-sdk/src/evaluation/bucketing.hpp
+++ b/libs/server-sdk/src/evaluation/bucketing.hpp
@@ -109,16 +109,16 @@ class BucketResult {
  * variation index for the context. For a plain variation, this is simply the
  * variation index. For a rollout, this utilizes the Bucket function.
  *
- * @param vr Variation or rollout.
+ * @param variation_or_rollout Variation or rollout.
  * @param flag_key Key of flag.
  * @param context Context to bucket.
  * @param salt Salt to use when bucketing.
  * @return A BucketResult on success, or an error if bucketing failed.
  */
 tl::expected<BucketResult, Error> Variation(
-    data_model::Flag::VariationOrRollout const& vr,
+    data_model::Flag::VariationOrRollout const& variation_or_rollout,
     std::string const& flag_key,
-    launchdarkly::Context const& context,
+    Context const& context,
     std::optional<std::string> const& salt);
 
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/bucketing.hpp
+++ b/libs/server-sdk/src/evaluation/bucketing.hpp
@@ -8,12 +8,12 @@
 
 #include <tl/expected.hpp>
 
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <ostream>
 #include <string>
 #include <variant>
-#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation {
 

--- a/libs/server-sdk/src/evaluation/bucketing.hpp
+++ b/libs/server-sdk/src/evaluation/bucketing.hpp
@@ -13,6 +13,7 @@
 #include <ostream>
 #include <string>
 #include <variant>
+#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation {
 

--- a/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
+++ b/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation::detail {
 

--- a/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
+++ b/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <variant>
 #include <vector>
-#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation::detail {
 

--- a/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
+++ b/libs/server-sdk/src/evaluation/detail/semver_operations.hpp
@@ -82,8 +82,8 @@ bool operator>(SemVer const& lhs, SemVer const& rhs);
  * containing a build string, it will not be present as this information
  * is discarded when parsing.
  */
-std::ostream& operator<<(std::ostream& out, SemVer const& sv);
+std::ostream& operator<<(std::ostream& out, SemVer const& semver);
 
-std::ostream& operator<<(std::ostream& out, SemVer::Token const& sv);
+std::ostream& operator<<(std::ostream& out, SemVer::Token const& semver_token);
 
 }  // namespace launchdarkly::server_side::evaluation::detail

--- a/libs/server-sdk/src/evaluation/evaluation_error.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <ostream>
-#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation {
 

--- a/libs/server-sdk/src/evaluation/evaluation_error.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_error.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <ostream>
+#include <cstdint>
 
 namespace launchdarkly::server_side::evaluation {
 


### PR DESCRIPTION
On our existing test systems (ubuntu, mac, windows), <cstdint> is included via other system headers such that compilation succeeds.

On Arch, this isn't the case. 