### PR TITLE
test: add <algorithm> header to logging_c_binding_test.cpp

### DIFF
--- a/libs/internal/tests/ld_logger_test.cpp
+++ b/libs/internal/tests/ld_logger_test.cpp
@@ -1,7 +1,11 @@
 #include <gtest/gtest.h>
+
 #include <launchdarkly/logging/console_backend.hpp>
 #include <launchdarkly/logging/logger.hpp>
+
 #include "ostream_tester.hpp"
+
+#include <algorithm>
 
 using launchdarkly::Logger;
 using launchdarkly::LogLevel;


### PR DESCRIPTION
Test uses `std::remove_if` which is found in the`<algorithm>` header. It happens that our compilers/configuration doesn't need it, but others do.