### PR TITLE
fix: guard against overflow in sse backoff calculation

### DIFF
--- a/libs/server-sent-events/src/CMakeLists.txt
+++ b/libs/server-sent-events/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(${LIBNAME} OBJECT
         parser.cpp
         event.cpp
         error.cpp
+        backoff_detail.cpp
         backoff.cpp)
 
 target_link_libraries(${LIBNAME}

--- a/libs/server-sent-events/src/backoff.cpp
+++ b/libs/server-sent-events/src/backoff.cpp
@@ -55,7 +55,7 @@ Backoff::Backoff(std::chrono::milliseconds initial,
       attempt_(1),
       jitter_ratio_(jitter_ratio),
       reset_interval_(reset_interval),
-      random_(random) {}
+      random_(std::move(random)) {}
 
 Backoff::Backoff(std::chrono::milliseconds initial,
                  std::chrono::milliseconds max)

--- a/libs/server-sent-events/src/backoff.hpp
+++ b/libs/server-sent-events/src/backoff.hpp
@@ -51,7 +51,7 @@ class Backoff {
     /**
      * Get the current reconnect delay.
      */
-    std::chrono::milliseconds delay() const;
+    [[nodiscard]] std::chrono::milliseconds delay() const;
 
    private:
     std::chrono::milliseconds initial_;

--- a/libs/server-sent-events/src/backoff.hpp
+++ b/libs/server-sent-events/src/backoff.hpp
@@ -6,7 +6,6 @@
 #include <random>
 
 namespace launchdarkly::sse {
-
 /**
  * Implements an algorithm for calculating the delay between connection
  * attempts.
@@ -52,35 +51,18 @@ class Backoff {
     /**
      * Get the current reconnect delay.
      */
-    std::chrono::milliseconds delay();
+    std::chrono::milliseconds delay() const;
 
    private:
-    /**
-     * Calculate an exponential backoff based on the initial retry time and
-     * the current attempt.
-     *
-     * @param attempt The current attempt count.
-     * @param initial The initial retry delay.
-     * @return The current backoff based on the number of attempts.
-     */
-    std::chrono::milliseconds calculate_backoff();
-
-    /**
-     * Produce a jittered version of the base value. This value will be adjusted
-     * randomly to be between 50% and 100% of the input duration.
-     *
-     * @param base The base duration to jitter.
-     * @return The jittered duration.
-     */
-    std::chrono::milliseconds jitter(std::chrono::milliseconds base);
-
     std::chrono::milliseconds initial_;
     std::chrono::milliseconds max_;
-    uint64_t attempt_;
+
+    std::uint64_t max_exponent_;
+    std::uint64_t attempt_;
     std::optional<std::chrono::time_point<std::chrono::system_clock>>
         active_since_;
     double const jitter_ratio_;
-    const std::chrono::milliseconds reset_interval_;
+    std::chrono::milliseconds const reset_interval_;
     // Default random generator. Used when random method not specified.
     std::function<double(double ratio)> random_;
     std::default_random_engine random_gen_;

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -6,14 +6,16 @@ std::chrono::milliseconds calculate_backoff(
     std::uint64_t const attempt,
     std::uint64_t const max_exponent) {
     std::uint64_t const exponent = std::min(attempt - 1, max_exponent);
-    return initial * static_cast<uint64_t>(std::pow(2, exponent));
+    double const exponentiated = std::pow(2, exponent);
+    return initial * static_cast<uint64_t>(exponentiated);
 }
 
 std::chrono::milliseconds jitter(std::chrono::milliseconds const base,
                                  double const jitter_ratio,
                                  std::function<double(double)> const& random) {
-    return std::chrono::milliseconds(static_cast<uint64_t>(
-        base.count() - (random(jitter_ratio) * base.count())));
+    double const jitter = random(jitter_ratio);
+    double const jittered_base = base.count() - (jitter * base.count());
+    return std::chrono::milliseconds(static_cast<uint64_t>(jittered_base));
 }
 
 std::chrono::milliseconds delay(std::chrono::milliseconds const initial,
@@ -22,8 +24,8 @@ std::chrono::milliseconds delay(std::chrono::milliseconds const initial,
                                 std::uint64_t const max_exponent,
                                 double const jitter_ratio,
                                 std::function<double(double)> const& random) {
-    return jitter(
-        std::min(calculate_backoff(initial, attempt, max_exponent), max),
-        jitter_ratio, random);
+    auto const backoff = calculate_backoff(initial, attempt, max_exponent);
+    auto const constrained_backoff = std::min(backoff, max);
+    return jitter(constrained_backoff, jitter_ratio, random);
 }
-}  // namespace detail
+}  // namespace launchdarkly::sse::detail

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -17,8 +17,8 @@ std::chrono::milliseconds jitter(std::chrono::milliseconds const base,
                                  double const jitter_ratio,
                                  std::function<double(double)> const& random) {
     double const jitter = random(jitter_ratio);
-    double const jittered_base =
-        static_cast<double>(base.count()) - jitter * base.count();
+    double const base_as_double = static_cast<double>(base.count());
+    double const jittered_base = base_as_double - jitter * base_as_double;
     return std::chrono::milliseconds(static_cast<uint64_t>(jittered_base));
 }
 

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -1,5 +1,7 @@
 #include "backoff_detail.hpp"
 
+#include <cmath>
+
 namespace launchdarkly::sse::detail {
 std::chrono::milliseconds calculate_backoff(
     std::chrono::milliseconds const initial,

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -17,7 +17,7 @@ std::chrono::milliseconds jitter(std::chrono::milliseconds const base,
                                  double const jitter_ratio,
                                  std::function<double(double)> const& random) {
     double const jitter = random(jitter_ratio);
-    double const base_as_double = static_cast<double>(base.count());
+    auto const base_as_double = static_cast<double>(base.count());
     double const jittered_base = base_as_double - jitter * base_as_double;
     return std::chrono::milliseconds(static_cast<uint64_t>(jittered_base));
 }

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -1,0 +1,29 @@
+#include "backoff_detail.hpp"
+
+namespace launchdarkly::sse::detail {
+std::chrono::milliseconds calculate_backoff(
+    std::chrono::milliseconds const initial,
+    std::uint64_t const attempt,
+    std::uint64_t const max_exponent) {
+    std::uint64_t const exponent = std::min(attempt - 1, max_exponent);
+    return initial * static_cast<uint64_t>(std::pow(2, exponent));
+}
+
+std::chrono::milliseconds jitter(std::chrono::milliseconds const base,
+                                 double const jitter_ratio,
+                                 std::function<double(double)> const& random) {
+    return std::chrono::milliseconds(static_cast<uint64_t>(
+        base.count() - (random(jitter_ratio) * base.count())));
+}
+
+std::chrono::milliseconds delay(std::chrono::milliseconds const initial,
+                                std::chrono::milliseconds const max,
+                                std::uint64_t const attempt,
+                                std::uint64_t const max_exponent,
+                                double const jitter_ratio,
+                                std::function<double(double)> const& random) {
+    return jitter(
+        std::min(calculate_backoff(initial, attempt, max_exponent), max),
+        jitter_ratio, random);
+}
+}  // namespace detail

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -1,5 +1,6 @@
 #include "backoff_detail.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 namespace launchdarkly::sse::detail {

--- a/libs/server-sent-events/src/backoff_detail.cpp
+++ b/libs/server-sent-events/src/backoff_detail.cpp
@@ -17,7 +17,8 @@ std::chrono::milliseconds jitter(std::chrono::milliseconds const base,
                                  double const jitter_ratio,
                                  std::function<double(double)> const& random) {
     double const jitter = random(jitter_ratio);
-    double const jittered_base = base.count() - (jitter * base.count());
+    double const jittered_base =
+        static_cast<double>(base.count()) - jitter * base.count();
     return std::chrono::milliseconds(static_cast<uint64_t>(jittered_base));
 }
 

--- a/libs/server-sent-events/src/backoff_detail.hpp
+++ b/libs/server-sent-events/src/backoff_detail.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+
+namespace launchdarkly::sse::detail {
+/**
+ * Calculate an exponential backoff based on the initial retry time and
+ * the current attempt.
+ *
+ * @param initial The initial retry delay.
+ * @param attempt The current attempt count.
+ * @param max_exponent The maximum exponent to use in the calculation.
+ *
+ * @return The current backoff based on the number of attempts.
+ */
+
+std::chrono::milliseconds calculate_backoff(std::chrono::milliseconds initial,
+                                            std::uint64_t attempt,
+                                            std::uint64_t max_exponent);
+/**
+ * Produce a jittered version of the base value. This value will be adjusted
+ * randomly to be between 50% and 100% of the input duration.
+ *
+ * @param base The base duration to jitter.
+ * @param jitter_ratio The ratio to use when jittering.
+ * @param random A random method which produces a value between 0 and
+ * jitter_ratio.
+ * @return The jittered duration.
+ */
+std::chrono::milliseconds jitter(std::chrono::milliseconds base,
+                                 double jitter_ratio,
+                                 std::function<double(double)> const& random);
+
+/**
+ *
+ * @param initial The initial retry delay.
+ * @param max The maximum delay between retries.
+ * @param attempt The current attempt.
+ * @param max_exponent The maximum exponent to use in the calculation.
+ * @param jitter_ratio The ratio to use when jittering.
+ * @param random A random method which produces a value between 0 and
+ * jitter_ratio.
+ * @return The delay between connection attempts.
+ */
+std::chrono::milliseconds delay(std::chrono::milliseconds initial,
+                                std::chrono::milliseconds max,
+                                std::uint64_t attempt,
+                                std::uint64_t max_exponent,
+                                double jitter_ratio,
+                                std::function<double(double)> const& random);
+}  // namespace launchdarkly::sse::detail

--- a/libs/server-sent-events/tests/backoff_test.cpp
+++ b/libs/server-sent-events/tests/backoff_test.cpp
@@ -146,14 +146,16 @@ TEST_P(BackoffOverflowEndToEndTest, BackoffDoesNotOverflowWithVariousAttempts) {
 
     for (int i = 0; i < attempts; i++) {
         backoff.fail();
-        auto const val = backoff.delay();
-        EXPECT_EQ(val, std::chrono::milliseconds{30000});
     }
+
+    auto const val = backoff.delay();
+    EXPECT_EQ(val, std::chrono::milliseconds{30000});
 }
 
-INSTANTIATE_TEST_SUITE_P(VariousBackoffAttempts,
-                         BackoffOverflowEndToEndTest,
-                         ::testing::Values<std::uint64_t>(63, 64, 65, 1000));
+INSTANTIATE_TEST_SUITE_P(
+    VariousBackoffAttempts,
+    BackoffOverflowEndToEndTest,
+    ::testing::Values<std::uint64_t>(10, 54, 55, 63, 64, 65, 500, 1000));
 
 class BackoffOverflowUnitTest : public ::testing::TestWithParam<std::uint64_t> {
 };

--- a/libs/server-sent-events/tests/backoff_test.cpp
+++ b/libs/server-sent-events/tests/backoff_test.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <numeric>
 #include <thread>
 
 #include "backoff.hpp"
+#include "backoff_detail.hpp"
 
 using launchdarkly::sse::Backoff;
 
@@ -95,18 +97,71 @@ TEST(BackoffTests, BackoffDoesNotResetActiveConnectionWasTooShort) {
     EXPECT_EQ(8000, backoff.delay().count());
 }
 
-TEST(BackoffTests, BackoffDoesNotOverflowWhenAttemptsGreaterThan64) {
+class BackoffOverflowEndToEndTest
+    : public ::testing::TestWithParam<std::uint64_t> {};
+
+TEST_P(BackoffOverflowEndToEndTest, BackoffDoesNotOverflowWithVariousAttempts) {
     Backoff backoff(
         std::chrono::milliseconds{1000}, std::chrono::milliseconds{30000}, 0,
         std::chrono::milliseconds{60000}, [](auto ratio) { return 0; });
 
-    for (int i = 0; i < 65; i++) {
+    std::uint64_t const attempts = GetParam();
+
+    for (int i = 0; i < attempts; i++) {
         backoff.fail();
     }
 
     auto const val = backoff.delay();
-    EXPECT_FALSE(std::isnan(val.count()));
-    EXPECT_LE(val, std::chrono::milliseconds::max());
-    EXPECT_GT(val, std::chrono::milliseconds::min());
-    EXPECT_GT(val.count(), 0);
+    EXPECT_EQ(val, std::chrono::milliseconds{30000});
 }
+
+INSTANTIATE_TEST_SUITE_P(VariousBackoffAttempts,
+                         BackoffOverflowEndToEndTest,
+                         ::testing::Values<std::uint64_t>(63, 64, 65, 1000));
+
+class BackoffOverflowUnitTest : public ::testing::TestWithParam<std::uint64_t> {
+};
+
+TEST_P(BackoffOverflowUnitTest,
+       BackoffDoesNotOverflowWithVariousAttemptsInCalculateBackoff) {
+    std::uint64_t const attempts = GetParam();
+
+    constexpr std::uint64_t max_exponent = 5;
+
+    // Given an exponent of 5, and initial delay of 1ms, the max should be
+    // 2^5 = 32 for any amount of attempts > 5.
+
+    constexpr auto initial = std::chrono::milliseconds{1};
+    constexpr auto max = std::chrono::milliseconds{32};
+
+    auto const milliseconds = launchdarkly::sse::detail::calculate_backoff(
+        initial, attempts, max_exponent);
+
+    ASSERT_EQ(milliseconds, max);
+}
+
+TEST_P(BackoffOverflowUnitTest,
+       BackoffDoesNotOverflowWithVariousAttemptsInDelay) {
+    std::uint64_t const attempts = GetParam();
+
+    constexpr std::uint64_t max_exponent = 5;
+
+    // Given an exponent of 5, and initial delay of 1ms, the max should be
+    // 2^5 = 32 for any amount of attempts > 5.
+
+    constexpr auto initial = std::chrono::milliseconds{1};
+    constexpr auto max = std::chrono::milliseconds{32};
+
+    auto const milliseconds = launchdarkly::sse::detail::delay(
+        initial, max, attempts, max_exponent, 0, [](auto ratio) { return 0; });
+
+    ASSERT_EQ(milliseconds, max);
+}
+
+INSTANTIATE_TEST_SUITE_P(VariousBackoffAttempts,
+                         BackoffOverflowUnitTest,
+                         ::testing::Values<std::uint64_t>(
+                             1000,
+                             10000,
+                             100000,
+                             std::numeric_limits<std::uint64_t>::max()));


### PR DESCRIPTION
In some platform configurations, the SSE backoff calculation overflows which results in failing to schedule another backoff attempt via `asio::deadline_timer::expires_from_now`.

This PR refactors the backoff algorithm to use free functions which can be independently tested. 

It fixes the bug by constraining the maximum backoff exponent based on the configurable max backoff parameter. 

Finally, I've added some test vectors for large attempt values. In the bug report, the overflow happens at about 34 minutes which corresponded to 55 attempts.  
