### PR TITLE
feat: specify a custom CA file for TLS peer verification

### DIFF
--- a/contract-tests/client-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/client-contract-tests/src/entity_manager.cpp
@@ -135,7 +135,7 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
             builder.SkipVerifyPeer(*in.tls->skipVerifyPeer);
         }
         if (in.tls->customCAFile) {
-            builder.CABundlePath(*in.tls->customCAFile);
+            builder.CustomCAFile(*in.tls->customCAFile);
         }
         config_builder.HttpProperties().Tls(std::move(builder));
     }

--- a/contract-tests/client-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/client-contract-tests/src/entity_manager.cpp
@@ -134,6 +134,9 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
         if (in.tls->skipVerifyPeer) {
             builder.SkipVerifyPeer(*in.tls->skipVerifyPeer);
         }
+        if (in.tls->customCAPath) {
+            builder.CABundlePath(*in.tls->customCAPath);
+        }
         config_builder.HttpProperties().Tls(std::move(builder));
     }
 

--- a/contract-tests/client-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/client-contract-tests/src/entity_manager.cpp
@@ -134,8 +134,8 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
         if (in.tls->skipVerifyPeer) {
             builder.SkipVerifyPeer(*in.tls->skipVerifyPeer);
         }
-        if (in.tls->customCAPath) {
-            builder.CABundlePath(*in.tls->customCAPath);
+        if (in.tls->customCAFile) {
+            builder.CABundlePath(*in.tls->customCAFile);
         }
         config_builder.HttpProperties().Tls(std::move(builder));
     }

--- a/contract-tests/client-contract-tests/src/main.cpp
+++ b/contract-tests/client-contract-tests/src/main.cpp
@@ -45,7 +45,8 @@ int main(int argc, char* argv[]) {
         srv.add_capability("anonymous-redaction");
         srv.add_capability("tls:verify-peer");
         srv.add_capability("tls:skip-verify-peer");
-
+        srv.add_capability("tls:custom-ca");
+        
         net::signal_set signals{ioc, SIGINT, SIGTERM};
 
         boost::asio::spawn(ioc.get_executor(), [&](auto yield) mutable {

--- a/contract-tests/data-model/include/data_model/data_model.hpp
+++ b/contract-tests/data-model/include/data_model/data_model.hpp
@@ -31,9 +31,12 @@ struct adl_serializer<std::optional<T>> {
 
 struct ConfigTLSParams {
     std::optional<bool> skipVerifyPeer;
+    std::optional<std::string> customCAPath;
 };
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ConfigTLSParams,
-                                                skipVerifyPeer);
+                                                skipVerifyPeer,
+                                                customCAPath);
 
 struct ConfigStreamingParams {
     std::optional<std::string> baseUri;

--- a/contract-tests/data-model/include/data_model/data_model.hpp
+++ b/contract-tests/data-model/include/data_model/data_model.hpp
@@ -31,12 +31,12 @@ struct adl_serializer<std::optional<T>> {
 
 struct ConfigTLSParams {
     std::optional<bool> skipVerifyPeer;
-    std::optional<std::string> customCAPath;
+    std::optional<std::string> customCAFile;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ConfigTLSParams,
                                                 skipVerifyPeer,
-                                                customCAPath);
+                                                customCAFile);
 
 struct ConfigStreamingParams {
     std::optional<std::string> baseUri;

--- a/contract-tests/server-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/server-contract-tests/src/entity_manager.cpp
@@ -126,7 +126,7 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
             builder.SkipVerifyPeer(*in.tls->skipVerifyPeer);
         }
         if (in.tls->customCAFile) {
-            builder.CABundlePath(*in.tls->customCAFile);
+            builder.CustomCAFile(*in.tls->customCAFile);
         }
         config_builder.HttpProperties().Tls(std::move(builder));
     }

--- a/contract-tests/server-contract-tests/src/entity_manager.cpp
+++ b/contract-tests/server-contract-tests/src/entity_manager.cpp
@@ -125,6 +125,9 @@ std::optional<std::string> EntityManager::create(ConfigParams const& in) {
         if (in.tls->skipVerifyPeer) {
             builder.SkipVerifyPeer(*in.tls->skipVerifyPeer);
         }
+        if (in.tls->customCAFile) {
+            builder.CABundlePath(*in.tls->customCAFile);
+        }
         config_builder.HttpProperties().Tls(std::move(builder));
     }
 

--- a/contract-tests/server-contract-tests/src/main.cpp
+++ b/contract-tests/server-contract-tests/src/main.cpp
@@ -44,6 +44,7 @@ int main(int argc, char* argv[]) {
         srv.add_capability("anonymous-redaction");
         srv.add_capability("tls:verify-peer");
         srv.add_capability("tls:skip-verify-peer");
+        srv.add_capability("tls:custom-ca");
 
         net::signal_set signals{ioc, SIGINT, SIGTERM};
 

--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
@@ -442,11 +442,18 @@ LDClientHttpPropertiesTlsBuilder_SkipVerifyPeer(
 
 /**
  * Configures TLS peer certificate verification to use a custom
- * CA file. The parameter is a filepath pointing to a bundle of
- * one or more x509 certificates comprising the root of trust for the SDK's
- * outbound connections.
+ * CA file.
+ *
+ * The parameter is a filepath pointing to a bundle of
+ * one or more PEM-encoded x509 certificates comprising the root of trust for
+ * the SDK's outbound connections.
+ *
+ * By default, the SDK uses the system's CA bundle. Passing the empty string
+ * will unset any previously set path and revert to the system's CA bundle.
+ *
  * @param b Client config builder. Must not be NULL.
- * @param custom_ca_file Filepath of the custom CA bundle. Must not be NULL.
+ * @param custom_ca_file Filepath of the custom CA bundle, or empty string. Must
+ * not be NULL.
  */
 LD_EXPORT(void)
 LDClientHttpPropertiesTlsBuilder_CustomCAFile(

--- a/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
+++ b/libs/client-sdk/include/launchdarkly/client_side/bindings/c/config/builder.h
@@ -441,6 +441,19 @@ LDClientHttpPropertiesTlsBuilder_SkipVerifyPeer(
     bool skip_verify_peer);
 
 /**
+ * Configures TLS peer certificate verification to use a custom
+ * CA file. The parameter is a filepath pointing to a bundle of
+ * one or more x509 certificates comprising the root of trust for the SDK's
+ * outbound connections.
+ * @param b Client config builder. Must not be NULL.
+ * @param custom_ca_file Filepath of the custom CA bundle. Must not be NULL.
+ */
+LD_EXPORT(void)
+LDClientHttpPropertiesTlsBuilder_CustomCAFile(
+    LDClientHttpPropertiesTlsBuilder b,
+    char const* custom_ca_file);
+
+/**
  * Disables the default SDK logging.
  * @param b Client config builder. Must not be NULL.
  */

--- a/libs/client-sdk/src/bindings/c/builder.cpp
+++ b/libs/client-sdk/src/bindings/c/builder.cpp
@@ -332,6 +332,16 @@ LDClientHttpPropertiesTlsBuilder_SkipVerifyPeer(
     TO_TLS_BUILDER(b)->SkipVerifyPeer(skip_verify_peer);
 }
 
+LD_EXPORT(void)
+LDClientHttpPropertiesTlsBuilder_CustomCAFile(
+    LDClientHttpPropertiesTlsBuilder b,
+    char const* custom_ca_file) {
+    LD_ASSERT_NOT_NULL(b);
+    LD_ASSERT_NOT_NULL(custom_ca_file);
+
+    TO_TLS_BUILDER(b)->CABundlePath(custom_ca_file);
+}
+
 LD_EXPORT(LDClientHttpPropertiesTlsBuilder)
 LDClientHttpPropertiesTlsBuilder_New(void) {
     return FROM_TLS_BUILDER(new TlsBuilder());

--- a/libs/client-sdk/src/bindings/c/builder.cpp
+++ b/libs/client-sdk/src/bindings/c/builder.cpp
@@ -339,7 +339,7 @@ LDClientHttpPropertiesTlsBuilder_CustomCAFile(
     LD_ASSERT_NOT_NULL(b);
     LD_ASSERT_NOT_NULL(custom_ca_file);
 
-    TO_TLS_BUILDER(b)->CABundlePath(custom_ca_file);
+    TO_TLS_BUILDER(b)->CustomCAFile(custom_ca_file);
 }
 
 LD_EXPORT(LDClientHttpPropertiesTlsBuilder)

--- a/libs/client-sdk/src/client_impl.cpp
+++ b/libs/client-sdk/src/client_impl.cpp
@@ -109,6 +109,16 @@ ClientImpl::ClientImpl(Config in_cfg,
       eval_reasons_available_(config_.DataSourceConfig().with_reasons) {
     flag_manager_.LoadCache(context_);
 
+    if (auto custom_ca = http_properties_.Tls().CustomCAFile()) {
+        LD_LOG(logger_, LogLevel::kInfo)
+            << "TLS peer verification configured with custom CA file: "
+            << *custom_ca;
+    }
+    if (http_properties_.Tls().PeerVerifyMode() ==
+        config::shared::built::TlsOptions::VerifyMode::kVerifyNone) {
+        LD_LOG(logger_, LogLevel::kInfo) << "TLS peer verification disabled";
+    }
+
     if (config_.Events().Enabled() && !config_.Offline()) {
         event_processor_ =
             std::make_unique<events::AsioEventProcessor<ClientSDK>>(

--- a/libs/client-sdk/src/data_sources/polling_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/polling_data_source.cpp
@@ -74,7 +74,7 @@ PollingDataSource::PollingDataSource(
       status_manager_(status_manager),
       data_source_handler_(
           DataSourceEventHandler(context, handler, logger, status_manager_)),
-      requester_(ioc, http_properties.Tls().PeerVerifyMode()),
+      requester_(ioc, http_properties.Tls()),
       timer_(ioc),
       polling_interval_(
           std::get<

--- a/libs/client-sdk/src/data_sources/polling_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/polling_data_source.cpp
@@ -88,15 +88,6 @@ PollingDataSource::PollingDataSource(
     auto const& polling_config = std::get<
         config::shared::built::PollingConfig<config::shared::ClientSDK>>(
         data_source_config.method);
-    if (http_properties.Tls().CustomCAFile()) {
-        LD_LOG(logger_, LogLevel::kDebug)
-            << "TLS peer verification configured with custom CA file: "
-            << *http_properties.Tls().CustomCAFile();
-    }
-    if (http_properties.Tls().PeerVerifyMode() ==
-        config::shared::built::TlsOptions::VerifyMode::kVerifyNone) {
-        LD_LOG(logger_, LogLevel::kDebug) << "TLS peer verification disabled";
-    }
     if (polling_interval_ < polling_config.min_polling_interval) {
         LD_LOG(logger_, LogLevel::kWarn)
             << "Polling interval too frequent, defaulting to "

--- a/libs/client-sdk/src/data_sources/polling_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/polling_data_source.cpp
@@ -88,6 +88,11 @@ PollingDataSource::PollingDataSource(
     auto const& polling_config = std::get<
         config::shared::built::PollingConfig<config::shared::ClientSDK>>(
         data_source_config.method);
+    if (http_properties.Tls().CustomCAFile()) {
+        LD_LOG(logger_, LogLevel::kDebug)
+            << "TLS peer verification configured with custom CA file: "
+            << *http_properties.Tls().CustomCAFile();
+    }
     if (http_properties.Tls().PeerVerifyMode() ==
         config::shared::built::TlsOptions::VerifyMode::kVerifyNone) {
         LD_LOG(logger_, LogLevel::kDebug) << "TLS peer verification disabled";

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -132,6 +132,10 @@ void StreamingDataSource::Start() {
         client_builder.skip_verify_peer(true);
     }
 
+    if (auto bundle = http_config_.Tls().CABundlePath()) {
+        client_builder.ca_bundle_path(*bundle);
+    }
+
     auto weak_self = weak_from_this();
 
     client_builder.receiver([weak_self](launchdarkly::sse::Event const& event) {

--- a/libs/client-sdk/src/data_sources/streaming_data_source.cpp
+++ b/libs/client-sdk/src/data_sources/streaming_data_source.cpp
@@ -132,8 +132,8 @@ void StreamingDataSource::Start() {
         client_builder.skip_verify_peer(true);
     }
 
-    if (auto bundle = http_config_.Tls().CABundlePath()) {
-        client_builder.ca_bundle_path(*bundle);
+    if (auto ca_file = http_config_.Tls().CustomCAFile()) {
+        client_builder.custom_ca_file(*ca_file);
     }
 
     auto weak_self = weak_from_this();

--- a/libs/client-sdk/tests/client_config_test.cpp
+++ b/libs/client-sdk/tests/client_config_test.cpp
@@ -82,6 +82,7 @@ TEST(ClientConfigBindings, AllConfigs) {
     LDClientHttpPropertiesTlsBuilder tls_builder =
         LDClientHttpPropertiesTlsBuilder_New();
     LDClientHttpPropertiesTlsBuilder_SkipVerifyPeer(tls_builder, false);
+    LDClientHttpPropertiesTlsBuilder_CustomCAFile(tls_builder, "ca.pem");
     LDClientConfigBuilder_HttpProperties_Tls(builder, tls_builder);
 
     LDClientHttpPropertiesTlsBuilder tls_builder2 =

--- a/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
+++ b/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
@@ -46,6 +46,10 @@ class TlsBuilder {
      *
      * By default, this is the system's root CA bundle.
      *
+     * If the empty string is passed, this function will clear any existing
+     * CA bundle path previously set, and the system's root CA bundle will be
+     * used.
+     *
      * @param ca_bundle_path File path.
      * @return A reference to this builder.
      */

--- a/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
+++ b/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
@@ -41,19 +41,19 @@ class TlsBuilder {
     TlsBuilder& SkipVerifyPeer(bool skip_verify_peer);
 
     /**
-     * Path to a file containing one or more certificates to verify
-     * the peer with.
+     * Path to a file containing one or more CAs to verify
+     * the peer with. The certificate(s) must be PEM-encoded.
      *
-     * By default, this is the system's root CA bundle.
+     * By default, the SDK uses the system's root CA bundle.
      *
      * If the empty string is passed, this function will clear any existing
      * CA bundle path previously set, and the system's root CA bundle will be
      * used.
      *
-     * @param ca_bundle_path File path.
+     * @param custom_ca_file File path.
      * @return A reference to this builder.
      */
-    TlsBuilder& CABundlePath(std::string ca_bundle_path);
+    TlsBuilder& CustomCAFile(std::string custom_ca_file);
 
     /**
      * Builds the TLS options.
@@ -63,7 +63,7 @@ class TlsBuilder {
 
    private:
     enum built::TlsOptions::VerifyMode verify_mode_;
-    std::optional<std::string> ca_bundle_path_;
+    std::optional<std::string> custom_ca_file_;
 };
 /**
  * Class used for building a set of HttpProperties.

--- a/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
+++ b/libs/common/include/launchdarkly/config/shared/builders/http_properties_builder.hpp
@@ -41,6 +41,17 @@ class TlsBuilder {
     TlsBuilder& SkipVerifyPeer(bool skip_verify_peer);
 
     /**
+     * Path to a file containing one or more certificates to verify
+     * the peer with.
+     *
+     * By default, this is the system's root CA bundle.
+     *
+     * @param ca_bundle_path File path.
+     * @return A reference to this builder.
+     */
+    TlsBuilder& CABundlePath(std::string ca_bundle_path);
+
+    /**
      * Builds the TLS options.
      * @return The built options.
      */
@@ -48,6 +59,7 @@ class TlsBuilder {
 
    private:
     enum built::TlsOptions::VerifyMode verify_mode_;
+    std::optional<std::string> ca_bundle_path_;
 };
 /**
  * Class used for building a set of HttpProperties.

--- a/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
+++ b/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
@@ -11,7 +11,7 @@ namespace launchdarkly::config::shared::built {
 class TlsOptions final {
    public:
     enum class VerifyMode { kVerifyPeer, kVerifyNone };
-    TlsOptions(VerifyMode verify_mode);
+    explicit TlsOptions(VerifyMode verify_mode);
     TlsOptions(VerifyMode verify_mode,
                std::optional<std::string> ca_bundle_path);
     TlsOptions();

--- a/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
+++ b/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
@@ -16,7 +16,7 @@ class TlsOptions final {
                std::optional<std::string> ca_bundle_path);
     TlsOptions();
     [[nodiscard]] VerifyMode PeerVerifyMode() const;
-    [[nodiscard]] std::optional<std::string> const& CABundlePath() const;
+    [[nodiscard]] std::optional<std::string> const& CustomCAFile() const;
 
    private:
     VerifyMode verify_mode_;

--- a/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
+++ b/libs/common/include/launchdarkly/config/shared/built/http_properties.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -11,11 +12,15 @@ class TlsOptions final {
    public:
     enum class VerifyMode { kVerifyPeer, kVerifyNone };
     TlsOptions(VerifyMode verify_mode);
+    TlsOptions(VerifyMode verify_mode,
+               std::optional<std::string> ca_bundle_path);
     TlsOptions();
     [[nodiscard]] VerifyMode PeerVerifyMode() const;
+    [[nodiscard]] std::optional<std::string> const& CABundlePath() const;
 
    private:
     VerifyMode verify_mode_;
+    std::optional<std::string> ca_bundle_path_;
 };
 
 class HttpProperties final {

--- a/libs/common/src/config/http_properties.cpp
+++ b/libs/common/src/config/http_properties.cpp
@@ -4,13 +4,22 @@
 
 namespace launchdarkly::config::shared::built {
 
-TlsOptions::TlsOptions(enum TlsOptions::VerifyMode verify_mode)
-    : verify_mode_(verify_mode) {}
+TlsOptions::TlsOptions(TlsOptions::VerifyMode verify_mode,
+                       std::optional<std::string> ca_bundle_path)
+    : verify_mode_(verify_mode), ca_bundle_path_(std::move(ca_bundle_path)) {}
 
-TlsOptions::TlsOptions() : TlsOptions(TlsOptions::VerifyMode::kVerifyPeer) {}
+TlsOptions::TlsOptions(TlsOptions::VerifyMode verify_mode)
+    : TlsOptions(verify_mode, std::nullopt) {}
+
+TlsOptions::TlsOptions()
+    : TlsOptions(TlsOptions::VerifyMode::kVerifyPeer, std::nullopt) {}
 
 TlsOptions::VerifyMode TlsOptions::PeerVerifyMode() const {
     return verify_mode_;
+}
+
+std::optional<std::string> const& TlsOptions::CABundlePath() const {
+    return ca_bundle_path_;
 }
 
 HttpProperties::HttpProperties(std::chrono::milliseconds connect_timeout,
@@ -58,7 +67,8 @@ bool operator==(HttpProperties const& lhs, HttpProperties const& rhs) {
 }
 
 bool operator==(TlsOptions const& lhs, TlsOptions const& rhs) {
-    return lhs.PeerVerifyMode() == rhs.PeerVerifyMode();
+    return lhs.PeerVerifyMode() == rhs.PeerVerifyMode() &&
+           lhs.CABundlePath() == rhs.CABundlePath();
 }
 
 }  // namespace launchdarkly::config::shared::built

--- a/libs/common/src/config/http_properties.cpp
+++ b/libs/common/src/config/http_properties.cpp
@@ -18,7 +18,7 @@ TlsOptions::VerifyMode TlsOptions::PeerVerifyMode() const {
     return verify_mode_;
 }
 
-std::optional<std::string> const& TlsOptions::CABundlePath() const {
+std::optional<std::string> const& TlsOptions::CustomCAFile() const {
     return ca_bundle_path_;
 }
 
@@ -68,7 +68,7 @@ bool operator==(HttpProperties const& lhs, HttpProperties const& rhs) {
 
 bool operator==(TlsOptions const& lhs, TlsOptions const& rhs) {
     return lhs.PeerVerifyMode() == rhs.PeerVerifyMode() &&
-           lhs.CABundlePath() == rhs.CABundlePath();
+           lhs.CustomCAFile() == rhs.CustomCAFile();
 }
 
 }  // namespace launchdarkly::config::shared::built

--- a/libs/common/src/config/http_properties_builder.cpp
+++ b/libs/common/src/config/http_properties_builder.cpp
@@ -12,7 +12,7 @@ TlsBuilder<SDK>::TlsBuilder() : TlsBuilder(shared::Defaults<SDK>::TLS()) {}
 template <typename SDK>
 TlsBuilder<SDK>::TlsBuilder(built::TlsOptions const& tls) {
     verify_mode_ = tls.PeerVerifyMode();
-    ca_bundle_path_ = tls.CABundlePath();
+    custom_ca_file_ = tls.CustomCAFile();
 }
 
 template <typename SDK>
@@ -24,18 +24,18 @@ TlsBuilder<SDK>& TlsBuilder<SDK>::SkipVerifyPeer(bool skip_verify_peer) {
 }
 
 template <typename SDK>
-TlsBuilder<SDK>& TlsBuilder<SDK>::CABundlePath(std::string ca_bundle_path) {
-    if (ca_bundle_path.empty()) {
-        ca_bundle_path_ = std::nullopt;
+TlsBuilder<SDK>& TlsBuilder<SDK>::CustomCAFile(std::string custom_ca_file) {
+    if (custom_ca_file.empty()) {
+        custom_ca_file_ = std::nullopt;
     } else {
-        ca_bundle_path_ = std::move(ca_bundle_path);
+        custom_ca_file_ = std::move(custom_ca_file);
     }
     return *this;
 }
 
 template <typename SDK>
 built::TlsOptions TlsBuilder<SDK>::Build() const {
-    return {verify_mode_, ca_bundle_path_};
+    return {verify_mode_, custom_ca_file_};
 }
 
 template <typename SDK>

--- a/libs/common/src/config/http_properties_builder.cpp
+++ b/libs/common/src/config/http_properties_builder.cpp
@@ -25,7 +25,11 @@ TlsBuilder<SDK>& TlsBuilder<SDK>::SkipVerifyPeer(bool skip_verify_peer) {
 
 template <typename SDK>
 TlsBuilder<SDK>& TlsBuilder<SDK>::CABundlePath(std::string ca_bundle_path) {
-    ca_bundle_path_ = std::move(ca_bundle_path);
+    if (ca_bundle_path.empty()) {
+        ca_bundle_path_ = std::nullopt;
+    } else {
+        ca_bundle_path_ = std::move(ca_bundle_path);
+    }
     return *this;
 }
 

--- a/libs/common/src/config/http_properties_builder.cpp
+++ b/libs/common/src/config/http_properties_builder.cpp
@@ -12,6 +12,7 @@ TlsBuilder<SDK>::TlsBuilder() : TlsBuilder(shared::Defaults<SDK>::TLS()) {}
 template <typename SDK>
 TlsBuilder<SDK>::TlsBuilder(built::TlsOptions const& tls) {
     verify_mode_ = tls.PeerVerifyMode();
+    ca_bundle_path_ = tls.CABundlePath();
 }
 
 template <typename SDK>
@@ -23,8 +24,14 @@ TlsBuilder<SDK>& TlsBuilder<SDK>::SkipVerifyPeer(bool skip_verify_peer) {
 }
 
 template <typename SDK>
+TlsBuilder<SDK>& TlsBuilder<SDK>::CABundlePath(std::string ca_bundle_path) {
+    ca_bundle_path_ = std::move(ca_bundle_path);
+    return *this;
+}
+
+template <typename SDK>
 built::TlsOptions TlsBuilder<SDK>::Build() const {
-    return {verify_mode_};
+    return {verify_mode_, ca_bundle_path_};
 }
 
 template <typename SDK>

--- a/libs/internal/include/launchdarkly/events/detail/request_worker.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/request_worker.hpp
@@ -99,13 +99,12 @@ class RequestWorker {
      * @param mode TLS peer verification mode.
      * @param logger Logger.
      */
-    RequestWorker(
-        boost::asio::any_io_executor io,
-        std::chrono::milliseconds retry_after,
-        std::size_t id,
-        std::optional<std::locale> date_header_locale,
-        enum config::shared::built::TlsOptions::VerifyMode verify_mode,
-        Logger& logger);
+    RequestWorker(boost::asio::any_io_executor io,
+                  std::chrono::milliseconds retry_after,
+                  std::size_t id,
+                  std::optional<std::locale> date_header_locale,
+                  config::shared::built::TlsOptions tls_options,
+                  Logger& logger);
 
     /**
      * Returns true if the worker is available for delivery.

--- a/libs/internal/include/launchdarkly/events/detail/worker_pool.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/worker_pool.hpp
@@ -30,13 +30,14 @@ class WorkerPool {
      * @param pool_size How many workers to make available.
      * @param delivery_retry_delay How long a worker should wait after a failed
      * delivery before trying again.
-     * @param verify_mode The TLS verification mode.
+     * @param tls_options The TLS options to use for the connection to
+     * LaunchDarkly event delivery endpoint.
      * @param logger Logger.
      */
     WorkerPool(boost::asio::any_io_executor io,
                std::size_t pool_size,
                std::chrono::milliseconds delivery_retry_delay,
-               enum config::shared::built::TlsOptions::VerifyMode verify_mode,
+               config::shared::built::TlsOptions tls_options,
                Logger& logger);
 
     /**

--- a/libs/internal/include/launchdarkly/events/detail/worker_pool.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/worker_pool.hpp
@@ -37,7 +37,7 @@ class WorkerPool {
     WorkerPool(boost::asio::any_io_executor io,
                std::size_t pool_size,
                std::chrono::milliseconds delivery_retry_delay,
-               config::shared::built::TlsOptions tls_options,
+               config::shared::built::TlsOptions const& tls_options,
                Logger& logger);
 
     /**

--- a/libs/internal/include/launchdarkly/network/asio_requester.hpp
+++ b/libs/internal/include/launchdarkly/network/asio_requester.hpp
@@ -263,12 +263,12 @@ class AsioRequester {
         : ctx_(std::move(ctx)),
           ssl_ctx_(std::make_shared<net::ssl::context>(
               launchdarkly::foxy::make_ssl_ctx(ssl::context::tlsv12_client))) {
-        std::optional<std::string> const& bundle = tls_options.CABundlePath();
-        if (bundle) {
-            // The builder should enforce that the bundle path (if set) is not
-            // empty.
-            LD_ASSERT(!bundle->empty());
-            ssl_ctx_->load_verify_file(bundle->c_str());
+        std::optional<std::string> const& custom_ca_file =
+            tls_options.CustomCAFile();
+        if (custom_ca_file) {
+            // The builder should enforce that the path (if set) is not empty.
+            LD_ASSERT(!custom_ca_file->empty());
+            ssl_ctx_->load_verify_file(custom_ca_file->c_str());
         } else {
             ssl_ctx_->set_default_verify_paths();
         }

--- a/libs/internal/include/launchdarkly/network/asio_requester.hpp
+++ b/libs/internal/include/launchdarkly/network/asio_requester.hpp
@@ -268,7 +268,7 @@ class AsioRequester {
             // The builder should enforce that the bundle path (if set) is not
             // empty.
             LD_ASSERT(!bundle->empty());
-            ssl_ctx_->add_verify_path(bundle->c_str());
+            ssl_ctx_->load_verify_file(bundle->c_str());
         } else {
             ssl_ctx_->set_default_verify_paths();
         }

--- a/libs/internal/src/events/asio_event_processor.cpp
+++ b/libs/internal/src/events/asio_event_processor.cpp
@@ -47,7 +47,7 @@ AsioEventProcessor<SDK>::AsioEventProcessor(
       workers_(io_,
                events_config.FlushWorkers(),
                events_config.DeliveryRetryDelay(),
-               http_properties.Tls().PeerVerifyMode(),
+               http_properties.Tls(),
                logger),
       inbox_capacity_(events_config.Capacity()),
       inbox_size_(0),

--- a/libs/internal/src/events/request_worker.cpp
+++ b/libs/internal/src/events/request_worker.cpp
@@ -3,17 +3,16 @@
 
 namespace launchdarkly::events::detail {
 
-RequestWorker::RequestWorker(
-    boost::asio::any_io_executor io,
-    std::chrono::milliseconds retry_after,
-    std::size_t id,
-    std::optional<std::locale> date_header_locale,
-    enum config::shared::built::TlsOptions::VerifyMode verify_mode,
-    Logger& logger)
+RequestWorker::RequestWorker(boost::asio::any_io_executor io,
+                             std::chrono::milliseconds retry_after,
+                             std::size_t id,
+                             std::optional<std::locale> date_header_locale,
+                             config::shared::built::TlsOptions tls_options,
+                             Logger& logger)
     : timer_(std::move(io)),
       retry_delay_(retry_after),
       state_(State::Idle),
-      requester_(timer_.get_executor(), verify_mode),
+      requester_(timer_.get_executor(), tls_options),
       batch_(std::nullopt),
       tag_("flush-worker[" + std::to_string(id) + "]: "),
       date_header_locale_(std::move(date_header_locale)),

--- a/libs/internal/src/events/worker_pool.cpp
+++ b/libs/internal/src/events/worker_pool.cpp
@@ -24,7 +24,7 @@ std::optional<std::locale> GetLocale(std::string const& locale,
 WorkerPool::WorkerPool(boost::asio::any_io_executor io,
                        std::size_t pool_size,
                        std::chrono::milliseconds delivery_retry_delay,
-                       TlsOptions tls_options,
+                       TlsOptions const& tls_options,
                        Logger& logger)
     : io_(io), workers_() {
     // The en_US.utf-8 locale is used whenever a date is parsed from the HTTP
@@ -38,8 +38,8 @@ WorkerPool::WorkerPool(boost::asio::any_io_executor io,
 
     for (std::size_t i = 0; i < pool_size; i++) {
         workers_.emplace_back(std::make_unique<RequestWorker>(
-            io_, delivery_retry_delay, i, date_header_locale,
-            tls_options.PeerVerifyMode(), logger));
+            io_, delivery_retry_delay, i, date_header_locale, tls_options,
+            logger));
     }
 }
 

--- a/libs/internal/src/events/worker_pool.cpp
+++ b/libs/internal/src/events/worker_pool.cpp
@@ -24,7 +24,7 @@ std::optional<std::locale> GetLocale(std::string const& locale,
 WorkerPool::WorkerPool(boost::asio::any_io_executor io,
                        std::size_t pool_size,
                        std::chrono::milliseconds delivery_retry_delay,
-                       enum TlsOptions::VerifyMode verify_mode,
+                       TlsOptions tls_options,
                        Logger& logger)
     : io_(io), workers_() {
     // The en_US.utf-8 locale is used whenever a date is parsed from the HTTP
@@ -38,8 +38,8 @@ WorkerPool::WorkerPool(boost::asio::any_io_executor io,
 
     for (std::size_t i = 0; i < pool_size; i++) {
         workers_.emplace_back(std::make_unique<RequestWorker>(
-            io_, delivery_retry_delay, i, date_header_locale, verify_mode,
-            logger));
+            io_, delivery_retry_delay, i, date_header_locale,
+            tls_options.PeerVerifyMode(), logger));
     }
 }
 

--- a/libs/internal/tests/event_processor_test.cpp
+++ b/libs/internal/tests/event_processor_test.cpp
@@ -13,6 +13,7 @@
 using namespace launchdarkly::events;
 using namespace launchdarkly::events::detail;
 using namespace launchdarkly::network;
+using namespace launchdarkly::config::shared;
 
 static std::chrono::system_clock::time_point TimeZero() {
     return std::chrono::system_clock::time_point{};
@@ -32,7 +33,7 @@ TEST(WorkerPool, PoolReturnsAvailableWorker) {
     std::thread ioc_thread([&]() { ioc.run(); });
 
     WorkerPool pool(ioc.get_executor(), 1, std::chrono::seconds(1),
-                    VerifyMode::kVerifyPeer, logger);
+                    built::TlsOptions{}, logger);
 
     RequestWorker* worker = pool.Get(boost::asio::use_future).get();
     ASSERT_TRUE(worker);
@@ -51,7 +52,7 @@ TEST(WorkerPool, PoolReturnsNullptrWhenNoWorkerAvaialable) {
     std::thread ioc_thread([&]() { ioc.run(); });
 
     WorkerPool pool(ioc.get_executor(), 0, std::chrono::seconds(1),
-                    VerifyMode::kVerifyPeer, logger);
+                    built::TlsOptions{}, logger);
 
     RequestWorker* worker = pool.Get(boost::asio::use_future).get();
     ASSERT_FALSE(worker);

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/config/builder.h
@@ -398,6 +398,26 @@ LDServerHttpPropertiesTlsBuilder_SkipVerifyPeer(
     bool skip_verify_peer);
 
 /**
+ * Configures TLS peer certificate verification to use a custom
+ * CA file.
+ *
+ * The parameter is a filepath pointing to a bundle of
+ * one or more PEM-encoded x509 certificates comprising the root of trust for
+ * the SDK's outbound connections.
+ *
+ * By default, the SDK uses the system's CA bundle. Passing the empty string
+ * will unset any previously set path and revert to the system's CA bundle.
+ *
+ * @param b Server config builder. Must not be NULL.
+ * @param custom_ca_file Filepath of the custom CA bundle, or empty string.
+ * Must not be NULL.
+ */
+LD_EXPORT(void)
+LDServerHttpPropertiesTlsBuilder_CustomCAFile(
+    LDServerHttpPropertiesTlsBuilder b,
+    char const* custom_ca_file);
+
+/**
  * Disables the default SDK logging.
  * @param b Server config builder. Must not be NULL.
  */

--- a/libs/server-sdk/src/bindings/c/builder.cpp
+++ b/libs/server-sdk/src/bindings/c/builder.cpp
@@ -358,6 +358,16 @@ LDServerHttpPropertiesTlsBuilder_SkipVerifyPeer(
     TO_TLS_BUILDER(b)->SkipVerifyPeer(skip_verify_peer);
 }
 
+LD_EXPORT(void)
+LDServerHttpPropertiesTlsBuilder_CustomCAFile(
+    LDServerHttpPropertiesTlsBuilder b,
+    char const* custom_ca_file) {
+    LD_ASSERT_NOT_NULL(b);
+    LD_ASSERT_NOT_NULL(custom_ca_file);
+
+    TO_TLS_BUILDER(b)->CustomCAFile(custom_ca_file);
+}
+
 LD_EXPORT(LDServerHttpPropertiesTlsBuilder)
 LDServerHttpPropertiesTlsBuilder_New(void) {
     return FROM_TLS_BUILDER(new TlsBuilder());

--- a/libs/server-sdk/src/client_impl.cpp
+++ b/libs/server-sdk/src/client_impl.cpp
@@ -8,6 +8,7 @@
 
 #include "data_interfaces/system/idata_system.hpp"
 
+#include <launchdarkly/config/shared/built/http_properties.hpp>
 #include <launchdarkly/encoding/sha_256.hpp>
 #include <launchdarkly/events/asio_event_processor.hpp>
 #include <launchdarkly/events/data/common_events.hpp>
@@ -124,6 +125,17 @@ ClientImpl::ClientImpl(Config config, std::string const& version)
                            EventFactory::WithReasons()) {
     LD_LOG(logger_, LogLevel::kDebug)
         << "data system: " << data_system_->Identity();
+    if (auto custom_ca = http_properties_.Tls().CustomCAFile()) {
+        LD_LOG(logger_, LogLevel::kInfo)
+            << "TLS peer verification configured with custom CA file: "
+            << *custom_ca;
+    }
+    if (http_properties_.Tls().PeerVerifyMode() ==
+        launchdarkly::config::shared::built::TlsOptions::VerifyMode::
+            kVerifyNone) {
+        LD_LOG(logger_, LogLevel::kInfo) << "TLS peer verification disabled";
+    }
+
     run_thread_ = std::move(std::thread([&]() { ioc_.run(); }));
 }
 

--- a/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
@@ -57,11 +57,6 @@ PollingDataSource::PollingDataSource(
       request_(MakeRequest(data_source_config, endpoints, http_properties)),
       timer_(ioc),
       sink_(nullptr) {
-    if (http_properties.Tls().PeerVerifyMode() ==
-        launchdarkly::config::shared::built::TlsOptions::VerifyMode::
-            kVerifyNone) {
-        LD_LOG(logger_, LogLevel::kDebug) << "TLS peer verification disabled";
-    }
     if (polling_interval_ < data_source_config.min_polling_interval) {
         LD_LOG(logger_, LogLevel::kWarn)
             << "Polling interval too frequent, defaulting to "

--- a/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/polling/polling_data_source.cpp
@@ -52,7 +52,7 @@ PollingDataSource::PollingDataSource(
     config::built::HttpProperties const& http_properties)
     : logger_(logger),
       status_manager_(status_manager),
-      requester_(ioc, http_properties.Tls().PeerVerifyMode()),
+      requester_(ioc, http_properties.Tls()),
       polling_interval_(data_source_config.poll_interval),
       request_(MakeRequest(data_source_config, endpoints, http_properties)),
       timer_(ioc),

--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
@@ -110,8 +110,8 @@ void StreamingDataSource::StartAsync(
         client_builder.skip_verify_peer(true);
     }
 
-    if (auto bundle = http_config_.Tls().CABundlePath()) {
-        client_builder.ca_bundle_path(*bundle);
+    if (auto ca_file = http_config_.Tls().CustomCAFile()) {
+        client_builder.custom_ca_file(*ca_file);
     }
 
     auto weak_self = weak_from_this();

--- a/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
+++ b/libs/server-sdk/src/data_systems/background_sync/sources/streaming/streaming_data_source.cpp
@@ -110,6 +110,10 @@ void StreamingDataSource::StartAsync(
         client_builder.skip_verify_peer(true);
     }
 
+    if (auto bundle = http_config_.Tls().CABundlePath()) {
+        client_builder.ca_bundle_path(*bundle);
+    }
+
     auto weak_self = weak_from_this();
 
     client_builder.receiver([weak_self](launchdarkly::sse::Event const& event) {

--- a/libs/server-sdk/tests/server_c_bindings_test.cpp
+++ b/libs/server-sdk/tests/server_c_bindings_test.cpp
@@ -251,7 +251,7 @@ TEST(ClientBindings, LazyLoadDataSource) {
     LDStatus_Free(status);
 }
 
-TEST(ClientBindings, TlsConfiguration) {
+TEST(ClientBindings, TlsConfigurationSkipVerifyPeer) {
     LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
 
     LDServerHttpPropertiesTlsBuilder tls =
@@ -262,6 +262,42 @@ TEST(ClientBindings, TlsConfiguration) {
 
     LDServerConfig config;
     LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+    ASSERT_TRUE(LDStatus_Ok(status));
+
+    LDServerConfig_Free(config);
+}
+
+TEST(ClientBindings, TlsConfigurationCustomCAFile) {
+    LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
+
+    LDServerHttpPropertiesTlsBuilder tls =
+        LDServerHttpPropertiesTlsBuilder_New();
+    LDServerHttpPropertiesTlsBuilder_CustomCAFile(tls, "/path/to/file.pem");
+
+    LDServerConfigBuilder_HttpProperties_Tls(cfg_builder, tls);
+
+    LDServerConfig config;
+    LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+    ASSERT_TRUE(LDStatus_Ok(status));
+
+    LDServerConfig_Free(config);
+}
+
+TEST(ClientBindings, TlsConfigurationSystemCAFile) {
+    LDServerConfigBuilder cfg_builder = LDServerConfigBuilder_New("sdk-123");
+
+    LDServerHttpPropertiesTlsBuilder tls =
+        LDServerHttpPropertiesTlsBuilder_New();
+
+    // Set, then unset the file. This should not cause a configuration error.
+    LDServerHttpPropertiesTlsBuilder_CustomCAFile(tls, "/path/to/file.pem");
+    LDServerHttpPropertiesTlsBuilder_CustomCAFile(tls, "");
+
+    LDServerConfigBuilder_HttpProperties_Tls(cfg_builder, tls);
+
+    LDServerConfig config;
+    LDStatus status = LDServerConfigBuilder_Build(cfg_builder, &config);
+    ASSERT_TRUE(LDStatus_Ok(status));
 
     LDServerConfig_Free(config);
 }

--- a/libs/server-sent-events/include/launchdarkly/sse/client.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/client.hpp
@@ -141,6 +141,17 @@ class Builder {
     Builder& skip_verify_peer(bool skip_verify_peer);
 
     /**
+     * Specify the path to a CA bundle file for verifying the peer's
+     * certificate.
+     *
+     * By default, the system's CA bundle is used. Passing an empty string will
+     * unset any previously set path, and
+     * @param path
+     * @return
+     */
+    Builder& ca_bundle_path(std::string path);
+
+    /**
      * Builds a Client. The shared pointer is necessary to extend the lifetime
      * of the Client to encompass each asynchronous operation that it performs.
      * @return New client; call run() to kickoff the connection process and
@@ -160,6 +171,7 @@ class Builder {
     EventReceiver receiver_;
     ErrorCallback error_cb_;
     bool skip_verify_peer_;
+    std::string ca_bundle_path_;
 };
 
 /**

--- a/libs/server-sent-events/include/launchdarkly/sse/client.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/client.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace launchdarkly::sse {
@@ -145,11 +146,12 @@ class Builder {
      * certificate.
      *
      * By default, the system's CA bundle is used. Passing an empty string will
-     * unset any previously set path, and
-     * @param path
-     * @return
+     * unset any previously set path and revert to the system's CA bundle.
+     *
+     * @param path The filepath.
+     * @return Reference to this builder.
      */
-    Builder& ca_bundle_path(std::string path);
+    Builder& custom_ca_file(std::string path);
 
     /**
      * Builds a Client. The shared pointer is necessary to extend the lifetime
@@ -171,7 +173,7 @@ class Builder {
     EventReceiver receiver_;
     ErrorCallback error_cb_;
     bool skip_verify_peer_;
-    std::string ca_bundle_path_;
+    std::optional<std::string> custom_ca_file_;
 };
 
 /**

--- a/libs/server-sent-events/src/client.cpp
+++ b/libs/server-sent-events/src/client.cpp
@@ -621,7 +621,7 @@ std::shared_ptr<Client> Builder::build() {
         if (ca_bundle_path_.empty()) {
             ssl->set_default_verify_paths();
         } else {
-            ssl->add_verify_path(ca_bundle_path_);
+            ssl->load_verify_file(ca_bundle_path_);
         }
         if (skip_verify_peer_) {
             ssl->set_verify_mode(ssl::context::verify_none);

--- a/libs/server-sent-events/src/client.cpp
+++ b/libs/server-sent-events/src/client.cpp
@@ -629,14 +629,10 @@ std::shared_ptr<Client> Builder::build() {
         if (custom_ca_file_) {
             assert(!custom_ca_file_->empty());
             ssl->load_verify_file(*custom_ca_file_);
-            logging_cb_(
-                "TLS peer verification configured with custom CA file: " +
-                *custom_ca_file_);
         }
 
         if (skip_verify_peer_) {
             ssl->set_verify_mode(ssl::context::verify_none);
-            logging_cb_("TLS peer verification disabled");
         }
     }
 


### PR DESCRIPTION
This adds a new config builder option, `CustomCAFile` and associated C binding to the server and client SDKs.

When specified, the SDK's streaming, polling, and event connections will verify its TLS peer based on the CAs found in this file. The custom file may be un-set by passing an empty string. 

We could instead make empty string be a configuration error, but it would involve changing the signature for the `Build()` methods of the HTTPs properties + TLS properties builders. That might be a safer default, although potentially less convenient. 