### PR TITLE
ci: use boost 1.83 to test a bug

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: MarkusJx/install-boost@v2.4.4
       id: boost-action
       with:
-        boost_version: 1.82.0
+        boost_version: 1.84.0
         toolset: ${{ inputs.toolset }}
         platform_version: ${{ inputs.platform_version }}
 

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: MarkusJx/install-boost@v2.4.4
       id: boost-action
       with:
-        boost_version: 1.81.0
+        boost_version: 1.83.0
         toolset: ${{ inputs.toolset }}
         platform_version: ${{ inputs.platform_version }}
 

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: MarkusJx/install-boost@v2.4.4
       id: boost-action
       with:
-        boost_version: 1.83.0
+        boost_version: 1.82.0
         toolset: ${{ inputs.toolset }}
         platform_version: ${{ inputs.platform_version }}
 

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -19,10 +19,10 @@ runs:
   steps:
     - name: Install boost using action
       if: runner.os == 'Linux'
-      uses: MarkusJx/install-boost@v2.4.4
+      uses: MarkusJx/install-boost@v2.4.5
       id: boost-action
       with:
-        boost_version: 1.84.0
+        boost_version: 1.85.0
         toolset: ${{ inputs.toolset }}
         platform_version: ${{ inputs.platform_version }}
 


### PR DESCRIPTION
Customer reports some failing JSON tests in Boost 1.83. The tests pass on Boost 1.81 and 1.85.

It's possible a bug was introduced in Boost 1.83, so testing that here.