### PR TITLE
fix: improve caching behavior of database integration

### DIFF
--- a/libs/server-sdk/src/data_systems/lazy_load/lazy_load_system.hpp
+++ b/libs/server-sdk/src/data_systems/lazy_load/lazy_load_system.hpp
@@ -145,8 +145,9 @@ class LazyLoad final : public data_interfaces::IDataSystem {
         std::function<
             data_interfaces::IDataReader::CollectionResult<Item>()> const&
             getter) const {
-        // Storing an expiry time so that the 'all' key and the individual
-        // item keys will expire at the same time.
+        // The 'all' key and the individual item keys should expire
+        // at exactly the same time, because there is no separate data item
+        // for 'all' - it exists only to rate limit the refresh of all items.
         auto const updated_expiry = ExpiryTime();
 
         // Refreshing 'all' for this item is always rate limited, even if
@@ -158,7 +159,7 @@ class LazyLoad final : public data_interfaces::IDataSystem {
 
             for (auto item : *all_items) {
                 cache_.Upsert(item.first, std::move(item.second));
-                tracker_.Add(item.first, updated_expiry);
+                tracker_.Add(item_kind, item.first, updated_expiry);
             }
         } else {
             status_manager_.SetState(


### PR DESCRIPTION
This improves the caching behavior of the Lazy Load data system.

Previously, calling `AllFlags` or `AllSegments` updated an "allFlags" or "allSegments" key in the unscoped freshness tracker. That's correct, as those keys act as rate limiters for the "all" queries.

It then upserted each individual item in the _unscoped_ freshness tracker.

This is not optimal, as the unscoped tracker is not referenced when we read individual items. This results in cache misses for individual items, even after they were all refreshed. 

This change properly adds the individual items into the scoped tracker. Now, `AllFlags` or `AllSegments` should result in "priming" the cache for future individual item fetches.

This does have the behavior of syncing the TTL dates of all items to a single point in time. 

-------------

Before:
```
[LaunchDarkly] lazy load via redis (JSON): get allFlags - cache miss
[LaunchDarkly] lazy load via redis (JSON): get allSegments - cache miss
[LaunchDarkly] lazy load via redis (JSON): get test - cache miss
[LaunchDarkly] lazy load via redis (JSON): get my-boolean-flag - cache miss
```

After:
```
[LaunchDarkly] lazy load via redis (JSON): get allFlags - cache miss
[LaunchDarkly] lazy load via redis (JSON): get allSegments - cache miss
[LaunchDarkly] lazy load via redis (JSON): get test - cache hit
[LaunchDarkly] lazy load via redis (JSON): get my-boolean-flag - cache hit
```