### PR TITLE
ci: upgrade googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,19 +97,7 @@ if (LD_BUILD_UNIT_TESTS)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=leak")
         endif ()
     endif ()
-    include(FetchContent)
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
-        # Affects robustness of timestamp checking on FetchContent dependencies.
-        cmake_policy(SET CMP0135 NEW)
-    endif ()
-    FetchContent_Declare(
-            googletest
-            URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
-    )
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-
+    include(${CMAKE_FILES}/googletest.cmake)
     enable_testing()
 endif ()
 

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(FetchContent)
+
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    # Affects robustness of timestamp checking on FetchContent dependencies.
+    cmake_policy(SET CMP0135 NEW)
+endif ()
+
+FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG c231e6f5b152029dbd5fa4a9e0c04095035aec3f
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
This upgrades googletest to a much more recent commit. The intention is to see if it helps with the `DEADLYSIGNAL` issue that has been plaguing this repo's CI for the last couple weeks. 

Underlying theory is that possibly there is some incompatibilitiy between the old googletest and gcc.