### PR TITLE
fix(deps): build with openssl 3.4.0 on windows

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 3.1.1 -y --no-progress
+        choco install openssl --version 3.4.0 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
This bumps OpenSSL from 3.1.1 to 3.4.0 on Windows ([the latest, released two days ago](https://github.com/openssl/openssl/releases/tag/openssl-3.4.0)). This will resolve outstanding CVEs filed against 3.1.1.