### PR TITLE
build: do not set MSVC_RUNTIME_LIBRARY

### DIFF
--- a/libs/client-sdk/src/CMakeLists.txt
+++ b/libs/client-sdk/src/CMakeLists.txt
@@ -48,9 +48,6 @@ target_link_libraries(${LIBNAME}
 
 add_library(launchdarkly::client ALIAS ${LIBNAME})
 
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-
 # Optional in case only the server SDK is being built.
 install(TARGETS ${LIBNAME} OPTIONAL)
 if (LD_BUILD_SHARED_LIBS AND MSVC)

--- a/libs/common/src/CMakeLists.txt
+++ b/libs/common/src/CMakeLists.txt
@@ -62,9 +62,6 @@ add_library(${LIBNAME} OBJECT
 
 add_library(launchdarkly::common ALIAS ${LIBNAME})
 
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-
 install(TARGETS ${LIBNAME})
 
 # Using PUBLIC_HEADERS would flatten the include.

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB HEADER_LIST CONFIGURE_DEPENDS
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/serialization/events/*.hpp"
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/signals/*.hpp"
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/data_sources/*.hpp"
-        )
+)
 
 # Automatic library: static or dynamic based on user config.
 add_library(${LIBNAME} OBJECT
@@ -55,9 +55,6 @@ target_compile_options(${LIBNAME} PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
         -Wno-deprecated-declarations>
 )
-
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 install(TARGETS ${LIBNAME})
 

--- a/libs/server-sdk-redis-source/src/CMakeLists.txt
+++ b/libs/server-sdk-redis-source/src/CMakeLists.txt
@@ -27,9 +27,6 @@ target_link_libraries(${LIBNAME}
 
 add_library(launchdarkly::server_redis_source ALIAS ${LIBNAME})
 
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-
 # Optional in case only the client SDK is being built.
 install(TARGETS ${LIBNAME} OPTIONAL)
 if (LD_BUILD_SHARED_LIBS AND MSVC)

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -78,9 +78,6 @@ target_link_libraries(${LIBNAME}
 
 add_library(launchdarkly::server ALIAS ${LIBNAME})
 
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-
 # Optional in case only the client SDK is being built.
 install(TARGETS ${LIBNAME} OPTIONAL)
 if (LD_BUILD_SHARED_LIBS AND MSVC)

--- a/libs/server-sent-events/src/CMakeLists.txt
+++ b/libs/server-sent-events/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 file(GLOB HEADER_LIST CONFIGURE_DEPENDS
         "${LaunchDarklySSEClient_SOURCE_DIR}/include/launchdarkly/*.hpp"
         "${LaunchDarklySSEClient_SOURCE_DIR}/include/launchdarkly/sse/*.hpp"
-        )
+)
 
 # Automatic library: static or dynamic based on user config.
 add_library(${LIBNAME} OBJECT
@@ -15,13 +15,9 @@ add_library(${LIBNAME} OBJECT
 target_link_libraries(${LIBNAME}
         PUBLIC OpenSSL::SSL Boost::headers foxy
         PRIVATE Boost::url Boost::disable_autolinking
-        )
+)
 
 add_library(launchdarkly::sse ALIAS ${LIBNAME})
-
-
-set_property(TARGET ${LIBNAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 install(TARGETS ${LIBNAME})
 


### PR DESCRIPTION
See: https://github.com/launchdarkly/cpp-sdks/issues/369

We're currently setting this variable explicitely. According to CMake docs, users can instead set `CMAKE_MSVC_RUNTIME_LIBRARY`: 
> This variable is used to initialize the [MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html#prop_tgt:MSVC_RUNTIME_LIBRARY) property on all targets as they are created.

If it's not set, then:
> If this variable is not set then the [MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html#prop_tgt:MSVC_RUNTIME_LIBRARY) target property will not be set automatically. If that property is not set then CMake uses the default value **MultiThreaded$<$<CONFIG:Debug>:Debug>DLL** to select a MSVC runtime library.

[(source)](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html)

That default value is what we were explicitly setting, so by removing that config, there should be no change in behavior besides allowing users to have control over it. 

Test build, Windows succeeds: https://github.com/launchdarkly/cpp-sdks/releases/tag/launchdarkly-cpp-server-v3.4.0