### PR TITLE
ci: upgrade mac executors to macos-13

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -43,7 +43,7 @@ jobs:
           cmake_target: launchdarkly-cpp-client
           simulate_release: true
   build-test-client-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
           platform_version: '22.04'
 
   test-macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cmake-test

--- a/.github/workflows/hello-apps.yml
+++ b/.github/workflows/hello-apps.yml
@@ -15,7 +15,7 @@ jobs:
   smoketest:
     strategy:
       matrix:
-        os: [ "ubuntu-22.04", "macos-12", "windows-2022" ]
+        os: [ "ubuntu-22.04", "macos-13", "windows-2022" ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Each of the platforms for which release-artifacts need generated.
-        os: [ ubuntu-latest, windows-2022, macos-12 ]
+        os: [ ubuntu-latest, windows-2022, macos-13 ]
     runs-on: ${{ matrix.os }}
     outputs:
       hashes-linux: ${{ steps.release-sdk.outputs.hashes-linux }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # Each of the platforms for which release-artifacts need generated.
-        os: [ ubuntu-latest, windows-2022, macos-12 ]
+        os: [ ubuntu-latest, windows-2022, macos-13 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
     if: ${{ needs.release-please.outputs.package-client-released == 'true'}}
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         # Each of the platforms for which release-artifacts need generated.
-        os: [ ubuntu-latest, windows-2022, macos-12 ]
+        os: [ ubuntu-latest, windows-2022, macos-13 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
     if: ${{ needs.release-please.outputs.package-server-released == 'true'}}
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         # Each of the platforms for which release-artifacts need generated.
-        os: [ ubuntu-latest, windows-2022, macos-12 ]
+        os: [ ubuntu-latest, windows-2022, macos-13 ]
     runs-on: ${{ matrix.os }}
     needs: [ 'release-please' ]
     if: ${{ needs.release-please.outputs.package-server-redis-released  == 'true'}}

--- a/.github/workflows/server-redis.yml
+++ b/.github/workflows/server-redis.yml
@@ -28,7 +28,7 @@ jobs:
           cmake_target: launchdarkly-cpp-server-redis-source
           simulate_release: true
   build-redis-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -43,7 +43,7 @@ jobs:
           cmake_target: launchdarkly-cpp-server
           simulate_release: true
   build-test-server-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/ci


### PR DESCRIPTION
MacOS 12 executors are deprecated and will cease operation in December. Github randomly failed some jobs today during a "brownout" to let us know about this. 

Very effective I must say.