### PR TITLE
feat: expose prerequisite relations in AllFlags API

### DIFF
--- a/contract-tests/server-contract-tests/src/main.cpp
+++ b/contract-tests/server-contract-tests/src/main.cpp
@@ -47,6 +47,8 @@ int main(int argc, char* argv[]) {
         srv.add_capability("tls:custom-ca");
         srv.add_capability("filtering");
         srv.add_capability("filtering-strict");
+        srv.add_capability("client-prereq-events");
+
         net::signal_set signals{ioc, SIGINT, SIGTERM};
 
         boost::asio::spawn(ioc.get_executor(), [&](auto yield) mutable {

--- a/libs/internal/include/launchdarkly/events/data/common_events.hpp
+++ b/libs/internal/include/launchdarkly/events/data/common_events.hpp
@@ -8,7 +8,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <variant>
 
 namespace launchdarkly::events {
 

--- a/libs/internal/include/launchdarkly/events/data/events.hpp
+++ b/libs/internal/include/launchdarkly/events/data/events.hpp
@@ -3,6 +3,8 @@
 #include <launchdarkly/events/data/common_events.hpp>
 #include <launchdarkly/events/data/server_events.hpp>
 
+#include <variant>
+
 namespace launchdarkly::events {
 
 using InputEvent = std::variant<FeatureEventParams,

--- a/libs/internal/include/launchdarkly/events/event_processor_interface.hpp
+++ b/libs/internal/include/launchdarkly/events/event_processor_interface.hpp
@@ -12,7 +12,7 @@ class IEventProcessor {
      * capacity.
      * @param event InputEvent to deliver.
      */
-    virtual void SendAsync(events::InputEvent event) = 0;
+    virtual void SendAsync(InputEvent event) = 0;
     /**
      * Asynchronously flush's the processor's events, returning as soon as
      * possible. Flushing may be a no-op if a flush is ongoing.

--- a/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/all_flags_state.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace launchdarkly::server_side {
 
@@ -62,6 +63,14 @@ class AllFlagsState {
               bool track_reason,
               std::optional<std::uint64_t> debug_events_until_date);
 
+        State(std::uint64_t version,
+              std::optional<std::int64_t> variation,
+              std::optional<EvaluationReason> reason,
+              bool track_events,
+              bool track_reason,
+              std::optional<std::uint64_t> debug_events_until_date,
+              std::vector<std::string> prerequisites);
+
         /**
          * @return The flag's version number when it was evaluated.
          */
@@ -110,6 +119,12 @@ class AllFlagsState {
          */
         [[nodiscard]] bool OmitDetails() const;
 
+        /**
+         * @return The list of prerequisites for this flag in the order they
+         * were evaluated.
+         */
+        [[nodiscard]] std::vector<std::string> const& Prerequisites() const;
+
         friend class AllFlagsStateBuilder;
 
        private:
@@ -120,6 +135,7 @@ class AllFlagsState {
         bool track_reason_;
         std::optional<std::uint64_t> debug_events_until_date_;
         bool omit_details_;
+        std::vector<std::string> prerequisites_;
     };
 
     /**

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(${LIBNAME}
         all_flags_state/json_all_flags_state.cpp
         all_flags_state/all_flags_state_builder.cpp
         integrations/data_reader/kinds.cpp
+        prereq_event_recorder/prereq_event_recorder.cpp
+        prereq_event_recorder/prereq_event_recorder.hpp
         data_components/change_notifier/change_notifier.hpp
         data_components/change_notifier/change_notifier.cpp
         data_components/dependency_tracker/dependency_tracker.hpp

--- a/libs/server-sdk/src/all_flags_state/all_flags_state.cpp
+++ b/libs/server-sdk/src/all_flags_state/all_flags_state.cpp
@@ -3,19 +3,36 @@
 namespace launchdarkly::server_side {
 
 AllFlagsState::State::State(
-    std::uint64_t version,
-    std::optional<std::int64_t> variation,
+    std::uint64_t const version,
+    std::optional<std::int64_t> const variation,
     std::optional<EvaluationReason> reason,
-    bool track_events,
-    bool track_reason,
-    std::optional<std::uint64_t> debug_events_until_date)
+    bool const track_events,
+    bool const track_reason,
+    std::optional<std::uint64_t> const debug_events_until_date)
+    : State(version,
+            variation,
+            std::move(reason),
+            track_events,
+            track_reason,
+            debug_events_until_date,
+            std::vector<std::string>{}) {}
+
+AllFlagsState::State::State(
+    std::uint64_t const version,
+    std::optional<std::int64_t> const variation,
+    std::optional<EvaluationReason> reason,
+    bool const track_events,
+    bool const track_reason,
+    std::optional<std::uint64_t> const debug_events_until_date,
+    std::vector<std::string> prerequisites)
     : version_(version),
       variation_(variation),
-      reason_(reason),
+      reason_(std::move(reason)),
       track_events_(track_events),
       track_reason_(track_reason),
       debug_events_until_date_(debug_events_until_date),
-      omit_details_(false) {}
+      omit_details_(false),
+      prerequisites_(std::move(prerequisites)) {}
 
 std::uint64_t AllFlagsState::State::Version() const {
     return version_;
@@ -35,6 +52,10 @@ bool AllFlagsState::State::TrackEvents() const {
 
 bool AllFlagsState::State::TrackReason() const {
     return track_reason_;
+}
+
+std::vector<std::string> const& AllFlagsState::State::Prerequisites() const {
+    return prerequisites_;
 }
 
 std::optional<std::uint64_t> const& AllFlagsState::State::DebugEventsUntilDate()
@@ -80,7 +101,8 @@ bool operator==(AllFlagsState::State const& lhs,
            lhs.TrackEvents() == rhs.TrackEvents() &&
            lhs.TrackReason() == rhs.TrackReason() &&
            lhs.DebugEventsUntilDate() == rhs.DebugEventsUntilDate() &&
-           lhs.OmitDetails() == rhs.OmitDetails();
+           lhs.OmitDetails() == rhs.OmitDetails() &&
+           lhs.Prerequisites() == rhs.Prerequisites();
 }
 
 }  // namespace launchdarkly::server_side

--- a/libs/server-sdk/src/all_flags_state/json_all_flags_state.cpp
+++ b/libs/server-sdk/src/all_flags_state/json_all_flags_state.cpp
@@ -31,6 +31,11 @@ void tag_invoke(boost::json::value_from_tag const& unused,
             obj.emplace("debugEventsUntilDate", boost::json::value_from(*date));
         }
     }
+
+    if (auto const& prerequisites = state.Prerequisites();
+        !prerequisites.empty()) {
+        obj.emplace("prerequisites", boost::json::value_from(prerequisites));
+    }
 }
 
 void tag_invoke(boost::json::value_from_tag const& unused,

--- a/libs/server-sdk/src/events/event_factory.cpp
+++ b/libs/server-sdk/src/events/event_factory.cpp
@@ -3,8 +3,7 @@
 #include <chrono>
 namespace launchdarkly::server_side {
 
-EventFactory::EventFactory(
-    launchdarkly::server_side::EventFactory::ReasonPolicy reason_policy)
+EventFactory::EventFactory(ReasonPolicy const reason_policy)
     : reason_policy_(reason_policy),
       now_([]() { return events::Date{std::chrono::system_clock::now()}; }) {}
 

--- a/libs/server-sdk/src/prereq_event_recorder/prereq_event_recorder.cpp
+++ b/libs/server-sdk/src/prereq_event_recorder/prereq_event_recorder.cpp
@@ -1,0 +1,30 @@
+#include "prereq_event_recorder.hpp"
+
+namespace launchdarkly::server_side {
+
+PrereqEventRecorder::PrereqEventRecorder(std::string flag_key)
+    : flag_key_(std::move(flag_key)) {}
+
+void PrereqEventRecorder::SendAsync(events::InputEvent const event) {
+    if (auto const* feat = std::get_if<events::FeatureEventParams>(&event)) {
+        if (auto const prereq_of = feat->prereq_of) {
+            if (*prereq_of == flag_key_) {
+                prereqs_.push_back(feat->key);
+            }
+        }
+    }
+}
+
+void PrereqEventRecorder::FlushAsync() {}
+
+void PrereqEventRecorder::ShutdownAsync() {}
+
+std::vector<std::string> const& PrereqEventRecorder::Prerequisites() const {
+    return prereqs_;
+}
+
+std::vector<std::string>&& PrereqEventRecorder::TakePrerequisites() && {
+    return std::move(prereqs_);
+}
+
+}  // namespace launchdarkly::server_side

--- a/libs/server-sdk/src/prereq_event_recorder/prereq_event_recorder.hpp
+++ b/libs/server-sdk/src/prereq_event_recorder/prereq_event_recorder.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <launchdarkly/events/event_processor_interface.hpp>
+
+#include <string>
+#include <vector>
+
+namespace launchdarkly::server_side {
+
+/**
+ * This class is meant only to record direct prerequisites of a flag. That is,
+ * although it will be passed events for all prerequisites seen during an
+ * evaluation via SendAsync, it will only store those that are a direct
+ * prerequisite of the parent flag passed in the constructor.
+ *
+ * As a future improvement, it would be possible to unify the EventScope
+ * mechanism currently used by the Evaluator to send events with a class
+ * similar to this one, or to refactor the Evaluator to include prerequisite
+ * information in the returned EvaluationDetail (or a new Result class, which
+ * would be a composite of the EvaluationDetail and a vector of prerequisites.)
+ */
+class PrereqEventRecorder final : public events::IEventProcessor {
+   public:
+    explicit PrereqEventRecorder(std::string flag_key);
+
+    void SendAsync(events::InputEvent event) override;
+
+    /* No-op */
+    void FlushAsync() override;
+
+    /* No-op */
+    void ShutdownAsync() override;
+
+    std::vector<std::string> const& Prerequisites() const;
+
+    std::vector<std::string>&& TakePrerequisites() &&;
+
+   private:
+    std::string const flag_key_;
+    std::vector<std::string> prereqs_;
+};
+
+}  // namespace launchdarkly::server_side

--- a/libs/server-sdk/tests/all_flags_state_test.cpp
+++ b/libs/server-sdk/tests/all_flags_state_test.cpp
@@ -42,6 +42,37 @@ TEST(AllFlagsTest, DefaultOptions) {
     ASSERT_EQ(got, expected);
 }
 
+TEST(AllFlagsTest, DefaultOptionsExposesPrerequisiteRelations) {
+    AllFlagsStateBuilder builder{AllFlagsState::Options::Default};
+
+    builder.AddFlag("myFlag", true,
+                    AllFlagsState::State{42,
+                                         1,
+                                         std::nullopt,
+                                         false,
+                                         false,
+                                         std::nullopt,
+                                         {"prereq1", "prereq2"}});
+
+    auto state = builder.Build();
+    ASSERT_TRUE(state.Valid());
+
+    auto expected = boost::json::parse(R"({
+        "myFlag": true,
+        "$flagsState": {
+            "myFlag": {
+                "version": 42,
+                "variation": 1,
+                "prerequisites": ["prereq1", "prereq2"]
+            }
+        },
+        "$valid": true
+    })");
+
+    auto got = boost::json::value_from(state);
+    ASSERT_EQ(got, expected);
+}
+
 TEST(AllFlagsTest, DetailsOnlyForTrackedFlags) {
     AllFlagsStateBuilder builder{
         AllFlagsState::Options::DetailsOnlyForTrackedFlags};
@@ -81,6 +112,55 @@ TEST(AllFlagsTest, DetailsOnlyForTrackedFlags) {
     ASSERT_EQ(got, expected);
 }
 
+TEST(AllFlagsTest, DetailsOnlyForTrackedFlagsExposesPrerequisiteRelations) {
+    AllFlagsStateBuilder builder{
+        AllFlagsState::Options::DetailsOnlyForTrackedFlags};
+    builder.AddFlag("myFlagTracked", true,
+                    AllFlagsState::State{42,
+                                         1,
+                                         EvaluationReason::Fallthrough(false),
+                                         true,
+                                         true,
+                                         std::nullopt,
+                                         {"prereq1", "prereq2"}});
+    builder.AddFlag("myFlagUntracked", true,
+                    AllFlagsState::State{42,
+                                         1,
+                                         EvaluationReason::Fallthrough(false),
+                                         false,
+                                         false,
+                                         std::nullopt,
+                                         {"prereq1", "prereq2"}});
+
+    auto state = builder.Build();
+    ASSERT_TRUE(state.Valid());
+
+    auto expected = boost::json::parse(R"({
+        "myFlagTracked" : true,
+        "myFlagUntracked" : true,
+        "$flagsState": {
+            "myFlagTracked": {
+                "version": 42,
+                "variation": 1,
+                "reason":{
+                    "kind" : "FALLTHROUGH"
+                },
+                "trackReason" : true,
+                "trackEvents" : true,
+                "prerequisites" : ["prereq1", "prereq2"]
+            },
+            "myFlagUntracked" : {
+                "variation" : 1,
+                "prerequisites" : ["prereq1", "prereq2"]
+            }
+        },
+        "$valid": true
+    })");
+
+    auto got = boost::json::value_from(state);
+    ASSERT_EQ(got, expected);
+}
+
 TEST(AllFlagsTest, IncludeReasons) {
     AllFlagsStateBuilder builder{AllFlagsState::Options::IncludeReasons};
     builder.AddFlag(
@@ -99,6 +179,38 @@ TEST(AllFlagsTest, IncludeReasons) {
                 "reason" : {
                     "kind": "FALLTHROUGH"
                 }
+            }
+        },
+        "$valid": true
+    })");
+
+    auto got = boost::json::value_from(state);
+    ASSERT_EQ(got, expected);
+}
+
+TEST(AllFlagsTest, IncludeReasonsExposesPrerequisiteRelations) {
+    AllFlagsStateBuilder builder{AllFlagsState::Options::IncludeReasons};
+    builder.AddFlag("myFlag", true,
+                    AllFlagsState::State{42,
+                                         1,
+                                         EvaluationReason::Fallthrough(false),
+                                         false,
+                                         false,
+                                         std::nullopt,
+                                         {"prereq1", "prereq2"}});
+    auto state = builder.Build();
+    ASSERT_TRUE(state.Valid());
+
+    auto expected = boost::json::parse(R"({
+        "myFlag": true,
+        "$flagsState": {
+            "myFlag": {
+                "version": 42,
+                "variation": 1,
+                "reason" : {
+                    "kind": "FALLTHROUGH"
+                },
+                "prerequisites": ["prereq1", "prereq2"]
             }
         },
         "$valid": true
@@ -130,12 +242,13 @@ TEST(AllFlagsTest, FlagValues) {
     }));
 }
 
-TEST(AllFlagsTest, FlagState) {
+TEST(AllFlagsTest, FlagStatePassedInIsEquivalentToRetrievedState) {
     AllFlagsStateBuilder builder{AllFlagsState::Options::Default};
 
     std::size_t const kNumFlags = 10;
 
-    AllFlagsState::State state{42, 1, std::nullopt, false, false, std::nullopt};
+    AllFlagsState::State state{
+        42, 1, std::nullopt, false, false, std::nullopt, {"a", "b", "c"}};
     for (std::size_t i = 0; i < kNumFlags; i++) {
         builder.AddFlag("myFlag" + std::to_string(i), "value", state);
     }
@@ -151,18 +264,27 @@ TEST(AllFlagsTest, FlagState) {
     }));
 }
 
-TEST(AllFlagsTest, FlagStateCanBeConstructedWithPrerequisites) {
-    auto const prereqs = std::vector<std::string>{"a", "b", "c"};
-    AllFlagsState::State const state{
-        42, 1, std::nullopt, false, false, std::nullopt, prereqs};
-    ASSERT_EQ(state.Prerequisites(), prereqs);
-}
+// Similar to the test above but with the prerequisite list reversed, as a
+// sanity check that the list order is preserved.
+TEST(AllFlagsTest,
+     FlagStatePassedInIsEquivalentToRetrievedState_ReversedPrereqs) {
+    AllFlagsStateBuilder builder{AllFlagsState::Options::Default};
 
-// Similar to the previous test, but serves as a sanity check that the vector's
-// order was preserved.
-TEST(AllFlagsTest, FlagStateCanBeConstructedWithPrerequisitesReversed) {
-    auto const prereqs = std::vector<std::string>{"c", "b", "a"};
-    AllFlagsState::State const state{
-        42, 1, std::nullopt, false, false, std::nullopt, prereqs};
-    ASSERT_EQ(state.Prerequisites(), prereqs);
+    std::size_t const kNumFlags = 10;
+
+    AllFlagsState::State state{
+        42, 1, std::nullopt, false, false, std::nullopt, {"c", "b", "a"}};
+    for (std::size_t i = 0; i < kNumFlags; i++) {
+        builder.AddFlag("myFlag" + std::to_string(i), "value", state);
+    }
+
+    auto all_flags_state = builder.Build();
+
+    auto const& states = all_flags_state.States();
+
+    ASSERT_EQ(states.size(), kNumFlags);
+
+    ASSERT_TRUE(std::all_of(states.begin(), states.end(), [&](auto const& kvp) {
+        return kvp.second == state;
+    }));
 }

--- a/libs/server-sdk/tests/all_flags_state_test.cpp
+++ b/libs/server-sdk/tests/all_flags_state_test.cpp
@@ -150,3 +150,19 @@ TEST(AllFlagsTest, FlagState) {
         return kvp.second == state;
     }));
 }
+
+TEST(AllFlagsTest, FlagStateCanBeConstructedWithPrerequisites) {
+    auto const prereqs = std::vector<std::string>{"a", "b", "c"};
+    AllFlagsState::State const state{
+        42, 1, std::nullopt, false, false, std::nullopt, prereqs};
+    ASSERT_EQ(state.Prerequisites(), prereqs);
+}
+
+// Similar to the previous test, but serves as a sanity check that the vector's
+// order was preserved.
+TEST(AllFlagsTest, FlagStateCanBeConstructedWithPrerequisitesReversed) {
+    auto const prereqs = std::vector<std::string>{"c", "b", "a"};
+    AllFlagsState::State const state{
+        42, 1, std::nullopt, false, false, std::nullopt, prereqs};
+    ASSERT_EQ(state.Prerequisites(), prereqs);
+}

--- a/libs/server-sdk/tests/prereq_event_recorder_test.cpp
+++ b/libs/server-sdk/tests/prereq_event_recorder_test.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include "events/event_factory.hpp"
+#include "prereq_event_recorder/prereq_event_recorder.hpp"
+
+#include <launchdarkly/context_builder.hpp>
+
+using namespace launchdarkly;
+using namespace launchdarkly::server_side;
+using namespace launchdarkly::events;
+
+TEST(PrereqEventRecorderTest, EmptyByDefault) {
+    PrereqEventRecorder recorder{"foo"};
+    ASSERT_TRUE(recorder.Prerequisites().empty());
+
+    std::vector<std::string> prereqs = std::move(recorder).TakePrerequisites();
+    ASSERT_TRUE(prereqs.empty());
+}
+
+TEST(PrereqEventRecorderTest, RecordsPrerequisites) {
+    std::string const flag = "toplevel";
+
+    PrereqEventRecorder recorder{flag};
+
+    auto factory = EventFactory::WithoutReasons();
+
+    auto const context = ContextBuilder().Kind("cat", "shadow").Build();
+
+    recorder.SendAsync(factory.Eval("prereq1", context, std::nullopt,
+                                    EvaluationReason::Fallthrough(false), false,
+                                    flag));
+
+    recorder.SendAsync(factory.Eval("prereq2", context, std::nullopt,
+                                    EvaluationReason::Fallthrough(false), false,
+                                    flag));
+
+    auto const expectedPrereqs = std::vector<std::string>{"prereq1", "prereq2"};
+    ASSERT_EQ(recorder.Prerequisites(), expectedPrereqs);
+}
+
+TEST(PrereqEventRecorderTest, IgnoresIrrelevantEvents) {
+    PrereqEventRecorder recorder{"foo"};
+
+    auto factory = EventFactory::WithoutReasons();
+
+    auto const context = ContextBuilder().Kind("cat", "shadow").Build();
+
+    recorder.SendAsync(factory.Identify(context));
+    recorder.SendAsync(factory.UnknownFlag(
+        "flag", context, EvaluationReason::Fallthrough(false), true));
+    recorder.SendAsync(factory.Custom(context, "event", std::nullopt, 1.0));
+
+    ASSERT_TRUE(recorder.Prerequisites().empty());
+}
+
+TEST(PrereqEventRecorderTest, IgnoresEvalEventsWithoutPrereqOf) {
+    PrereqEventRecorder recorder{"toplevel"};
+
+    auto factory = EventFactory::WithoutReasons();
+
+    auto const context = ContextBuilder().Kind("cat", "shadow").Build();
+
+    // Receiving an eval event without a prereq_of field shouldn't actually
+    // happen when calling AllFlags, but regardless we should ignore it that
+    // would signify that this isn't a prerequisite.
+    recorder.SendAsync(factory.Eval("not-a-prereq", context, std::nullopt,
+                                    EvaluationReason::Fallthrough(false), false,
+                                    std::nullopt));
+
+    ASSERT_TRUE(recorder.Prerequisites().empty());
+}
+
+TEST(PrereqEventRecorderTest, TakesPrerequisites) {
+    std::string const flag = "toplevel";
+
+    PrereqEventRecorder recorder{flag};
+
+    auto factory = EventFactory::WithoutReasons();
+
+    auto const context = ContextBuilder().Kind("cat", "shadow").Build();
+
+    recorder.SendAsync(factory.Eval("prereq1", context, std::nullopt,
+                                    EvaluationReason::Fallthrough(false), false,
+                                    flag));
+
+    recorder.SendAsync(factory.Eval("prereq2", context, std::nullopt,
+                                    EvaluationReason::Fallthrough(false), false,
+                                    flag));
+
+    auto const expectedPrereqs = std::vector<std::string>{"prereq1", "prereq2"};
+    auto gotPrereqs = std::move(recorder).TakePrerequisites();
+    ASSERT_EQ(gotPrereqs, expectedPrereqs);
+    ASSERT_TRUE(recorder.Prerequisites().empty());
+}

--- a/libs/server-sdk/tests/prereq_event_recorder_test.cpp
+++ b/libs/server-sdk/tests/prereq_event_recorder_test.cpp
@@ -61,8 +61,8 @@ TEST(PrereqEventRecorderTest, IgnoresEvalEventsWithoutPrereqOf) {
     auto const context = ContextBuilder().Kind("cat", "shadow").Build();
 
     // Receiving an eval event without a prereq_of field shouldn't actually
-    // happen when calling AllFlags, but regardless we should ignore it that
-    // would signify that this isn't a prerequisite.
+    // happen when calling AllFlags, but regardless we should ignore it because
+    // that would signify that it isn't a prerequisite.
     recorder.SendAsync(factory.Eval("not-a-prereq", context, std::nullopt,
                                     EvaluationReason::Fallthrough(false), false,
                                     std::nullopt));


### PR DESCRIPTION
Updates the `AllFlags()` API to gather and expose prerequisite information for flags. 

The prereqs are available via `State::Prerequisites()`, and are more importantly serialized in the JSON representation of the bootstrap payload. 

The implementation strategy was to create a custom `IEventProcessor` specifically for `AllFlags` usage. Previously, `AllFlags` invoked the evaluator with a no-op `EventScope`, which made event creation a no-op within the eval algorithm.

This change now passes in a `PrereqEventRecorder` which tracks the top-level prerequisites of each flag. 