### PR TITLE
refactor: replace boost::json::error_code with boost::system::error_code

### DIFF
--- a/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
+++ b/libs/client-sdk/src/data_sources/data_source_event_handler.cpp
@@ -85,7 +85,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
     std::string const& type,
     std::string const& data) {
     if (type == "put") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingPut;
@@ -114,7 +114,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
         return MessageStatus::kInvalidMessage;
     }
     if (type == "patch") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingPatch;
@@ -137,7 +137,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
         return MessageStatus::kInvalidMessage;
     }
     if (type == "delete") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingDelete;

--- a/libs/client-sdk/src/flag_manager/flag_persistence.cpp
+++ b/libs/client-sdk/src/flag_manager/flag_persistence.cpp
@@ -65,7 +65,7 @@ void FlagPersistence::LoadCached(Context const& context) {
         return;
     }
 
-    boost::json::error_code error_code;
+    boost::system::error_code error_code;
     auto parsed = boost::json::parse(*data, error_code);
     if (error_code) {
         LD_LOG(logger_, LogLevel::kError)
@@ -119,7 +119,7 @@ ContextIndex FlagPersistence::GetIndex() {
             persistence_->Read(environment_namespace_, index_key_);
 
         if (index_data) {
-            boost::json::error_code error_code;
+            boost::system::error_code error_code;
             auto parsed = boost::json::parse(*index_data, error_code);
             if (error_code) {
                 LD_LOG(logger_, LogLevel::kError)

--- a/libs/client-sdk/tests/context_index_test.cpp
+++ b/libs/client-sdk/tests/context_index_test.cpp
@@ -99,7 +99,7 @@ TEST(ContextIndexTests, CanSerializeAndDeserialize) {
 
     auto str = boost::json::serialize(boost::json::value_from(context_index));
 
-    boost::json::error_code error_code;
+    boost::system::error_code error_code;
     auto parsed = boost::json::parse(str, error_code);
     auto deserialized = boost::json::value_to<ContextIndex>(parsed);
 

--- a/libs/internal/src/serialization/json_primitives.cpp
+++ b/libs/internal/src/serialization/json_primitives.cpp
@@ -26,7 +26,7 @@ tl::expected<std::optional<std::uint64_t>, JsonError> tag_invoke(
     if (!json_value.is_number()) {
         return tl::unexpected(JsonError::kSchemaFailure);
     }
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     auto val = json_value.to_number<uint64_t>(ec);
     if (ec) {
         return tl::unexpected(JsonError::kSchemaFailure);
@@ -45,7 +45,7 @@ tl::expected<std::optional<std::int64_t>, JsonError> tag_invoke(
     if (!json_value.is_number()) {
         return tl::unexpected(JsonError::kSchemaFailure);
     }
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     auto val = json_value.to_number<int64_t>(ec);
     if (ec) {
         return tl::unexpected(JsonError::kSchemaFailure);

--- a/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
@@ -121,7 +121,7 @@ void PollingDataSource::HandlePollResult(network::HttpResult const& res) {
     } else if (res.Status() == 200) {
         auto const& body = res.Body();
         if (body.has_value()) {
-            boost::json::error_code error_code;
+            boost::system::error_code error_code;
             auto parsed = boost::json::parse(body.value(), error_code);
             if (error_code) {
                 LD_LOG(logger_, LogLevel::kError) << kErrorParsingPut;

--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/event_handler.cpp
@@ -135,7 +135,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
     std::string const& type,
     std::string const& data) {
     if (type == "put") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingPut;
@@ -165,7 +165,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
         return MessageStatus::kMessageHandled;
     }
     if (type == "patch") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingPut;
@@ -197,7 +197,7 @@ DataSourceEventHandler::MessageStatus DataSourceEventHandler::HandleMessage(
         return MessageStatus::kMessageHandled;
     }
     if (type == "delete") {
-        boost::json::error_code error_code;
+        boost::system::error_code error_code;
         auto parsed = boost::json::parse(data, error_code);
         if (error_code) {
             LD_LOG(logger_, LogLevel::kError) << kErrorParsingDelete;

--- a/libs/server-sdk/src/integrations/data_reader/kinds.cpp
+++ b/libs/server-sdk/src/integrations/data_reader/kinds.cpp
@@ -10,7 +10,7 @@ namespace launchdarkly::server_side::integrations {
 
 template <typename TData>
 static uint64_t GetVersion(std::string const& data) {
-    boost::json::error_code error_code;
+    boost::system::error_code error_code;
     auto const parsed = boost::json::parse(data, error_code);
 
     if (error_code) {


### PR DESCRIPTION
The latest Boost 1.85 release has deprecated usage of `boost::json::error_code`, and since that causes warnings, our CI fails (since we have warnings-as-errors in CI.)

That type was just an alias for `boost::system::error_code`, so I've done a find and replace.