### PR TITLE
fix: Summarizer::VariationKey operator< was unsound

### DIFF
--- a/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
@@ -83,7 +83,7 @@ class Summarizer {
                      std::optional<VariationIndex> variation);
 
         bool operator==(VariationKey const& k) const {
-            return k.variation == variation && k.version == version;
+            return !(*this < k) && !(k < *this);
         }
 
         bool operator!=(VariationKey const& k) const { return !(*this == k); }
@@ -91,7 +91,8 @@ class Summarizer {
         bool operator<(VariationKey const& k) const {
             if (variation < k.variation) {
                 return true;
-            } else if (variation > k.variation) {
+            }
+            if (variation > k.variation) {
                 return false;
             }
             return version < k.version;

--- a/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
@@ -89,6 +89,8 @@ class Summarizer {
         bool operator<(VariationKey const& k) const {
             if (variation < k.variation) {
                 return true;
+            } else if (variation > k.variation) {
+                return false;
             }
             return version < k.version;
         }

--- a/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
+++ b/libs/internal/include/launchdarkly/events/detail/summarizer.hpp
@@ -86,6 +86,8 @@ class Summarizer {
             return k.variation == variation && k.version == version;
         }
 
+        bool operator!=(VariationKey const& k) const { return !(*this == k); }
+
         bool operator<(VariationKey const& k) const {
             if (variation < k.variation) {
                 return true;
@@ -94,6 +96,8 @@ class Summarizer {
             }
             return version < k.version;
         }
+
+        bool operator>(VariationKey const& k) const { return k < *this; }
     };
 
     struct State {

--- a/libs/internal/tests/event_summarizer_test.cpp
+++ b/libs/internal/tests/event_summarizer_test.cpp
@@ -35,6 +35,52 @@ TEST(SummarizerTests, ExplicitStartTimeIsCorrect) {
     ASSERT_EQ(summarizer.StartTime(), start);
 }
 
+TEST(SummarizerTests, VariationKeyOrdering) {
+    Summarizer::VariationKey a(0, 1);
+    Summarizer::VariationKey b(1, 0);
+
+    ASSERT_FALSE(a < b);
+    ASSERT_TRUE(a > b);
+
+    ASSERT_FALSE(b > a);
+    ASSERT_TRUE(b < a);
+
+    ASSERT_TRUE(a != b);
+    ASSERT_FALSE(a == b);
+}
+
+TEST(SummarizerTests, VariationKeyEquality) {
+    Summarizer::VariationKey different(2, 2);
+
+    std::vector<Summarizer::VariationKey> keys = {
+        Summarizer::VariationKey(0, 1),
+        Summarizer::VariationKey(1, 0),
+        Summarizer::VariationKey(0, 0),
+        Summarizer::VariationKey(1, 1),
+        Summarizer::VariationKey(12412, 123),
+        Summarizer::VariationKey(324, 5323332)};
+
+    for (auto const& key : keys) {
+        Summarizer::VariationKey a = key;
+        Summarizer::VariationKey b = key;
+
+        ASSERT_EQ(a, b);
+        ASSERT_EQ(b, a);
+
+        ASSERT_FALSE(a != b);
+        ASSERT_FALSE(b != a);
+
+        ASSERT_FALSE(a < b);
+        ASSERT_FALSE(b < a);
+
+        ASSERT_FALSE(a > b);
+        ASSERT_FALSE(b > a);
+
+        ASSERT_NE(key, different);
+        ASSERT_FALSE(key == different);
+    }
+}
+
 struct EvaluationParams {
     std::string feature_key;
     Version feature_version;


### PR DESCRIPTION
This is a soundness bug that was detected by MSVC in debug configuration.

The `Summarizer::VariationKey` has `==` and `<` operators. 

In the case of `<`, the comparison wasn't properly handling the case where `this->variation` was greater than the parameter. In that case, it would fall back to comparing `this->version` which is incorrect (should only happen if the variations are equal.)

This could have affected the JSON serialization of the summary counters, mainly the order in which the array was serialized. I'm wondering if it could also caused bugs in actual counts. `std::map` uses the `<` operator to determine key equality. 
