### PR TITLE
ci: allow example cpp apps to be dynamically linked

### DIFF
--- a/.github/workflows/hello-apps.yml
+++ b/.github/workflows/hello-apps.yml
@@ -38,8 +38,7 @@ jobs:
       - name: Dynamically Linked Hello Apps
         shell: bash
         continue-on-error: true # TODO(SC-223804)
-        # Only the C bindings work with dynamic linking because C++ symbols are hidden
-        run: ./scripts/run-hello-apps.sh dynamic hello-c-client hello-c-server
+        run: ./scripts/run-hello-apps.sh dynamic hello-c-client hello-cpp-client hello-c-server hello-cpp-server
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
           OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}

--- a/.github/workflows/hello-apps.yml
+++ b/.github/workflows/hello-apps.yml
@@ -35,10 +35,17 @@ jobs:
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
           OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
-      - name: Dynamically Linked Hello Apps
+      - name: Dynamically Linked Hello Apps (C API only)
         shell: bash
         continue-on-error: true # TODO(SC-223804)
-        run: ./scripts/run-hello-apps.sh dynamic hello-c-client hello-cpp-client hello-c-server hello-cpp-server
+        run: ./scripts/run-hello-apps.sh dynamic hello-c-client hello-c-server
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+          OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
+      - name: Dynamically Linked Hello Apps (C and C++ APIs)
+        shell: bash
+        continue-on-error: true # TODO(SC-223804)
+        run: ./scripts/run-hello-apps.sh dynamic-export-all-symbols hello-c-client hello-cpp-client hello-c-server hello-cpp-server
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
           OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}

--- a/scripts/run-hello-apps.sh
+++ b/scripts/run-hello-apps.sh
@@ -32,7 +32,10 @@ cd build-"$1" || exit
 # script ends.
 trap cleanup EXIT
 
-cmake -G Ninja -D CMAKE_BUILD_TYPE=Release  -D BUILD_TESTING=OFF  -D LD_BUILD_SHARED_LIBS=$dynamic_linkage ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
+               -D BUILD_TESTING=OFF  \
+               -D LD_BUILD_SHARED_LIBS=$dynamic_linkage \
+               -D LD_BUILD_EXPORT_ALL_SYMBOLS=ON ..
 
 export LD_MOBILE_KEY="bogus"
 export LD_SDK_KEY="bogus"

--- a/scripts/run-hello-apps.sh
+++ b/scripts/run-hello-apps.sh
@@ -5,18 +5,26 @@
 # Example:
 # ./scripts/run-hello-apps.sh dynamic hello-cpp-client hello-c-client
 #
-# $1 is the linkage, either 'static' or 'dynamic'.
+# $1 is the linkage, either 'static', 'dynamic', or 'dynamic-export-all-symbols'.
+# The difference between the dynamic options is that 'dynamic' only exports the C API,
+# whereas 'dynamic-export-all-symbols' exports all symbols (including C++, so we can link
+# a dynamic C++ library in the hello example.)
 # Subsequent arguments are cmake target names.
 
-if [ "$1" != "static" ] && [ "$1" != "dynamic" ]
+if [ "$1" != "static" ] && [ "$1" != "dynamic" ] && [ "$1" != "dynamic-export-all-symbols" ]
 then
-  echo "Linkage must be specified ('static' or 'dynamic')"
+  echo "Linkage must be specified ('static', 'dynamic', or 'dynamic-export-all-symbols')"
   exit 1
 fi
 
 dynamic_linkage="Off"
+export_all_symbols="Off"
+
 if [ "$1" == "dynamic" ]; then
     dynamic_linkage="On"
+elif [ "$1" == "dynamic-export-all-symbols" ]; then
+    dynamic_linkage="On"
+    export_all_symbols="On"
 fi
 
 shift
@@ -35,7 +43,7 @@ trap cleanup EXIT
 cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                -D BUILD_TESTING=OFF  \
                -D LD_BUILD_SHARED_LIBS=$dynamic_linkage \
-               -D LD_BUILD_EXPORT_ALL_SYMBOLS=ON ..
+               -D LD_BUILD_EXPORT_ALL_SYMBOLS=$export_all_symbols ..
 
 export LD_MOBILE_KEY="bogus"
 export LD_SDK_KEY="bogus"


### PR DESCRIPTION
With the addition of the new `LD_BUILD_EXPORT_ALL_SYMBOLS`, we can easily build & run the `hello-cpp-*` binaries in CI. 


Although we don't build these libs for distribution (could cause ABI issues), building them from source in this type of configuration should be supported and tested.