### PR TITLE
docs: improve Doxygen rendering on C bindings

### DIFF
--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
@@ -92,12 +92,14 @@ struct LDPersistence {
  * passing a custom implementation into configuration.
  * @param backend Implementation to initialize.
  */
-LD_EXPORT(void) LDPersistence_Init(struct LDPersistence* implementation);
+LD_EXPORT(void)
+LDPersistence_Init(struct LDPersistence* implementation);
 
 /**
  * Constructs a client-side config builder.
  */
-LD_EXPORT(LDClientConfigBuilder) LDClientConfigBuilder_New(char const* sdk_key);
+LD_EXPORT(LDClientConfigBuilder)
+LDClientConfigBuilder_New(char const* sdk_key);
 
 /**
  * Sets a custom URL for the polling service.
@@ -325,7 +327,8 @@ LDDataSourceStreamBuilder_InitialReconnectDelayMs(LDDataSourceStreamBuilder b,
  *
  * @param b Builder to free.
  */
-LD_EXPORT(void) LDDataSourceStreamBuilder_Free(LDDataSourceStreamBuilder b);
+LD_EXPORT(void)
+LDDataSourceStreamBuilder_Free(LDDataSourceStreamBuilder b);
 
 /**
  * Creates a new DataSource builder for the Polling method.
@@ -353,7 +356,8 @@ LDDataSourcePollBuilder_IntervalS(LDDataSourcePollBuilder b,
  *
  * @param b Builder to free.
  */
-LD_EXPORT(void) LDDataSourcePollBuilder_Free(LDDataSourcePollBuilder b);
+LD_EXPORT(void)
+LDDataSourcePollBuilder_Free(LDDataSourcePollBuilder b);
 
 /**
  * This should be used for wrapper SDKs to set the wrapper name.
@@ -468,14 +472,16 @@ LDClientConfigBuilder_Logging_Custom(LDClientConfigBuilder b,
  * LDPersistenceCustomBuilder_Free.
  * @return New builder.
  */
-LD_EXPORT(LDPersistenceCustomBuilder) LDPersistenceCustomBuilder_New();
+LD_EXPORT(LDPersistenceCustomBuilder)
+LDPersistenceCustomBuilder_New();
 
 /**
  * Frees a custom persistence builder. Do not call if the builder was consumed
  * by the config builder.
  * @param b Builder to free.
  */
-LD_EXPORT(void) LDPersistenceCustomBuilder_Free(LDPersistenceCustomBuilder b);
+LD_EXPORT(void)
+LDPersistenceCustomBuilder_Free(LDPersistenceCustomBuilder b);
 
 /**
  * Sets a custom persistence implementation.

--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/config.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/config.h
@@ -19,7 +19,8 @@ typedef struct _LDClientConfig* LDClientConfig;
  *
  * @param config Config to free.
  */
-LD_EXPORT(void) LDClientConfig_Free(LDClientConfig config);
+LD_EXPORT(void)
+LDClientConfig_Free(LDClientConfig config);
 
 #ifdef __cplusplus
 }

--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/sdk.h
@@ -120,14 +120,16 @@ LDClientSDK_Start(LDClientSDK sdk,
  * @param sdk SDK. Must not be NULL.
  * @return True if initialized.
  */
-LD_EXPORT(bool) LDClientSDK_Initialized(LDClientSDK sdk);
+LD_EXPORT(bool)
+LDClientSDK_Initialized(LDClientSDK sdk);
 
 /**
  * Tracks that the current context performed an event for the given event name.
  * @param sdk SDK. Must not be NULL.
  * @param event_name Name of the event. Must not be NULL.
  */
-LD_EXPORT(void) LDClientSDK_TrackEvent(LDClientSDK sdk, char const* event_name);
+LD_EXPORT(void)
+LDClientSDK_TrackEvent(LDClientSDK sdk, char const* event_name);
 
 /**
  * Tracks that the current context performed an event for the given event
@@ -421,7 +423,8 @@ LDClientSDK_AllFlags(LDClientSDK sdk);
  * Frees the SDK's resources, shutting down any connections. May block.
  * @param sdk SDK.
  */
-LD_EXPORT(void) LDClientSDK_Free(LDClientSDK sdk);
+LD_EXPORT(void)
+LDClientSDK_Free(LDClientSDK sdk);
 
 /**
  * Listen for changes for the specific flag.
@@ -545,7 +548,8 @@ LDDataSourceStatus_GetLastError(LDDataSourceStatus status);
  * encountered an unrecoverable error or that the SDK was explicitly shut
  * down.
  */
-LD_EXPORT(time_t) LDDataSourceStatus_StateSince(LDDataSourceStatus status);
+LD_EXPORT(time_t)
+LDDataSourceStatus_StateSince(LDDataSourceStatus status);
 
 typedef void (*DataSourceStatusCallbackFn)(LDDataSourceStatus status,
                                            void* user_data);
@@ -619,7 +623,8 @@ LDClientSDK_DataSourceStatus_Status(LDClientSDK sdk);
  * Frees the data source status.
  * @param status The data source status to free.
  */
-LD_EXPORT(void) LDDataSourceStatus_Free(LDDataSourceStatus status);
+LD_EXPORT(void)
+LDDataSourceStatus_Free(LDDataSourceStatus status);
 
 #ifdef __cplusplus
 }

--- a/libs/common/include/launchdarkly/bindings/c/export.h
+++ b/libs/common/include/launchdarkly/bindings/c/export.h
@@ -1,3 +1,7 @@
+/**
+ * @file export.h
+ * @brief Export macros for C bindings
+ */
 #pragma once
 
 #ifdef DOXYGEN_SHOULD_SKIP_THIS

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
@@ -28,7 +28,8 @@ typedef struct _LDServerHttpPropertiesTlsBuilder*
 /**
  * Constructs a client-side config builder.
  */
-LD_EXPORT(LDServerConfigBuilder) LDServerConfigBuilder_New(char const* sdk_key);
+LD_EXPORT(LDServerConfigBuilder)
+LDServerConfigBuilder_New(char const* sdk_key);
 
 /**
  * Sets a custom URL for the polling service.

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/config.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/config.h
@@ -17,7 +17,8 @@ typedef struct _LDCServerConfig* LDServerConfig;
  * not need to be freed.
  * @param config Config to free.
  */
-LD_EXPORT(void) LDServerConfig_Free(LDServerConfig config);
+LD_EXPORT(void)
+LDServerConfig_Free(LDServerConfig config);
 
 #ifdef __cplusplus
 }

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/sdk.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/sdk.h
@@ -117,7 +117,8 @@ LDServerSDK_Start(LDServerSDK sdk,
  * @param sdk SDK. Must not be NULL.
  * @return True if initialized.
  */
-LD_EXPORT(bool) LDServerSDK_Initialized(LDServerSDK sdk);
+LD_EXPORT(bool)
+LDServerSDK_Initialized(LDServerSDK sdk);
 
 /**
  * Tracks that the given context performed an event with the given event name.
@@ -397,7 +398,8 @@ LDServerSDK_AllFlagsState(LDServerSDK sdk,
  * Frees the SDK's resources, shutting down any connections. May block.
  * @param sdk SDK.
  */
-LD_EXPORT(void) LDServerSDK_Free(LDServerSDK sdk);
+LD_EXPORT(void)
+LDServerSDK_Free(LDServerSDK sdk);
 
 typedef struct _LDServerDataSourceStatus* LDServerDataSourceStatus;
 
@@ -572,7 +574,8 @@ LDServerSDK_DataSourceStatus_Status(LDServerSDK sdk);
  * Frees the data source status.
  * @param status The data source status to free.
  */
-LD_EXPORT(void) LDServerDataSourceStatus_Free(LDServerDataSourceStatus status);
+LD_EXPORT(void)
+LDServerDataSourceStatus_Free(LDServerDataSourceStatus status);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When `LD_EXPORT` appears on the same line as the function name, Doxygen doesn't render the function name nicely and it's confusing.

This fixes a bunch of instances that I found in the C bindings.