### PR TITLE
chore: Update OpenSSL for CI

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 3.4.2 -y --no-progress
+        choco install openssl --version 3.5.3 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 3.4.1 -y --no-progress
+        choco install openssl --version 3.4.2 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
The daily builds have been failing when trying to download OpenSSL 3.4.1. The package maintainer removes older versions with security vulnerabilities. This bumps to the latest 3.5 version. The package maintainer provides a 3.4.2 but chocolatey does not.