### PR TITLE
ci: upgrade to release-please v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,12 +15,10 @@ jobs:
       package-server-redis-released: ${{ steps.release.outputs['libs/server-sdk-redis-source--release_created'] }}
       package-server-redis-tag: ${{ steps.release.outputs['libs/server-sdk-redis-source--tag_name'] }}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{ secrets.GITHUB_TOKEN }}
-          default-branch: main
 
   release-client:
     strategy:
@@ -29,7 +27,7 @@ jobs:
         os: [ ubuntu-latest, windows-2022, macos-12 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
-    if: ${{ needs.release-please.outputs.package-client-released }}
+    if: ${{ needs.release-please.outputs.package-client-released == 'true'}}
     outputs:
       hashes-linux: ${{ steps.release-client.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-client.outputs.hashes-windows }}
@@ -53,7 +51,7 @@ jobs:
         os: [ ubuntu-latest, windows-2022, macos-12 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
-    if: ${{ needs.release-please.outputs.package-server-released }}
+    if: ${{ needs.release-please.outputs.package-server-released == 'true'}}
     outputs:
       hashes-linux: ${{ steps.release-server.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-server.outputs.hashes-windows }}
@@ -77,7 +75,7 @@ jobs:
         os: [ ubuntu-latest, windows-2022, macos-12 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
-    if: ${{ needs.release-please.outputs.package-server-redis-released }}
+    if: ${{ needs.release-please.outputs.package-server-redis-released  == 'true'}}
     outputs:
       hashes-linux: ${{ steps.release-server-redis.outputs.hashes-linux }}
       hashes-windows: ${{ steps.release-server-redis.outputs.hashes-windows }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,14 +24,8 @@
         "CMakeLists.txt"
       ]
     },
-    "libs/server-sent-events": {
-      "initial-version": "0.1.0"
-    },
-    "libs/common": {
-      "initial-version": "0.1.0"
-    },
-    "libs/internal": {
-      "initial-version": "0.1.0"
-    }
+    "libs/server-sent-events": {},
+    "libs/common": {},
+    "libs/internal": {}
   }
 }


### PR DESCRIPTION
Bumps release-please to v4, removing explicit `manifest` command. 