### PR TITLE
chore: use @launchdarkly scoped names in package.json files

### DIFF
--- a/libs/client-sdk/package.json
+++ b/libs/client-sdk/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "launchdarkly-cpp-client",
+  "name": "@launchdarkly/cpp-client",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "3.11.1",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-internal": "0.13.0",
-    "launchdarkly-cpp-common": "1.11.0",
-    "launchdarkly-cpp-sse-client": "0.6.1"
+    "@launchdarkly/cpp-internal": "0.13.0",
+    "@launchdarkly/cpp-common": "1.11.0",
+    "@launchdarkly/cpp-sse-client": "0.6.1"
   }
 }

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "launchdarkly-cpp-common",
+  "name": "@launchdarkly/cpp-common",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "1.11.0",
   "private": true

--- a/libs/internal/package.json
+++ b/libs/internal/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "launchdarkly-cpp-internal",
+  "name": "@launchdarkly/cpp-internal",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "0.13.0",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-common": "1.11.0",
-    "launchdarkly-cpp-networking": "0.2.0"
+    "@launchdarkly/cpp-common": "1.11.0",
+    "@launchdarkly/cpp-networking": "0.2.0"
   }
 }

--- a/libs/networking/package.json
+++ b/libs/networking/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "launchdarkly-cpp-networking",
+  "name": "@launchdarkly/cpp-networking",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "0.2.0",
   "private": true

--- a/libs/server-sdk-otel/package.json
+++ b/libs/server-sdk-otel/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "launchdarkly-cpp-server-otel",
+  "name": "@launchdarkly/cpp-server-otel",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "0.1.1",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-server": "3.10.1"
+    "@launchdarkly/cpp-server": "3.10.1"
   }
 }

--- a/libs/server-sdk-redis-source/package.json
+++ b/libs/server-sdk-redis-source/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "launchdarkly-cpp-server-redis-source",
+  "name": "@launchdarkly/cpp-server-redis-source",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "2.2.2",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-server": "3.10.1"
+    "@launchdarkly/cpp-server": "3.10.1"
   }
 }

--- a/libs/server-sdk/package.json
+++ b/libs/server-sdk/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "launchdarkly-cpp-server",
+  "name": "@launchdarkly/cpp-server",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "version": "3.10.1",
   "private": true,
   "dependencies": {
-    "launchdarkly-cpp-internal": "0.13.0",
-    "launchdarkly-cpp-common": "1.11.0",
-    "launchdarkly-cpp-sse-client": "0.6.1"
+    "@launchdarkly/cpp-internal": "0.13.0",
+    "@launchdarkly/cpp-common": "1.11.0",
+    "@launchdarkly/cpp-sse-client": "0.6.1"
   }
 }

--- a/libs/server-sent-events/package.json
+++ b/libs/server-sent-events/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "launchdarkly-cpp-sse-client",
+  "name": "@launchdarkly/cpp-sse-client",
   "description": "This package.json exists for modeling dependencies for the release process.",
   "private": true,
   "version": "0.6.1",
   "dependencies": {
-    "launchdarkly-cpp-networking": "0.2.0"
+    "@launchdarkly/cpp-networking": "0.2.0"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   ],
   "packages": {
     "libs/client-sdk": {
+      "component": "launchdarkly-cpp-client",
       "extra-files": [
         "include/launchdarkly/client_side/client.hpp",
         "tests/client_c_bindings_test.cpp",
@@ -12,6 +13,7 @@
       ]
     },
     "libs/server-sdk": {
+      "component": "launchdarkly-cpp-server",
       "extra-files": [
         "include/launchdarkly/server_side/client.hpp",
         "tests/server_c_bindings_test.cpp",
@@ -20,19 +22,29 @@
       ]
     },
     "libs/server-sdk-redis-source": {
+      "component": "launchdarkly-cpp-server-redis-source",
       "extra-files": [
         "CMakeLists.txt"
       ]
     },
     "libs/server-sdk-otel": {
+      "component": "launchdarkly-cpp-server-otel",
       "bump-minor-pre-major": true,
       "extra-files": [
         "CMakeLists.txt"
       ]
     },
-    "libs/server-sent-events": {},
-    "libs/common": {},
-    "libs/internal": {},
-    "libs/networking": {}
+    "libs/server-sent-events": {
+      "component": "launchdarkly-cpp-sse-client"
+    },
+    "libs/common": {
+      "component": "launchdarkly-cpp-common"
+    },
+    "libs/internal": {
+      "component": "launchdarkly-cpp-internal"
+    },
+    "libs/networking": {
+      "component": "launchdarkly-cpp-networking"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Updates all 8 `package.json` files to use `@launchdarkly/`-scoped package names (e.g. `@launchdarkly/cpp-client` instead of `launchdarkly-cpp-client`). These `package.json` files are not published npm packages — they exist solely to model the inter-package dependency graph for release-please's `node-workspace` plugin.

To prevent the name change from altering git tag format (release-please strips the `@scope/` prefix by default, which would change tags from `launchdarkly-cpp-client-v3.11.1` to `cpp-client-v3.11.1`), explicit `"component"` overrides have been added to each package in `release-please-config.json`. This preserves the existing `launchdarkly-cpp-*-v<version>` tag format.

No changes to versions, dependency graph structure, CMake targets, build scripts, CI workflows, or workflow outputs.

## Review & Testing Checklist for Human

- [ ] **Verify `component` + `node-workspace` interaction**: Confirm that release-please respects the `"component"` field when the `node-workspace` plugin is active with scoped package names. This cannot be tested locally — it only runs on push to `main`. Consider doing a dry run or checking release-please source/docs for confirmation.
- [ ] **Verify dependency graph is fully updated**: Every `dependencies` reference across all 8 `package.json` files should use the new `@launchdarkly/` prefix. A stale reference would break the `node-workspace` plugin's graph resolution.
- [ ] **Spot-check component values match old names**: Each `"component"` value in `release-please-config.json` should exactly match the previous `"name"` from the corresponding `package.json` (e.g. `libs/server-sent-events` had name `launchdarkly-cpp-sse-client`, and the component is `launchdarkly-cpp-sse-client`).

### Notes
- The `js-core` repo already uses `@launchdarkly/`-scoped names with the `node-workspace` plugin successfully, which gives some confidence this pattern works. However, `js-core` does not use explicit `component` overrides — its tags use the stripped names (e.g. `js-client-sdk-v4.4.1`). So the combination of scoped names + component overrides in `node-workspace` is the novel part here.
- Recommended test plan: After merge, monitor the next release-please PR to confirm it generates correct tag names and updates dependency versions as expected.

Link to Devin session: https://app.devin.ai/sessions/37efb8037fa940deb4938b906a1a42ad
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates release-please/node-workspace metadata (package names and dependency references) without touching runtime code. Main risk is misconfiguration causing incorrect tag naming or dependency graph resolution in the release process.
> 
> **Overview**
> Updates the workspace `package.json` metadata to use `@launchdarkly/`-scoped names and updates all inter-package `dependencies` to reference the scoped packages.
> 
> Adjusts `release-please-config.json` to add explicit `component` values for each package so release-please continues generating the existing `launchdarkly-cpp-*-v<version>` tag/component names despite the new scoped package names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db44f100bb0465dc52f8440bdc4fe7b87e136bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->