### PR TITLE
ci: force boost to be linked statically in hello apps

### DIFF
--- a/scripts/run-hello-apps.sh
+++ b/scripts/run-hello-apps.sh
@@ -42,6 +42,8 @@ trap cleanup EXIT
 
 cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                -D BUILD_TESTING=OFF  \
+               -D LD_DYNAMIC_LINK_OPENSSL=OFF \
+               -D LD_DYNAMIC_LINK_BOOST=OFF \
                -D LD_BUILD_SHARED_LIBS=$dynamic_linkage \
                -D LD_BUILD_EXPORT_ALL_SYMBOLS=$export_all_symbols ..
 


### PR DESCRIPTION
The dynamically linked hello apps on Windows haven't worked, ever. Missing symbols in boost. 

This might be because we're trying to link boost dynamically, but we're somehow doing it wrong (or the artifacts are built wrong?).

So, this PR attempts to force static linking of boost. This might not work because we don't have position-independent boost static libs on Windows. But it's worth a shot.