### PR TITLE
fix: Change notification consistency.

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -31,8 +31,8 @@ runs:
       id: boost-download
       shell: bash
       run: |
-        choco install boost-msvc-14.3 --version 1.81.0 -y --no-progress
-        echo "BOOST_ROOT=C:\local\boost_1_81_0" >> $GITHUB_OUTPUT
+        choco install boost-msvc-14.3 --version 1.87.0 -y --no-progress
+        echo "BOOST_ROOT=C:\local\boost_1_87_0" >> $GITHUB_OUTPUT
 
     - name: Install boost using homebrew
       id: brew-action

--- a/libs/client-sdk/src/flag_manager/flag_updater.cpp
+++ b/libs/client-sdk/src/flag_manager/flag_updater.cpp
@@ -95,6 +95,7 @@ void FlagUpdater::Upsert(Context const& context,
         return;
     }
 
+    flag_store_.Upsert(key, descriptor);
     if (HasListeners()) {
         // Existed and updated.
         if (existing && descriptor.item) {
@@ -112,7 +113,6 @@ void FlagUpdater::Upsert(Context const& context,
             // Do nothing.
         }
     }
-    flag_store_.Upsert(key, descriptor);
 }
 
 bool FlagUpdater::HasListeners() const {

--- a/libs/client-sdk/tests/flag_updater_test.cpp
+++ b/libs/client-sdk/tests/flag_updater_test.cpp
@@ -207,13 +207,21 @@ TEST(FlagUpdaterEventTests, SecondInitWithUpdateProducesEvents) {
 
     std::atomic_bool got_event(false);
     notifier->OnFlagChange(
-        "flagA", [&got_event](std::shared_ptr<FlagValueChangeEvent> event) {
+        "flagA", [&got_event, &manager](std::shared_ptr<FlagValueChangeEvent> event) {
             got_event.store(true);
 
             EXPECT_EQ("test", event->OldValue().AsString());
             EXPECT_EQ("potato", event->NewValue().AsString());
             EXPECT_EQ("flagA", event->FlagName());
             EXPECT_FALSE(event->Deleted());
+
+            // The value in the store should be consistent with the new value.
+            EXPECT_EQ(event->NewValue().AsString(), manager.Get("flagA")
+                                                        .get()
+                                                        ->item.value()
+                                                        .Detail()
+                                                        .Value()
+                                                        .AsString());
         });
 
     updater.Init(
@@ -283,13 +291,21 @@ TEST(FlagUpdaterDataTests, PatchWithUpdateProducesEvent) {
 
     std::atomic_bool got_event(false);
     notifier->OnFlagChange(
-        "flagA", [&got_event](std::shared_ptr<FlagValueChangeEvent> event) {
+        "flagA",
+        [&got_event, &manager](std::shared_ptr<FlagValueChangeEvent> event) {
             got_event.store(true);
 
             EXPECT_EQ("test", event->OldValue().AsString());
             EXPECT_EQ("second", event->NewValue().AsString());
             EXPECT_EQ("flagA", event->FlagName());
             EXPECT_FALSE(event->Deleted());
+            // The value in the store should be consistent with the new value.
+            EXPECT_EQ(event->NewValue().AsString(), manager.Get("flagA")
+                                                        .get()
+                                                        ->item.value()
+                                                        .Detail()
+                                                        .Value()
+                                                        .AsString());
         });
 
     updater.Init(
@@ -317,13 +333,22 @@ TEST(FlagUpdaterEventTests, PatchWithNewFlagProducesEvent) {
 
     std::atomic_bool got_event(false);
     notifier->OnFlagChange(
-        "flagB", [&got_event](std::shared_ptr<FlagValueChangeEvent> event) {
+        "flagB",
+        [&got_event, &manager](std::shared_ptr<FlagValueChangeEvent> event) {
             got_event.store(true);
 
             EXPECT_TRUE(event->OldValue().IsNull());
             EXPECT_EQ("second", event->NewValue().AsString());
             EXPECT_EQ("flagB", event->FlagName());
             EXPECT_FALSE(event->Deleted());
+
+            // The value in the store should be consistent with the new value.
+            EXPECT_EQ(event->NewValue().AsString(), manager.Get("flagB")
+                                                        .get()
+                                                        ->item.value()
+                                                        .Detail()
+                                                        .Value()
+                                                        .AsString());
         });
 
     updater.Init(


### PR DESCRIPTION
The store should be updated before events are dispatched to ensure consistent data between event information and variation calls.