### PR TITLE
fix: Bump redis-plus-plus to v1.3.14

### DIFF
--- a/cmake/redis-plus-plus.cmake
+++ b/cmake/redis-plus-plus.cmake
@@ -18,11 +18,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/_deps)
 
 set(REDIS_PLUS_PLUS_BUILD_TEST OFF CACHE BOOL "" FORCE)
 
-# 1.3.7 is the last release that works with FetchContent, due to a problem with CheckSymbolExists
-# when it tries to do feature detection on hiredis.
 FetchContent_Declare(redis-plus-plus
         GIT_REPOSITORY https://github.com/sewenew/redis-plus-plus.git
-        GIT_TAG 1.3.7
+        GIT_TAG 1.3.14
         GIT_SHALLOW TRUE
 )
 


### PR DESCRIPTION
gcc no longer transitively includes <cstdint>. This resulted in a break
in redis-plus-plus, which is fixed in v1.3.8.

But in true in-for-a-penny fashion, we are going to update to the latest
version.
