### PR TITLE
fix: more helpful error messages for streaming connection failures

### DIFF
--- a/contract-tests/sse-contract-tests/src/event_outbox.cpp
+++ b/contract-tests/sse-contract-tests/src/event_outbox.cpp
@@ -1,9 +1,11 @@
 #include "event_outbox.hpp"
 #include "definitions.hpp"
 
+#include <boost/beast/core/bind_handler.hpp>
 #include <boost/url/parse.hpp>
-#include <iostream>
 #include <nlohmann/json.hpp>
+
+#include <iostream>
 
 // Check the outbox at this interval. Normally a flush is triggered for
 // every event; this is just a failsafe in case a flush is happening
@@ -78,22 +80,8 @@ EventOutbox::RequestType EventOutbox::build_request(
                     json = EventMessage{"event", Event{std::move(arg)}};
                 }
             } else if constexpr (std::is_same_v<T, launchdarkly::sse::Error>) {
-                using launchdarkly::sse::Error;
-                auto msg = ErrorMessage{"error"};
-                switch (arg) {
-                    case Error::NoContent:
-                        msg.comment = "no content";
-                        break;
-                    case Error::InvalidRedirectLocation:
-                        msg.comment = "invalid redirect location";
-                        break;
-                    case Error::UnrecoverableClientError:
-                        msg.comment = "unrecoverable client error";
-                    case Error::ReadTimeout:
-                        msg.comment = "read timeout";
-                    default:
-                        msg.comment = "unspecified error";
-                }
+                auto msg = ErrorMessage{"error",
+                                        launchdarkly::sse::ErrorToString(arg)};
                 json = msg;
             }
         },

--- a/libs/server-sent-events/include/launchdarkly/sse/error.hpp
+++ b/libs/server-sent-events/include/launchdarkly/sse/error.hpp
@@ -1,11 +1,44 @@
 #pragma once
+#include <chrono>
+#include <optional>
+#include <ostream>
+#include <variant>
+
+#include <boost/beast/http/status.hpp>
 
 namespace launchdarkly::sse {
+namespace errors {
 
-enum class Error {
-    NoContent = 1,
-    InvalidRedirectLocation = 2,
-    UnrecoverableClientError = 3,
-    ReadTimeout = 4,
+struct NoContent {};
+std::ostream& operator<<(std::ostream& out, NoContent const&);
+
+struct InvalidRedirectLocation {
+    std::string location;
 };
-}
+std::ostream& operator<<(std::ostream& out, InvalidRedirectLocation const&);
+
+struct NotRedirectable {};
+std::ostream& operator<<(std::ostream& out, NotRedirectable const&);
+
+struct ReadTimeout {
+    std::optional<std::chrono::milliseconds> timeout;
+};
+std::ostream& operator<<(std::ostream& out, ReadTimeout const&);
+
+struct UnrecoverableClientError {
+    boost::beast::http::status status;
+};
+std::ostream& operator<<(std::ostream& out, UnrecoverableClientError const&);
+
+}  // namespace errors
+
+using Error = std::variant<errors::NoContent,
+                           errors::InvalidRedirectLocation,
+                           errors::NotRedirectable,
+                           errors::ReadTimeout,
+                           errors::UnrecoverableClientError>;
+
+std::ostream& operator<<(std::ostream& out, Error const& error);
+
+std::string ErrorToString(Error const& error);
+}  // namespace launchdarkly::sse

--- a/libs/server-sent-events/src/CMakeLists.txt
+++ b/libs/server-sent-events/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(${LIBNAME} OBJECT
         client.cpp
         parser.cpp
         event.cpp
+        error.cpp
         backoff.cpp)
 
 target_link_libraries(${LIBNAME}

--- a/libs/server-sent-events/src/error.cpp
+++ b/libs/server-sent-events/src/error.cpp
@@ -6,25 +6,27 @@ namespace launchdarkly::sse {
 namespace errors {
 
 std::ostream& operator<<(std::ostream& out, NoContent const&) {
-    out << "no content, will not attempt to reconnect (HTTP 204)";
+    out << "received HTTP error 204 (no content) - giving up "
+           "permanently";
     return out;
 }
 
 std::ostream& operator<<(std::ostream& out,
                          InvalidRedirectLocation const& invalid) {
-    out << "server responded with an invalid redirect (" << invalid.location
-        << ")";
+    out << "received invalid redirect from server, cannot follow ("
+        << invalid.location << ") - giving up permanently";
     return out;
 }
 
 std::ostream& operator<<(std::ostream& out, NotRedirectable const&) {
-    out << "cannot follow server redirect";
+    out << "received malformed redirect from server, cannot follow - giving up "
+           "permanently";
     return out;
 }
 
 std::ostream& operator<<(std::ostream& out, ReadTimeout const& err) {
     out << "timed out reading response body (exceeded " << err.timeout->count()
-        << "ms)";
+        << "ms) - will retry";
     return out;
 }
 

--- a/libs/server-sent-events/src/error.cpp
+++ b/libs/server-sent-events/src/error.cpp
@@ -30,14 +30,14 @@ std::ostream& operator<<(std::ostream& out, ReadTimeout const& err) {
 
 std::ostream& operator<<(std::ostream& out,
                          UnrecoverableClientError const& err) {
+    std::string explanation;
     if (err.status == boost::beast::http::status::unauthorized ||
         err.status == boost::beast::http::status::forbidden) {
-        out << "invalid auth key (HTTP " << static_cast<int>(err.status) << ")";
-
-    } else {
-        out << "unrecoverable client-side error (HTTP "
-            << static_cast<int>(err.status) << ")";
+        explanation = " (invalid auth key)";
     }
+    out << "received HTTP error " << static_cast<int>(err.status) << explanation
+        << " for streaming connection - giving up "
+           "permanently";
     return out;
 }
 }  // namespace errors

--- a/libs/server-sent-events/src/error.cpp
+++ b/libs/server-sent-events/src/error.cpp
@@ -1,0 +1,61 @@
+#include <launchdarkly/sse/error.hpp>
+
+#include <sstream>
+
+namespace launchdarkly::sse {
+namespace errors {
+
+std::ostream& operator<<(std::ostream& out, NoContent const&) {
+    out << "no content, will not attempt to reconnect (HTTP 204)";
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out,
+                         InvalidRedirectLocation const& invalid) {
+    out << "server responded with an invalid redirect (" << invalid.location
+        << ")";
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out, NotRedirectable const&) {
+    out << "cannot follow server redirect";
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out, ReadTimeout const& err) {
+    out << "timed out reading response body (exceeded " << err.timeout->count()
+        << "ms)";
+    return out;
+}
+
+std::ostream& operator<<(std::ostream& out,
+                         UnrecoverableClientError const& err) {
+    if (err.status == boost::beast::http::status::unauthorized ||
+        err.status == boost::beast::http::status::forbidden) {
+        out << "invalid auth key (HTTP " << static_cast<int>(err.status) << ")";
+
+    } else {
+        out << "unrecoverable client-side error (HTTP "
+            << static_cast<int>(err.status) << ")";
+    }
+    return out;
+}
+}  // namespace errors
+
+std::ostream& operator<<(std::ostream& out, Error const& error) {
+    std::visit(
+        [&](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            out << arg;
+        },
+        error);
+    return out;
+}
+
+std::string ErrorToString(Error const& error) {
+    std::stringstream ss;
+    ss << error;
+    return ss.str();
+}
+
+}  // namespace launchdarkly::sse


### PR DESCRIPTION
This commit pulls the stringification logic of SSE errors into the SSE package itself, and refactors the enum into a richer sum type using `std::variant`. 

