### PR TITLE
ci: bump contract-tests action to 1.1.0

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -29,7 +29,7 @@ jobs:
           run_tests: false
       - name: 'Launch test service as background task'
         run: $TEST_SERVICE_BINARY $TEST_SERVICE_PORT 2>&1 &
-      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.2
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.1.0
         with:
           # Inform the test harness of test service's port.
           test_service_port: ${{ env.TEST_SERVICE_PORT }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -28,7 +28,7 @@ jobs:
           run_tests: false
       - name: 'Launch test service as background task'
         run: $TEST_SERVICE_BINARY $TEST_SERVICE_PORT 2>&1 &
-      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.2
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.1.0
         with:
           # Inform the test harness of test service's port.
           test_service_port: ${{ env.TEST_SERVICE_PORT }}

--- a/.github/workflows/sse.yml
+++ b/.github/workflows/sse.yml
@@ -32,7 +32,7 @@ jobs:
           run_tests: false
       - name: 'Launch test service as background task'
         run: $TEST_SERVICE_BINARY $TEST_SERVICE_PORT 2>&1 &
-      - uses: launchdarkly/gh-actions/actions/contract-tests@346636e580d3a19423a2e59c9f09cffe12695f25
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.1.0
         with:
           repo: 'sse-contract-tests'
           branch: 'main'

--- a/.github/workflows/sse.yml
+++ b/.github/workflows/sse.yml
@@ -32,8 +32,9 @@ jobs:
           run_tests: false
       - name: 'Launch test service as background task'
         run: $TEST_SERVICE_BINARY $TEST_SERVICE_PORT 2>&1 &
-      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.0
+      - uses: launchdarkly/gh-actions/actions/contract-tests@346636e580d3a19423a2e59c9f09cffe12695f25
         with:
           repo: 'sse-contract-tests'
+          branch: 'main'
           test_service_port: ${{ env.TEST_SERVICE_PORT }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed the dreaded "could not find release matching v2.." on the SSE package on a recent commit. Found that I missed updating the SSE client's CI configuration when I bumped the other packages.