### PR TITLE
refactor: add internal Promise/Future classes for future use

### DIFF
--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -13,6 +13,14 @@ namespace launchdarkly::async {
 // requires all captured variables to be copy-constructible, which prevents
 // storing lambdas that capture move-only types.
 //
+// Continuation is used to represent units of work passed to executors. An
+// executor is a callable with signature void(Continuation<void()>) that
+// schedules the work to run somewhere — for example, on an ASIO io_context:
+//
+//   auto executor = [&ioc](Continuation<void()> work) {
+//       boost::asio::post(ioc, std::move(work));
+//   };
+//
 // The primary template is declared but not defined; only the partial
 // specialization below (which splits Sig into R and Args...) is usable.
 // This lets callers write Continuation<void()> instead of Continuation<void>.
@@ -39,6 +47,8 @@ class Continuation<R(Args...)> {
     std::unique_ptr<Base> impl_;
 
    public:
+    // Constructs a Continuation from any callable F. F may be a lambda,
+    // function pointer, or other callable; it need not be copy-constructible.
     // F&& is a forwarding reference: accepts any callable by move or copy,
     // then moves it into Impl<F> so Continuation itself owns the callable.
     template <typename F>
@@ -47,6 +57,8 @@ class Continuation<R(Args...)> {
     Continuation(Continuation&&) = default;
     Continuation& operator=(Continuation&&) = default;
 
+    // Invokes the stored callable with the given arguments.
+    // Returns whatever the callable returns.
     R operator()(Args... args) {
         return impl_->call(std::forward<Args>(args)...);
     }
@@ -76,9 +88,17 @@ struct future_value<Future<T>> {
     using type = T;
 };
 
-// TODO: Document why things are what they are.
+// PromiseInternal holds the shared state between a Promise and its associated
+// Futures: the result value, the mutex protecting it, and the list of
+// continuations waiting to run when the result is set.
+//
+// This is an internal class and not intended to be used directly. Promise and
+// Future each hold a shared_ptr<PromiseInternal>, which lets multiple Future
+// copies all refer to the same underlying state, and lets Promise and Future
+// have independent lifetimes while the shared state remains alive as long as
+// either end holds it.
+//
 // TODO: Is it okay that the shared_ptr lets copies mutate the result??
-
 template <typename T>
 class PromiseInternal {
    public:
@@ -87,6 +107,9 @@ class PromiseInternal {
     PromiseInternal(PromiseInternal const&) = delete;
     PromiseInternal(PromiseInternal&&) = delete;
 
+    // Sets the result and schedules all registered continuations via their
+    // executors. Returns true if the result was set, or false if it was already
+    // set by a previous call to Resolve.
     bool Resolve(T result) {
         std::lock_guard lock(mutex_);
         if (result_->has_value()) {
@@ -103,11 +126,14 @@ class PromiseInternal {
         return true;
     }
 
+    // Returns true if Resolve has been called.
     bool IsFinished() const {
         std::lock_guard lock(mutex_);
         return result_->has_value();
     }
 
+    // Returns a reference to the result. The caller must ensure IsFinished()
+    // is true before calling this.
     T const& GetResult() const {
         std::lock_guard lock(mutex_);
         return **result_;
@@ -208,6 +234,21 @@ class PromiseInternal {
         continuations_;
 };
 
+// Promise is the write end of a one-shot async value, similar to std::promise.
+// Create a Promise<T>, hand its Future to a consumer via GetFuture(), then
+// call Resolve() exactly once to deliver the value.
+//
+// Promise is move-only: it cannot be copied, but it can be moved. This
+// prevents accidentally resolving the same promise from two places.
+//
+// Using std::expected<V, E> as T is the recommended way to represent
+// operations that may fail:
+//
+//   Promise<std::expected<int, std::string>> promise;
+//   Future<std::expected<int, std::string>> future = promise.GetFuture();
+//   // ... hand future to a consumer, then later:
+//   promise.Resolve(42);                            // success
+//   promise.Resolve(std::unexpected("timed out"));  // failure
 template <typename T>
 class Promise {
    public:
@@ -216,14 +257,44 @@ class Promise {
     Promise(Promise const&) = delete;
     Promise(Promise&&) = default;
 
+    // Sets the result to the given value and schedules any continuations that
+    // were registered via Future::Then. Returns true if the result was set, or
+    // false if Resolve was already called.
     bool Resolve(T result) { return internal_->Resolve(result); }
 
+    // Returns a Future that will resolve when this Promise is resolved.
+    // May be called multiple times; each call returns a Future referring to
+    // the same underlying state.
     Future<T> GetFuture() { return Future(internal_); }
 
    private:
     std::shared_ptr<PromiseInternal<T>> internal_;
 };
 
+// Future is the read end of a one-shot async value, similar to std::future,
+// but with support for chaining via Then.
+//
+// A Future is obtained from Promise::GetFuture(). Multiple copies of a Future
+// may exist and all refer to the same underlying result. When the associated
+// Promise is resolved, all continuations registered via Then are scheduled.
+//
+// Unlike std::future, Future does not support blocking on the result directly.
+// Instead, use Then to attach work that runs once the value is available.
+//
+// Example using std::expected<V, E> to represent a fallible async operation:
+//
+//   boost::asio::io_context ioc;
+//   auto executor = [&ioc](Continuation<void()> work) {
+//       boost::asio::post(ioc, std::move(work));
+//   };
+//
+//   Future<std::expected<float, std::string>> result = future.Then(
+//       [](std::expected<int, std::string> const& val)
+//               -> std::expected<float, std::string> {
+//           if (!val) return std::unexpected(val.error());
+//           return *val * 1.5f;
+//       },
+//       executor);
 template <typename T>
 class Future {
    public:
@@ -233,11 +304,24 @@ class Future {
     Future(Future const&) = default;
     Future(Future&&) = default;
 
+    // Returns true if the associated Promise has been resolved.
     bool IsFinished() const { return internal_->IsFinished(); }
 
+    // Returns a reference to the result. The caller must ensure IsFinished()
+    // is true before calling this. The reference is valid for the lifetime of
+    // the Future (or any copy of it).
     T const& GetResult() const { return internal_->GetResult(); }
 
-    // Then where the continuation returns R directly, yielding Future<R>.
+    // Registers a continuation to run when this Future resolves, returning a
+    // new Future<R> that resolves to the continuation's return value.
+    //
+    // Parameters:
+    //   continuation - Called with the resolved T const& when this Future
+    //                  resolves. Must return a value of type R (not a Future).
+    //   executor     - Called with the work to schedule when this Future
+    //                  resolves. Controls where and when the continuation runs.
+    //
+    // Returns a Future<R> that resolves to whatever the continuation returns.
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,
@@ -249,8 +333,25 @@ class Future {
                                std::move(executor));
     }
 
-    // Then where the continuation returns Future<T2> (i.e. R = Future<T2>),
-    // yielding a flattened Future<T2> that resolves when the inner future does.
+    // Registers a continuation to run when this Future resolves, where the
+    // continuation itself returns a Future<T2>. Returns a flattened Future<T2>
+    // that resolves when the inner future does, avoiding Future<Future<T2>>.
+    // Use this overload to chain async operations that themselves return a
+    // Future, avoiding a nested Future<Future<T2>>:
+    //
+    //   Future<std::expected<Data, Err>> result = future.Then(
+    //       [](std::expected<Key, Err> const& key) {
+    //           return fetch(key);  // fetch returns Future<expected<Data, Err>>
+    //       },
+    //       executor);
+    //
+    // Parameters:
+    //   continuation - Called with the resolved T const& when this Future
+    //                  resolves. Must return a Future<T2>.
+    //   executor     - Called with the work to schedule when this Future
+    //                  resolves, and again when the inner Future resolves.
+    //
+    // Returns a Future<T2> that resolves when the inner Future<T2> resolves.
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -114,22 +114,29 @@ class PromiseInternal {
     // executors. Returns true if the result was set, or false if it was already
     // set by a previous call to Resolve.
     bool Resolve(T result) {
-        std::lock_guard lock(mutex_);
-        if (result_->has_value()) {
-            return false;
+        std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
+            to_call;
+        {
+            std::lock_guard lock(mutex_);
+            if (result_->has_value()) {
+                return false;
+            }
+
+            // Move result into storage if possible; otherwise copy.
+            if constexpr (std::is_move_assignable_v<T>) {
+                *result_ = std::move(result);
+            } else {
+                *result_ = result;
+            }
+
+            to_call = std::move(continuations_);
         }
 
-        // Move result into storage if possible; otherwise copy.
-        if constexpr (std::is_move_assignable_v<T>) {
-            *result_ = std::move(result);
-        } else {
-            *result_ = result;
-        }
-
-        for (auto& continuation : continuations_) {
+        // Call continuations outside the lock so that continuations which
+        // re-enter this future (e.g. via GetResult or Then) don't deadlock.
+        for (auto& continuation : to_call) {
             continuation(result_);
         }
-        continuations_.clear();
 
         return true;
     }
@@ -157,32 +164,39 @@ class PromiseInternal {
     Future<R> Then(F&& continuation,
                    std::function<void(Continuation<void()>)> executor) {
         Promise<R> newPromise;
-        std::lock_guard lock(mutex_);
-
         Future<R> newFuture = newPromise.GetFuture();
 
-        if (result_->has_value()) {
-            executor(Continuation<void()>(
-                [newPromise = std::move(newPromise),
-                 continuation = std::move(continuation),
-                 result = result_]() mutable {
-                    newPromise.Resolve(continuation(**result));
-                }));
-            return newFuture;
-        }
+        std::shared_ptr<std::optional<T>> already_resolved;
+        {
+            std::lock_guard lock(mutex_);
 
-        continuations_.push_back(
-            [newPromise = std::move(newPromise),
-             continuation = std::move(continuation),
-             executor](std::shared_ptr<std::optional<T>> result) mutable {
-                executor(Continuation<void()>(
+            if (result_->has_value()) {
+                already_resolved = result_;
+            } else {
+                continuations_.push_back(
                     [newPromise = std::move(newPromise),
                      continuation = std::move(continuation),
-                     result]() mutable {
-                        newPromise.Resolve(continuation(**result));
-                    }));
-            });
+                     executor](
+                        std::shared_ptr<std::optional<T>> result) mutable {
+                        executor(Continuation<void()>(
+                            [newPromise = std::move(newPromise),
+                             continuation = std::move(continuation),
+                             result]() mutable {
+                                newPromise.Resolve(continuation(**result));
+                            }));
+                    });
+                return newFuture;
+            }
+        }
 
+        // Already resolved: call executor outside the lock so that
+        // continuations which re-enter this future don't deadlock.
+        executor(Continuation<void()>(
+            [newPromise = std::move(newPromise),
+             continuation = std::move(continuation),
+             result = already_resolved]() mutable {
+                newPromise.Resolve(continuation(**result));
+            }));
         return newFuture;
     }
 
@@ -198,8 +212,6 @@ class PromiseInternal {
     Future<T2> Then(F&& continuation,
                     std::function<void(Continuation<void()>)> executor) {
         Promise<T2> outerPromise;
-        std::lock_guard lock(mutex_);
-
         Future<T2> outerFuture = outerPromise.GetFuture();
 
         auto do_work = [outerPromise = std::move(outerPromise),
@@ -215,23 +227,29 @@ class PromiseInternal {
                 executor);
         };
 
-        if (result_->has_value()) {
-            executor(Continuation<void()>(
-                [do_work = std::move(do_work), result = result_]() mutable {
-                    do_work(**result);
-                }));
-            return outerFuture;
+        std::shared_ptr<std::optional<T>> already_resolved;
+        {
+            std::lock_guard lock(mutex_);
+            if (result_->has_value()) {
+                already_resolved = result_;
+            } else {
+                continuations_.push_back(
+                    [do_work = std::move(do_work),
+                     executor](std::shared_ptr<std::optional<T>> result) mutable {
+                        executor(Continuation<void()>(
+                            [do_work = std::move(do_work), result]() mutable {
+                                do_work(**result);
+                            }));
+                    });
+                return outerFuture;
+            }
         }
 
-        continuations_.push_back(
+        // Already resolved: call executor outside the lock so that
+        // continuations which re-enter this future don't deadlock.
+        executor(Continuation<void()>(
             [do_work = std::move(do_work),
-             executor](std::shared_ptr<std::optional<T>> result) mutable {
-                executor(Continuation<void()>(
-                    [do_work = std::move(do_work), result]() mutable {
-                        do_work(**result);
-                    }));
-            });
-
+             result = already_resolved]() mutable { do_work(**result); }));
         return outerFuture;
     }
 

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -12,11 +12,18 @@ namespace launchdarkly::async {
 // for C++23's std::move_only_function. It exists because C++17's std::function
 // requires all captured variables to be copy-constructible, which prevents
 // storing lambdas that capture move-only types.
+//
+// The primary template is declared but not defined; only the partial
+// specialization below (which splits Sig into R and Args...) is usable.
+// This lets callers write Continuation<void()> instead of Continuation<void>.
 template <typename Sig>
 class Continuation;
 
 template <typename R, typename... Args>
 class Continuation<R(Args...)> {
+    // Base and Impl form a classic type-erasure pair. Base is a non-template
+    // abstract interface stored via unique_ptr, giving a stable type regardless
+    // of F. Impl<F> is the concrete template subclass that holds and calls F.
     struct Base {
         virtual R call(Args...) = 0;
         virtual ~Base() = default;
@@ -32,6 +39,8 @@ class Continuation<R(Args...)> {
     std::unique_ptr<Base> impl_;
 
    public:
+    // F&& is a forwarding reference: accepts any callable by move or copy,
+    // then moves it into Impl<F> so Continuation itself owns the callable.
     template <typename F>
     Continuation(F&& f)
         : impl_(std::make_unique<Impl<F>>(std::forward<F>(f))) {}
@@ -48,6 +57,24 @@ class Promise;
 
 template <typename T>
 class Future;
+
+// Type trait to detect whether a type is a Future<T>. The primary template
+// defaults to false; the partial specialization matches Future<T> specifically.
+template <typename T>
+struct is_future : std::false_type {};
+
+template <typename T>
+struct is_future<Future<T>> : std::true_type {};
+
+// Type trait to extract T from Future<T>. Only the partial specialization is
+// defined, so using future_value on a non-Future type is a compile error.
+template <typename T>
+struct future_value;
+
+template <typename T>
+struct future_value<Future<T>> {
+    using type = T;
+};
 
 // TODO: Document why things are what they are.
 // TODO: Is it okay that the shared_ptr lets copies mutate the result??
@@ -86,13 +113,18 @@ class PromiseInternal {
         return **result_;
     }
 
-    template <typename F, typename T2 = std::invoke_result_t<F, T const&>>
-    Future<T2> Then(F&& continuation,
-                    std::function<void(Continuation<void()>)> executor) {
-        Promise<T2> newPromise;
+    // Then where the continuation returns R directly, yielding Future<R>.
+    template <typename F,
+              // Deduce R from what F returns when called with T const&.
+              typename R = std::invoke_result_t<F, T const&>,
+              // Disable when R is a Future so the flattening overload wins instead.
+              typename = std::enable_if_t<!is_future<R>::value>>
+    Future<R> Then(F&& continuation,
+                   std::function<void(Continuation<void()>)> executor) {
+        Promise<R> newPromise;
         std::lock_guard lock(mutex_);
 
-        Future<T2> newFuture = newPromise.GetFuture();
+        Future<R> newFuture = newPromise.GetFuture();
 
         if (result_->has_value()) {
             executor(Continuation<void()>(
@@ -110,12 +142,62 @@ class PromiseInternal {
              executor](std::shared_ptr<std::optional<T>> result) mutable {
                 executor(Continuation<void()>(
                     [newPromise = std::move(newPromise),
-                     continuation = std::move(continuation), result]() mutable {
+                     continuation = std::move(continuation),
+                     result]() mutable {
                         newPromise.Resolve(continuation(**result));
                     }));
             });
 
         return newFuture;
+    }
+
+    // Then where the continuation returns Future<T2> (i.e. R = Future<T2>),
+    // yielding a flattened Future<T2> that resolves when the inner future does.
+    template <typename F,
+              // Deduce R from what F returns when called with T const&.
+              typename R = std::invoke_result_t<F, T const&>,
+              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not Future<Future<T2>>.
+              typename T2 = typename future_value<R>::type,
+              // Only enabled when R is a Future; otherwise the direct overload wins.
+              typename = std::enable_if_t<is_future<R>::value>>
+    Future<T2> Then(F&& continuation,
+                    std::function<void(Continuation<void()>)> executor) {
+        Promise<T2> outerPromise;
+        std::lock_guard lock(mutex_);
+
+        Future<T2> outerFuture = outerPromise.GetFuture();
+
+        auto do_work = [outerPromise = std::move(outerPromise),
+                        continuation = std::move(continuation),
+                        executor](T const& val) mutable {
+            Future<T2> innerFuture = continuation(val);
+            innerFuture.Then(
+                [outerPromise = std::move(outerPromise)](
+                    T2 const& inner_val) mutable -> T2 {
+                    outerPromise.Resolve(inner_val);
+                    return inner_val;
+                },
+                executor);
+        };
+
+        if (result_->has_value()) {
+            executor(Continuation<void()>(
+                [do_work = std::move(do_work), result = result_]() mutable {
+                    do_work(**result);
+                }));
+            return outerFuture;
+        }
+
+        continuations_.push_back(
+            [do_work = std::move(do_work),
+             executor](std::shared_ptr<std::optional<T>> result) mutable {
+                executor(Continuation<void()>(
+                    [do_work = std::move(do_work), result]() mutable {
+                        do_work(**result);
+                    }));
+            });
+
+        return outerFuture;
     }
 
    private:
@@ -155,7 +237,27 @@ class Future {
 
     T const& GetResult() const { return internal_->GetResult(); }
 
-    template <typename F, typename T2 = std::invoke_result_t<F, T const&>>
+    // Then where the continuation returns R directly, yielding Future<R>.
+    template <typename F,
+              // Deduce R from what F returns when called with T const&.
+              typename R = std::invoke_result_t<F, T const&>,
+              // Disable when R is a Future so the flattening overload wins instead.
+              typename = std::enable_if_t<!is_future<R>::value>>
+    Future<R> Then(F&& continuation,
+                   std::function<void(Continuation<void()>)> executor) {
+        return internal_->Then(std::forward<F>(continuation),
+                               std::move(executor));
+    }
+
+    // Then where the continuation returns Future<T2> (i.e. R = Future<T2>),
+    // yielding a flattened Future<T2> that resolves when the inner future does.
+    template <typename F,
+              // Deduce R from what F returns when called with T const&.
+              typename R = std::invoke_result_t<F, T const&>,
+              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not Future<Future<T2>>.
+              typename T2 = typename future_value<R>::type,
+              // Only enabled when R is a Future; otherwise the direct overload wins.
+              typename = std::enable_if_t<is_future<R>::value>>
     Future<T2> Then(F&& continuation,
                     std::function<void(Continuation<void()>)> executor) {
         return internal_->Then(std::forward<F>(continuation),

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -161,12 +161,12 @@ class PromiseInternal {
         Promise<R> newPromise;
         Future<R> newFuture = newPromise.GetFuture();
 
-        T already_resolved;
+        std::optional<T> already_resolved;
         {
             std::lock_guard lock(mutex_);
 
             if (result_.has_value()) {
-                already_resolved = *result_;
+                already_resolved = result_;
             } else {
                 continuations_.push_back(
                     [newPromise = std::move(newPromise),
@@ -189,7 +189,7 @@ class PromiseInternal {
             [newPromise = std::move(newPromise),
              continuation = std::move(continuation),
              result = std::move(already_resolved)]() mutable {
-                newPromise.Resolve(continuation(result));
+                newPromise.Resolve(continuation(*result));
             }));
         return newFuture;
     }
@@ -216,18 +216,18 @@ class PromiseInternal {
             Future<T2> innerFuture = continuation(val);
             innerFuture.Then(
                 [outerPromise = std::move(outerPromise)](
-                    T2 const& inner_val) mutable -> T2 {
+                    T2 const& inner_val) mutable -> std::monostate {
                     outerPromise.Resolve(inner_val);
-                    return inner_val;
+                    return {};
                 },
                 executor);
         };
 
-        T already_resolved;
+        std::optional<T> already_resolved;
         {
             std::lock_guard lock(mutex_);
             if (result_.has_value()) {
-                already_resolved = *result_;
+                already_resolved = result_;
             } else {
                 continuations_.push_back([do_work = std::move(do_work),
                                           executor](T const& result) mutable {
@@ -245,14 +245,14 @@ class PromiseInternal {
         executor(Continuation<void()>(
             [do_work = std::move(do_work),
              result = std::move(already_resolved)]() mutable {
-                do_work(result);
+                do_work(*result);
             }));
         return outerFuture;
     }
 
    private:
     mutable std::mutex mutex_;
-    std::optional<T> result_{std::nullopt};
+    std::optional<T> result_{};
     std::vector<Continuation<void(T const&)>> continuations_;
 };
 
@@ -284,7 +284,13 @@ class Promise {
     // Sets the result to the given value and schedules any continuations that
     // were registered via Future::Then. Returns true if the result was set, or
     // false if Resolve was already called.
-    bool Resolve(T result) { return internal_->Resolve(result); }
+    bool Resolve(T result) {
+        if constexpr (std::is_move_constructible_v<T>) {
+            return internal_->Resolve(std::move(result));
+        } else {
+            return internal_->Resolve(result);
+        }
+    }
 
     // Returns a Future that will resolve when this Promise is resolved.
     // May be called multiple times; each call returns a Future referring to

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -283,7 +283,9 @@ class Promise {
     Promise() : internal_(new PromiseInternal<T>()) {}
     ~Promise() = default;
     Promise(Promise const&) = delete;
+    Promise& operator=(Promise const&) = delete;
     Promise(Promise&&) = default;
+    Promise& operator=(Promise&&) = default;
 
     // Sets the result to the given value and schedules any continuations that
     // were registered via Future::Then. Returns true if the result was set, or
@@ -336,7 +338,9 @@ class Future {
         : internal_(internal) {}
     ~Future() = default;
     Future(Future const&) = default;
+    Future& operator=(Future const&) = default;
     Future(Future&&) = default;
+    Future& operator=(Future&&) = default;
 
     // Returns true if the associated Promise has been resolved.
     bool IsFinished() const { return internal_->IsFinished(); }

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -150,9 +150,17 @@ class PromiseInternal {
     // Returns a const reference to the optional result. The optional contains
     // a value if resolved, or is empty if not yet resolved. The reference is
     // valid for the lifetime of any Future referring to this PromiseInternal.
+    //
+    // Thread-safety: if the future is already resolved, the reference points
+    // to write-once storage and is safe to read without holding the lock. If
+    // the future is not yet resolved, the reference points to empty_, a const
+    // member that is never written, so it is equally safe.
     std::optional<T> const& GetResult() const {
         std::lock_guard lock(mutex_);
-        return *result_;
+        if (result_->has_value()) {
+            return *result_;
+        }
+        return empty_;
     }
 
     // Then where the continuation returns R directly, yielding Future<R>.
@@ -260,6 +268,7 @@ class PromiseInternal {
         new std::optional<T>(std::nullopt)};
     std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
         continuations_;
+    std::optional<T> const empty_{};
 };
 
 // Promise is the write end of a one-shot async value, similar to std::promise.

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -276,7 +276,7 @@ class PromiseInternal {
 template <typename T>
 class Promise {
    public:
-    Promise() : internal_(new PromiseInternal<T>()) {}
+    Promise() : internal_(std::make_shared<PromiseInternal<T>>()) {}
     ~Promise() = default;
     Promise(Promise const&) = delete;
     Promise& operator=(Promise const&) = delete;
@@ -497,8 +497,8 @@ Future<std::monostate> WhenAll(Future<Ts>... futures) {
 //   Future<std::string> f1 = ...;
 //   WhenAny(f0, f1).Then(
 //       [&](std::size_t const& index) {
-//           if (index == 0) use(*f0.GetResult());
-//           else            use(*f1.GetResult());
+//           if (index == 0) use(f0.GetResult().value());
+//           else            use(f1.GetResult().value());
 //           return std::monostate{};
 //       },
 //       executor);

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace launchdarkly::async {
+
+// Continuation is a move-only type-erased callable, effectively a polyfill
+// for C++23's std::move_only_function. It exists because C++17's std::function
+// requires all captured variables to be copy-constructible, which prevents
+// storing lambdas that capture move-only types.
+template <typename Sig>
+class Continuation;
+
+template <typename R, typename... Args>
+class Continuation<R(Args...)> {
+    struct Base {
+        virtual R call(Args...) = 0;
+        virtual ~Base() = default;
+    };
+
+    template <typename F>
+    struct Impl : Base {
+        F f;
+        Impl(F&& f) : f(std::move(f)) {}
+        R call(Args... args) override { return f(std::forward<Args>(args)...); }
+    };
+
+    std::unique_ptr<Base> impl_;
+
+   public:
+    template <typename F>
+    Continuation(F&& f)
+        : impl_(std::make_unique<Impl<F>>(std::forward<F>(f))) {}
+    Continuation(Continuation&&) = default;
+    Continuation& operator=(Continuation&&) = default;
+
+    R operator()(Args... args) {
+        return impl_->call(std::forward<Args>(args)...);
+    }
+};
+
+template <typename T>
+class Promise;
+
+template <typename T>
+class Future;
+
+// TODO: Document why things are what they are.
+// TODO: Is it okay that the shared_ptr lets copies mutate the result??
+
+template <typename T>
+class PromiseInternal {
+   public:
+    PromiseInternal() = default;
+    ~PromiseInternal() = default;
+    PromiseInternal(PromiseInternal const&) = delete;
+    PromiseInternal(PromiseInternal&&) = delete;
+
+    bool Resolve(T result) {
+        std::lock_guard lock(mutex_);
+        if (result_->has_value()) {
+            return false;
+        }
+
+        *result_ = result;
+
+        for (auto& continuation : continuations_) {
+            continuation(result_);
+        }
+        continuations_.clear();
+
+        return true;
+    }
+
+    bool IsFinished() const {
+        std::lock_guard lock(mutex_);
+        return result_->has_value();
+    }
+
+    T const& GetResult() const {
+        std::lock_guard lock(mutex_);
+        return **result_;
+    }
+
+    template <typename F, typename T2 = std::invoke_result_t<F, T const&>>
+    Future<T2> Then(F&& continuation,
+                    std::function<void(Continuation<void()>)> executor) {
+        Promise<T2> newPromise;
+        std::lock_guard lock(mutex_);
+
+        Future<T2> newFuture = newPromise.GetFuture();
+
+        if (result_->has_value()) {
+            executor(Continuation<void()>(
+                [newPromise = std::move(newPromise),
+                 continuation = std::move(continuation),
+                 result = result_]() mutable {
+                    newPromise.Resolve(continuation(**result));
+                }));
+            return newFuture;
+        }
+
+        continuations_.push_back(
+            [newPromise = std::move(newPromise),
+             continuation = std::move(continuation),
+             executor](std::shared_ptr<std::optional<T>> result) mutable {
+                executor(Continuation<void()>(
+                    [newPromise = std::move(newPromise),
+                     continuation = std::move(continuation), result]() mutable {
+                        newPromise.Resolve(continuation(**result));
+                    }));
+            });
+
+        return newFuture;
+    }
+
+   private:
+    std::mutex mutex_;
+    std::shared_ptr<std::optional<T>> result_{
+        new std::optional<T>(std::nullopt)};
+    std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
+        continuations_;
+};
+
+template <typename T>
+class Promise {
+   public:
+    Promise() : internal_(new PromiseInternal<T>()) {}
+    ~Promise() = default;
+    Promise(Promise const&) = delete;
+    Promise(Promise&&) = default;
+
+    bool Resolve(T result) { return internal_->Resolve(result); }
+
+    Future<T> GetFuture() { return Future(internal_); }
+
+   private:
+    std::shared_ptr<PromiseInternal<T>> internal_;
+};
+
+template <typename T>
+class Future {
+   public:
+    Future(std::shared_ptr<PromiseInternal<T>> internal)
+        : internal_(internal) {}
+    ~Future() = default;
+    Future(Future const&) = default;
+    Future(Future&&) = default;
+
+    bool IsFinished() const { return internal_->IsFinished(); }
+
+    T const& GetResult() const { return internal_->GetResult(); }
+
+    template <typename F, typename T2 = std::invoke_result_t<F, T const&>>
+    Future<T2> Then(F&& continuation,
+                    std::function<void(Continuation<void()>)> executor) {
+        return internal_->Then(std::forward<F>(continuation),
+                               std::move(executor));
+    }
+
+   private:
+    std::shared_ptr<PromiseInternal<T>> internal_;
+};
+
+}  // namespace launchdarkly::async

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -62,7 +62,7 @@ class Continuation<R(Args...)> {
 
     // Invokes the stored callable with the given arguments.
     // Returns whatever the callable returns.
-    R operator()(Args... args) {
+    R operator()(Args... args) const {
         return impl_->call(std::forward<Args>(args)...);
     }
 };
@@ -106,7 +106,9 @@ class PromiseInternal {
     PromiseInternal() = default;
     ~PromiseInternal() = default;
     PromiseInternal(PromiseInternal const&) = delete;
+    PromiseInternal& operator=(PromiseInternal const&) = delete;
     PromiseInternal(PromiseInternal&&) = delete;
+    PromiseInternal& operator=(PromiseInternal&&) = delete;
 
     // Sets the result and schedules all registered continuations via their
     // executors. Returns true if the result was set, or false if it was already
@@ -329,7 +331,7 @@ template <typename T>
 class Future {
    public:
     Future(std::shared_ptr<PromiseInternal<T>> internal)
-        : internal_(internal) {}
+        : internal_(std::move(internal)) {}
     ~Future() = default;
     Future(Future const&) = default;
     Future& operator=(Future const&) = default;
@@ -448,7 +450,7 @@ class Future {
 //   WhenAll(f1, f2).Then(
 //       [&](std::monostate const&) {
 //           // f1 and f2 are both finished here.
-//           use(*f1.GetResult(), *f2.GetResult());
+//           use(f1.GetResult().value(), f2.GetResult().value());
 //           return std::monostate{};
 //       },
 //       executor);

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -122,7 +122,7 @@ class PromiseInternal {
             }
 
             // Move result into storage if possible; otherwise copy.
-            if constexpr (std::is_move_assignable_v<T>) {
+            if constexpr (std::is_move_constructible_v<T>) {
                 result_ = std::move(result);
             } else {
                 result_ = result;

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -159,7 +159,8 @@ class PromiseInternal {
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,
-              // Disable when R is a Future so the flattening overload wins instead.
+              // Disable when R is a Future so the flattening overload wins
+              // instead.
               typename = std::enable_if_t<!is_future<R>::value>>
     Future<R> Then(F&& continuation,
                    std::function<void(Continuation<void()>)> executor) {
@@ -175,8 +176,7 @@ class PromiseInternal {
             } else {
                 continuations_.push_back(
                     [newPromise = std::move(newPromise),
-                     continuation = std::move(continuation),
-                     executor](
+                     continuation = std::move(continuation), executor](
                         std::shared_ptr<std::optional<T>> result) mutable {
                         executor(Continuation<void()>(
                             [newPromise = std::move(newPromise),
@@ -191,12 +191,11 @@ class PromiseInternal {
 
         // Already resolved: call executor outside the lock so that
         // continuations which re-enter this future don't deadlock.
-        executor(Continuation<void()>(
-            [newPromise = std::move(newPromise),
-             continuation = std::move(continuation),
-             result = already_resolved]() mutable {
-                newPromise.Resolve(continuation(**result));
-            }));
+        executor(Continuation<void()>([newPromise = std::move(newPromise),
+                                       continuation = std::move(continuation),
+                                       result = already_resolved]() mutable {
+            newPromise.Resolve(continuation(**result));
+        }));
         return newFuture;
     }
 
@@ -205,9 +204,11 @@ class PromiseInternal {
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,
-              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not Future<Future<T2>>.
+              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not
+              // Future<Future<T2>>.
               typename T2 = typename future_value<R>::type,
-              // Only enabled when R is a Future; otherwise the direct overload wins.
+              // Only enabled when R is a Future; otherwise the direct overload
+              // wins.
               typename = std::enable_if_t<is_future<R>::value>>
     Future<T2> Then(F&& continuation,
                     std::function<void(Continuation<void()>)> executor) {
@@ -234,8 +235,8 @@ class PromiseInternal {
                 already_resolved = result_;
             } else {
                 continuations_.push_back(
-                    [do_work = std::move(do_work),
-                     executor](std::shared_ptr<std::optional<T>> result) mutable {
+                    [do_work = std::move(do_work), executor](
+                        std::shared_ptr<std::optional<T>> result) mutable {
                         executor(Continuation<void()>(
                             [do_work = std::move(do_work), result]() mutable {
                                 do_work(**result);
@@ -363,16 +364,15 @@ class Future {
         // The continuation ignores T entirely (returning a dummy int) so that
         // T is not required to be copyable. The executor signals the cv when
         // called, since being called means the original future has resolved.
-        Then(
-            [](T const&) { return 0; },
-            [state](Continuation<void()> work) {
-                {
-                    std::lock_guard<std::mutex> lock(state->mutex);
-                    state->ready = true;
-                }
-                state->cv.notify_one();
-                work();
-            });
+        Then([](T const&) { return 0; },
+             [state](Continuation<void()> work) {
+                 {
+                     std::lock_guard<std::mutex> lock(state->mutex);
+                     state->ready = true;
+                 }
+                 state->cv.notify_one();
+                 work();
+             });
 
         std::unique_lock<std::mutex> lock(state->mutex);
         state->cv.wait_for(lock, timeout, [&state] { return state->ready; });
@@ -393,7 +393,8 @@ class Future {
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,
-              // Disable when R is a Future so the flattening overload wins instead.
+              // Disable when R is a Future so the flattening overload wins
+              // instead.
               typename = std::enable_if_t<!is_future<R>::value>>
     Future<R> Then(F&& continuation,
                    std::function<void(Continuation<void()>)> executor) {
@@ -409,7 +410,8 @@ class Future {
     //
     //   Future<tl::expected<Data, Err>> result = future.Then(
     //       [](tl::expected<Key, Err> const& key) {
-    //           return fetch(key);  // fetch returns Future<expected<Data, Err>>
+    //           return fetch(key);  // fetch returns Future<expected<Data,
+    //           Err>>
     //       },
     //       executor);
     //
@@ -423,9 +425,11 @@ class Future {
     template <typename F,
               // Deduce R from what F returns when called with T const&.
               typename R = std::invoke_result_t<F, T const&>,
-              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not Future<Future<T2>>.
+              // Unwrap Future<T2> -> T2 so the return type is Future<T2>, not
+              // Future<Future<T2>>.
               typename T2 = typename future_value<R>::type,
-              // Only enabled when R is a Future; otherwise the direct overload wins.
+              // Only enabled when R is a Future; otherwise the direct overload
+              // wins.
               typename = std::enable_if_t<is_future<R>::value>>
     Future<T2> Then(F&& continuation,
                     std::function<void(Continuation<void()>)> executor) {

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -133,6 +133,8 @@ class PromiseInternal {
         // Call continuations outside the lock so that continuations which
         // re-enter this future (e.g. via GetResult or Then) don't deadlock.
         for (auto& continuation : to_call) {
+            // It's safe to access result_ outside the lock here, because it
+            // can't be changed again.
             continuation(*result_);
         }
 
@@ -355,10 +357,10 @@ class Future {
         };
         auto state = std::make_shared<State>();
 
-        // The continuation ignores T entirely (returning a dummy int). The
-        // executor signals the cv when called, since being called means the
-        // original future has resolved.
-        Then([](T const&) { return 0; },
+        // The continuation ignores T entirely. The executor signals the cv
+        // when called, since being called means the original future has
+        // resolved.
+        Then([](T const&) { return std::monostate{}; },
              [state](Continuation<void()> work) {
                  {
                      std::lock_guard<std::mutex> lock(state->mutex);

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -100,8 +100,6 @@ struct future_value<Future<T>> {
 // copies all refer to the same underlying state, and lets Promise and Future
 // have independent lifetimes while the shared state remains alive as long as
 // either end holds it.
-//
-// TODO: Is it okay that the shared_ptr lets copies mutate the result??
 template <typename T>
 class PromiseInternal {
    public:
@@ -114,28 +112,26 @@ class PromiseInternal {
     // executors. Returns true if the result was set, or false if it was already
     // set by a previous call to Resolve.
     bool Resolve(T result) {
-        std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
-            to_call;
+        std::vector<Continuation<void(T const&)>> to_call;
         {
             std::lock_guard lock(mutex_);
-            if (result_->has_value()) {
+            if (result_.has_value()) {
                 return false;
             }
 
             // Move result into storage if possible; otherwise copy.
             if constexpr (std::is_move_assignable_v<T>) {
-                *result_ = std::move(result);
+                result_ = std::move(result);
             } else {
-                *result_ = result;
+                result_ = result;
             }
-
             to_call = std::move(continuations_);
         }
 
         // Call continuations outside the lock so that continuations which
         // re-enter this future (e.g. via GetResult or Then) don't deadlock.
         for (auto& continuation : to_call) {
-            continuation(result_);
+            continuation(*result_);
         }
 
         return true;
@@ -144,23 +140,13 @@ class PromiseInternal {
     // Returns true if Resolve has been called.
     bool IsFinished() const {
         std::lock_guard lock(mutex_);
-        return result_->has_value();
+        return result_.has_value();
     }
 
-    // Returns a const reference to the optional result. The optional contains
-    // a value if resolved, or is empty if not yet resolved. The reference is
-    // valid for the lifetime of any Future referring to this PromiseInternal.
-    //
-    // Thread-safety: if the future is already resolved, the reference points
-    // to write-once storage and is safe to read without holding the lock. If
-    // the future is not yet resolved, the reference points to empty_, a const
-    // member that is never written, so it is equally safe.
-    std::optional<T> const& GetResult() const {
+    // Returns a copy of the result, if resolved.
+    std::optional<T> GetResult() const {
         std::lock_guard lock(mutex_);
-        if (result_->has_value()) {
-            return *result_;
-        }
-        return empty_;
+        return result_;
     }
 
     // Then where the continuation returns R directly, yielding Future<R>.
@@ -175,22 +161,22 @@ class PromiseInternal {
         Promise<R> newPromise;
         Future<R> newFuture = newPromise.GetFuture();
 
-        std::shared_ptr<std::optional<T>> already_resolved;
+        T already_resolved;
         {
             std::lock_guard lock(mutex_);
 
-            if (result_->has_value()) {
-                already_resolved = result_;
+            if (result_.has_value()) {
+                already_resolved = *result_;
             } else {
                 continuations_.push_back(
                     [newPromise = std::move(newPromise),
-                     continuation = std::move(continuation), executor](
-                        std::shared_ptr<std::optional<T>> result) mutable {
+                     continuation = std::move(continuation),
+                     executor](T const& result) mutable {
                         executor(Continuation<void()>(
                             [newPromise = std::move(newPromise),
                              continuation = std::move(continuation),
                              result]() mutable {
-                                newPromise.Resolve(continuation(**result));
+                                newPromise.Resolve(continuation(result));
                             }));
                     });
                 return newFuture;
@@ -199,11 +185,12 @@ class PromiseInternal {
 
         // Already resolved: call executor outside the lock so that
         // continuations which re-enter this future don't deadlock.
-        executor(Continuation<void()>([newPromise = std::move(newPromise),
-                                       continuation = std::move(continuation),
-                                       result = already_resolved]() mutable {
-            newPromise.Resolve(continuation(**result));
-        }));
+        executor(Continuation<void()>(
+            [newPromise = std::move(newPromise),
+             continuation = std::move(continuation),
+             result = std::move(already_resolved)]() mutable {
+                newPromise.Resolve(continuation(result));
+            }));
         return newFuture;
     }
 
@@ -236,20 +223,19 @@ class PromiseInternal {
                 executor);
         };
 
-        std::shared_ptr<std::optional<T>> already_resolved;
+        T already_resolved;
         {
             std::lock_guard lock(mutex_);
-            if (result_->has_value()) {
-                already_resolved = result_;
+            if (result_.has_value()) {
+                already_resolved = *result_;
             } else {
-                continuations_.push_back(
-                    [do_work = std::move(do_work), executor](
-                        std::shared_ptr<std::optional<T>> result) mutable {
-                        executor(Continuation<void()>(
-                            [do_work = std::move(do_work), result]() mutable {
-                                do_work(**result);
-                            }));
-                    });
+                continuations_.push_back([do_work = std::move(do_work),
+                                          executor](T const& result) mutable {
+                    executor(Continuation<void()>(
+                        [do_work = std::move(do_work), result]() mutable {
+                            do_work(result);
+                        }));
+                });
                 return outerFuture;
             }
         }
@@ -258,17 +244,16 @@ class PromiseInternal {
         // continuations which re-enter this future don't deadlock.
         executor(Continuation<void()>(
             [do_work = std::move(do_work),
-             result = already_resolved]() mutable { do_work(**result); }));
+             result = std::move(already_resolved)]() mutable {
+                do_work(result);
+            }));
         return outerFuture;
     }
 
    private:
     mutable std::mutex mutex_;
-    std::shared_ptr<std::optional<T>> result_{
-        new std::optional<T>(std::nullopt)};
-    std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
-        continuations_;
-    std::optional<T> const empty_{};
+    std::optional<T> result_{std::nullopt};
+    std::vector<Continuation<void(T const&)>> continuations_;
 };
 
 // Promise is the write end of a one-shot async value, similar to std::promise.
@@ -299,13 +284,7 @@ class Promise {
     // Sets the result to the given value and schedules any continuations that
     // were registered via Future::Then. Returns true if the result was set, or
     // false if Resolve was already called.
-    bool Resolve(T result) {
-        if constexpr (std::is_move_constructible_v<T>) {
-            return internal_->Resolve(std::move(result));
-        } else {
-            return internal_->Resolve(result);
-        }
-    }
+    bool Resolve(T result) { return internal_->Resolve(result); }
 
     // Returns a Future that will resolve when this Promise is resolved.
     // May be called multiple times; each call returns a Future referring to
@@ -354,19 +333,13 @@ class Future {
     // Returns true if the associated Promise has been resolved.
     bool IsFinished() const { return internal_->IsFinished(); }
 
-    // Returns a const reference to the optional result. The optional contains
-    // a value if resolved, or is empty if not yet resolved. The reference is
-    // valid for the lifetime of this Future (or any copy of it).
-    std::optional<T> const& GetResult() const { return internal_->GetResult(); }
+    // Returns a copy of the result, if resolved.
+    std::optional<T> GetResult() const { return internal_->GetResult(); }
 
     // Blocks the calling thread until the future resolves or the timeout
-    // expires. Returns a const reference to the optional result: the optional
-    // contains a value if resolved within the timeout, or is empty if the
-    // timeout expired first. The reference is valid for the lifetime of this
-    // Future (or any copy of it).
+    // expires. Returns a copy of the result, if resolved within the timeout.
     template <typename Rep, typename Period>
-    std::optional<T> const& WaitForResult(
-        std::chrono::duration<Rep, Period> timeout) {
+    std::optional<T> WaitForResult(std::chrono::duration<Rep, Period> timeout) {
         struct State {
             std::mutex mutex;
             std::condition_variable cv;
@@ -374,9 +347,9 @@ class Future {
         };
         auto state = std::make_shared<State>();
 
-        // The continuation ignores T entirely (returning a dummy int) so that
-        // T is not required to be copyable. The executor signals the cv when
-        // called, since being called means the original future has resolved.
+        // The continuation ignores T entirely (returning a dummy int). The
+        // executor signals the cv when called, since being called means the
+        // original future has resolved.
         Then([](T const&) { return 0; },
              [state](Continuation<void()> work) {
                  {

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <functional>
@@ -417,5 +418,96 @@ class Future {
    private:
     std::shared_ptr<PromiseInternal<T>> internal_;
 };
+
+// WhenAll takes a variadic list of Futures (each with potentially different
+// value types) and returns a Future<std::monostate> that resolves once all
+// of the input futures have resolved. The result carries no value; callers
+// who need the individual results can read them from their original futures
+// after WhenAll resolves.
+//
+// If called with no arguments, the returned future is already resolved.
+//
+// Example:
+//
+//   Future<int> f1 = ...;
+//   Future<std::string> f2 = ...;
+//   WhenAll(f1, f2).Then(
+//       [&](std::monostate const&) {
+//           // f1 and f2 are both finished here.
+//           use(*f1.GetResult(), *f2.GetResult());
+//           return std::monostate{};
+//       },
+//       executor);
+template <typename... Ts>
+Future<std::monostate> WhenAll(Future<Ts>... futures) {
+    Promise<std::monostate> promise;
+    Future<std::monostate> result = promise.GetFuture();
+
+    if constexpr (sizeof...(Ts) == 0) {
+        promise.Resolve(std::monostate{});
+        return result;
+    }
+
+    auto shared_promise =
+        std::make_shared<Promise<std::monostate>>(std::move(promise));
+    auto count = std::make_shared<std::atomic<std::size_t>>(sizeof...(Ts));
+
+    auto attach = [&](auto future) {
+        future.Then(
+            [shared_promise, count](auto const&) -> std::monostate {
+                if (count->fetch_sub(1) == 1) {
+                    shared_promise->Resolve(std::monostate{});
+                }
+                return std::monostate{};
+            },
+            [](Continuation<void()> f) { f(); });
+    };
+
+    (attach(futures), ...);
+
+    return result;
+}
+
+// WhenAny takes a variadic list of Futures (each with potentially different
+// value types) and returns a Future<std::size_t> that resolves with the
+// 0-based index of whichever input future resolves first. The caller can use
+// the index to identify the winning future and read its result directly.
+//
+// If called with no arguments, the returned future never resolves.
+//
+// Example:
+//
+//   Future<int> f0 = ...;
+//   Future<std::string> f1 = ...;
+//   WhenAny(f0, f1).Then(
+//       [&](std::size_t const& index) {
+//           if (index == 0) use(*f0.GetResult());
+//           else            use(*f1.GetResult());
+//           return std::monostate{};
+//       },
+//       executor);
+template <typename... Ts>
+Future<std::size_t> WhenAny(Future<Ts>... futures) {
+    Promise<std::size_t> promise;
+    Future<std::size_t> result = promise.GetFuture();
+
+    auto shared_promise =
+        std::make_shared<Promise<std::size_t>>(std::move(promise));
+
+    std::size_t index = 0;
+    auto attach = [&](auto future) {
+        std::size_t i = index++;
+        future.Then(
+            [shared_promise, i](auto const&) -> std::monostate {
+                shared_promise->Resolve(i);
+                return std::monostate{};
+            },
+            [](Continuation<void()> f) { f(); });
+    };
+
+    (attach(futures), ...);
+
+    return result;
+}
 
 }  // namespace launchdarkly::async

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -43,7 +43,7 @@ class Continuation<R(Args...)> {
     template <typename F>
     struct Impl : Base {
         F f;
-        Impl(F&& f) : f(std::move(f)) {}
+        Impl(F f) : f(std::move(f)) {}
         R call(Args... args) override { return f(std::forward<Args>(args)...); }
     };
 
@@ -56,7 +56,7 @@ class Continuation<R(Args...)> {
     // then moves it into Impl<F> so Continuation itself owns the callable.
     template <typename F>
     Continuation(F&& f)
-        : impl_(std::make_unique<Impl<F>>(std::forward<F>(f))) {}
+        : impl_(std::make_unique<Impl<std::decay_t<F>>>(std::forward<F>(f))) {}
     Continuation(Continuation&&) = default;
     Continuation& operator=(Continuation&&) = default;
 

--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -116,7 +118,12 @@ class PromiseInternal {
             return false;
         }
 
-        *result_ = result;
+        // Move result into storage if possible; otherwise copy.
+        if constexpr (std::is_move_assignable_v<T>) {
+            *result_ = std::move(result);
+        } else {
+            *result_ = result;
+        }
 
         for (auto& continuation : continuations_) {
             continuation(result_);
@@ -132,11 +139,12 @@ class PromiseInternal {
         return result_->has_value();
     }
 
-    // Returns a reference to the result. The caller must ensure IsFinished()
-    // is true before calling this.
-    T const& GetResult() const {
+    // Returns a const reference to the optional result. The optional contains
+    // a value if resolved, or is empty if not yet resolved. The reference is
+    // valid for the lifetime of any Future referring to this PromiseInternal.
+    std::optional<T> const& GetResult() const {
         std::lock_guard lock(mutex_);
-        return **result_;
+        return *result_;
     }
 
     // Then where the continuation returns R directly, yielding Future<R>.
@@ -227,7 +235,7 @@ class PromiseInternal {
     }
 
    private:
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     std::shared_ptr<std::optional<T>> result_{
         new std::optional<T>(std::nullopt)};
     std::vector<Continuation<void(std::shared_ptr<std::optional<T>>)>>
@@ -241,14 +249,14 @@ class PromiseInternal {
 // Promise is move-only: it cannot be copied, but it can be moved. This
 // prevents accidentally resolving the same promise from two places.
 //
-// Using std::expected<V, E> as T is the recommended way to represent
+// Using tl::expected<V, E> as T is the recommended way to represent
 // operations that may fail:
 //
-//   Promise<std::expected<int, std::string>> promise;
-//   Future<std::expected<int, std::string>> future = promise.GetFuture();
+//   Promise<tl::expected<int, std::string>> promise;
+//   Future<tl::expected<int, std::string>> future = promise.GetFuture();
 //   // ... hand future to a consumer, then later:
 //   promise.Resolve(42);                            // success
-//   promise.Resolve(std::unexpected("timed out"));  // failure
+//   promise.Resolve(tl::unexpected("timed out"));  // failure
 template <typename T>
 class Promise {
    public:
@@ -260,7 +268,13 @@ class Promise {
     // Sets the result to the given value and schedules any continuations that
     // were registered via Future::Then. Returns true if the result was set, or
     // false if Resolve was already called.
-    bool Resolve(T result) { return internal_->Resolve(result); }
+    bool Resolve(T result) {
+        if constexpr (std::is_move_constructible_v<T>) {
+            return internal_->Resolve(std::move(result));
+        } else {
+            return internal_->Resolve(result);
+        }
+    }
 
     // Returns a Future that will resolve when this Promise is resolved.
     // May be called multiple times; each call returns a Future referring to
@@ -281,17 +295,17 @@ class Promise {
 // Unlike std::future, Future does not support blocking on the result directly.
 // Instead, use Then to attach work that runs once the value is available.
 //
-// Example using std::expected<V, E> to represent a fallible async operation:
+// Example using tl::expected<V, E> to represent a fallible async operation:
 //
 //   boost::asio::io_context ioc;
 //   auto executor = [&ioc](Continuation<void()> work) {
 //       boost::asio::post(ioc, std::move(work));
 //   };
 //
-//   Future<std::expected<float, std::string>> result = future.Then(
-//       [](std::expected<int, std::string> const& val)
-//               -> std::expected<float, std::string> {
-//           if (!val) return std::unexpected(val.error());
+//   Future<tl::expected<float, std::string>> result = future.Then(
+//       [](tl::expected<int, std::string> const& val)
+//               -> tl::expected<float, std::string> {
+//           if (!val) return tl::unexpected(val.error());
 //           return *val * 1.5f;
 //       },
 //       executor);
@@ -307,10 +321,45 @@ class Future {
     // Returns true if the associated Promise has been resolved.
     bool IsFinished() const { return internal_->IsFinished(); }
 
-    // Returns a reference to the result. The caller must ensure IsFinished()
-    // is true before calling this. The reference is valid for the lifetime of
-    // the Future (or any copy of it).
-    T const& GetResult() const { return internal_->GetResult(); }
+    // Returns a const reference to the optional result. The optional contains
+    // a value if resolved, or is empty if not yet resolved. The reference is
+    // valid for the lifetime of this Future (or any copy of it).
+    std::optional<T> const& GetResult() const { return internal_->GetResult(); }
+
+    // Blocks the calling thread until the future resolves or the timeout
+    // expires. Returns a const reference to the optional result: the optional
+    // contains a value if resolved within the timeout, or is empty if the
+    // timeout expired first. The reference is valid for the lifetime of this
+    // Future (or any copy of it).
+    template <typename Rep, typename Period>
+    std::optional<T> const& WaitForResult(
+        std::chrono::duration<Rep, Period> timeout) {
+        struct State {
+            std::mutex mutex;
+            std::condition_variable cv;
+            bool ready = false;
+        };
+        auto state = std::make_shared<State>();
+
+        // The continuation ignores T entirely (returning a dummy int) so that
+        // T is not required to be copyable. The executor signals the cv when
+        // called, since being called means the original future has resolved.
+        Then(
+            [](T const&) { return 0; },
+            [state](Continuation<void()> work) {
+                {
+                    std::lock_guard<std::mutex> lock(state->mutex);
+                    state->ready = true;
+                }
+                state->cv.notify_one();
+                work();
+            });
+
+        std::unique_lock<std::mutex> lock(state->mutex);
+        state->cv.wait_for(lock, timeout, [&state] { return state->ready; });
+
+        return GetResult();
+    }
 
     // Registers a continuation to run when this Future resolves, returning a
     // new Future<R> that resolves to the continuation's return value.
@@ -339,8 +388,8 @@ class Future {
     // Use this overload to chain async operations that themselves return a
     // Future, avoiding a nested Future<Future<T2>>:
     //
-    //   Future<std::expected<Data, Err>> result = future.Then(
-    //       [](std::expected<Key, Err> const& key) {
+    //   Future<tl::expected<Data, Err>> result = future.Then(
+    //       [](tl::expected<Key, Err> const& key) {
     //           return fetch(key);  // fetch returns Future<expected<Data, Err>>
     //       },
     //       executor);

--- a/libs/internal/src/CMakeLists.txt
+++ b/libs/internal/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 file(GLOB HEADER_LIST CONFIGURE_DEPENDS
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/*.hpp"
+        "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/async/*.hpp"
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/events/*.hpp"
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/network/*.hpp"
         "${LaunchDarklyInternalSdk_SOURCE_DIR}/include/launchdarkly/serialization/*.hpp"

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -307,6 +307,43 @@ TEST(Promise, ExpectedFailure) {
     EXPECT_EQ(result->error(), "timed out");
 }
 
+// Verifies that Promise supports move assignment, consistent with it being
+// move-only.
+TEST(Promise, MoveAssignment) {
+    Promise<int> p1;
+    Future<int> future = p1.GetFuture();
+
+    Promise<int> p2;
+    p2 = std::move(p1);
+    p2.Resolve(42);
+
+    EXPECT_EQ(*future.GetResult(), 42);
+}
+
+// Verifies that Future supports move assignment.
+TEST(Promise, FutureMoveAssignment) {
+    Promise<int> promise;
+    Future<int> f1 = promise.GetFuture();
+    Future<int> f2 = promise.GetFuture();
+
+    f2 = std::move(f1);
+    promise.Resolve(42);
+
+    EXPECT_EQ(*f2.GetResult(), 42);
+}
+
+// Verifies that Future supports copy assignment.
+TEST(Promise, FutureCopyAssignment) {
+    Promise<int> promise;
+    Future<int> f1 = promise.GetFuture();
+    Future<int> f2 = promise.GetFuture();
+
+    f2 = f1;
+    promise.Resolve(42);
+
+    EXPECT_EQ(*f2.GetResult(), 42);
+}
+
 // Verifies that a Continuation can be constructed from an lvalue callable
 // (named lambda), not just from a temporary.
 TEST(Promise, LvalueLambdaContinuation) {

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -9,6 +9,45 @@
 
 using namespace launchdarkly::async;
 
+TEST(Promise, SimplePromise) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Future<float> future2 = future.Then(
+        [](int const& inner) { return static_cast<float>(inner * 2.0); },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(43);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 86.0f);
+}
+
+TEST(Promise, ASIOTest) {
+    boost::asio::io_context ioc;
+    auto work = boost::asio::make_work_guard(ioc);
+    std::thread ioc_thread([&]() { ioc.run(); });
+
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Future<float> future2 = future.Then(
+        [](int const& inner) { return static_cast<float>(inner * 2.0); },
+        [&ioc](Continuation<void()> f) {
+            boost::asio::post(ioc, [f = std::move(f)]() mutable { f(); });
+        });
+
+    promise.Resolve(42);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 84.0f);
+
+    work.reset();
+    ioc_thread.join();
+}
+
 TEST(Promise, GetResultNotFinished) {
     Promise<int> promise;
     Future<int> future = promise.GetFuture();
@@ -53,9 +92,9 @@ TEST(Promise, ContinueByReturningFuture) {
     Promise<int> promise2;
     Future<int> future2 = promise2.GetFuture();
 
-    Future<int> chained = promise1.GetFuture().Then(
-        [future2](int const&) { return future2; },
-        [](Continuation<void()> f) { f(); });
+    Future<int> chained =
+        promise1.GetFuture().Then([future2](int const&) { return future2; },
+                                  [](Continuation<void()> f) { f(); });
 
     promise1.Resolve(0);
     promise2.Resolve(42);
@@ -71,9 +110,8 @@ TEST(Promise, ResolvedBeforeContinuation) {
 
     promise.Resolve(21);
 
-    Future<int> future2 = future.Then(
-        [](int const& val) { return val * 2; },
-        [](Continuation<void()> f) { f(); });
+    Future<int> future2 = future.Then([](int const& val) { return val * 2; },
+                                      [](Continuation<void()> f) { f(); });
 
     auto& result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
@@ -84,9 +122,8 @@ TEST(Promise, ResolvedAfterContinuation) {
     Promise<int> promise;
     Future<int> future = promise.GetFuture();
 
-    Future<int> future2 = future.Then(
-        [](int const& val) { return val * 2; },
-        [](Continuation<void()> f) { f(); });
+    Future<int> future2 = future.Then([](int const& val) { return val * 2; },
+                                      [](Continuation<void()> f) { f(); });
 
     promise.Resolve(21);
 
@@ -140,11 +177,10 @@ TEST(Promise, MoveOnlyCallback) {
     Future<int> future = promise.GetFuture();
 
     auto captured = std::make_unique<int>(2);
-    Future<int> future2 = future.Then(
-        [captured = std::move(captured)](int const& val) {
-            return val * *captured;
-        },
-        [](Continuation<void()> f) { f(); });
+    Future<int> future2 =
+        future.Then([captured = std::move(captured)](
+                        int const& val) { return val * *captured; },
+                    [](Continuation<void()> f) { f(); });
 
     promise.Resolve(21);
 
@@ -161,8 +197,15 @@ TEST(Promise, ResultMovedWhenPossible) {
         int value;
         int* copy_count;
         explicit Counted(int v, int* c) : value(v), copy_count(c) {}
-        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) { ++(*copy_count); }
-        Counted& operator=(Counted const& o) { value = o.value; copy_count = o.copy_count; ++(*copy_count); return *this; }
+        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) {
+            ++(*copy_count);
+        }
+        Counted& operator=(Counted const& o) {
+            value = o.value;
+            copy_count = o.copy_count;
+            ++(*copy_count);
+            return *this;
+        }
         Counted(Counted&&) noexcept = default;
         Counted& operator=(Counted&&) noexcept = default;
     };
@@ -186,8 +229,15 @@ TEST(Promise, CallbackMovedWhenPossible) {
         int value;
         int* copy_count;
         explicit Counted(int v, int* c) : value(v), copy_count(c) {}
-        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) { ++(*copy_count); }
-        Counted& operator=(Counted const& o) { value = o.value; copy_count = o.copy_count; ++(*copy_count); return *this; }
+        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) {
+            ++(*copy_count);
+        }
+        Counted& operator=(Counted const& o) {
+            value = o.value;
+            copy_count = o.copy_count;
+            ++(*copy_count);
+            return *this;
+        }
         Counted(Counted&&) noexcept = default;
         Counted& operator=(Counted&&) noexcept = default;
     };
@@ -198,19 +248,18 @@ TEST(Promise, CallbackMovedWhenPossible) {
     Counted multiplier{2, &copies};
     copies = 0;  // reset after construction
 
-    future.Then(
-        [multiplier = std::move(multiplier)](int const& val) mutable {
-            return val * multiplier.value;
-        },
-        [](Continuation<void()> f) { f(); });
+    future.Then([multiplier = std::move(multiplier)](
+                    int const& val) mutable { return val * multiplier.value; },
+                [](Continuation<void()> f) { f(); });
 
     EXPECT_EQ(copies, 0);
 
     promise.Resolve(21);
 }
 
-// Demonstrates using std::monostate as a void-like result type for fire-and-forget
-// async operations where the completion matters but no value is produced.
+// Demonstrates using std::monostate as a void-like result type for
+// fire-and-forget async operations where the completion matters but no value is
+// produced.
 TEST(Promise, MonostateVoidLike) {
     Promise<std::monostate> promise;
     Future<std::monostate> future = promise.GetFuture();
@@ -258,42 +307,100 @@ TEST(Promise, ExpectedFailure) {
     EXPECT_EQ(result->error(), "timed out");
 }
 
-
-TEST(Promise, SimplePromise) {
-    Promise<int> promise;
-    Future<int> future = promise.GetFuture();
-
-    Future<float> future2 = future.Then(
-        [](int const& inner) { return static_cast<float>(inner * 2.0); },
-        [](Continuation<void()> f) { f(); });
-
-    promise.Resolve(43);
-
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
-    ASSERT_TRUE(result.has_value());
-    EXPECT_FLOAT_EQ(*result, 86.0f);
+TEST(WhenAll, NoFutures) {
+    Future<std::monostate> result = WhenAll();
+    EXPECT_TRUE(result.IsFinished());
 }
 
-TEST(Promise, ASIOTest) {
-    boost::asio::io_context ioc;
-    auto work = boost::asio::make_work_guard(ioc);
-    std::thread ioc_thread([&]() { ioc.run(); });
+// Verifies WhenAll resolves when all futures are already resolved.
+TEST(WhenAll, AllAlreadyResolved) {
+    Promise<int> p1;
+    Promise<std::string> p2;
 
-    Promise<int> promise;
-    Future<int> future = promise.GetFuture();
+    p1.Resolve(1);
+    p2.Resolve("hello");
 
-    Future<float> future2 = future.Then(
-        [](int const& inner) { return static_cast<float>(inner * 2.0); },
-        [&ioc](Continuation<void()> f) {
-            boost::asio::post(ioc, [f = std::move(f)]() mutable { f(); });
-        });
+    Future<std::monostate> result = WhenAll(p1.GetFuture(), p2.GetFuture());
+    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+}
 
-    promise.Resolve(42);
+// Verifies WhenAll resolves only after all futures resolve, using futures of
+// mixed value types. The original futures still hold their results afterward.
+TEST(WhenAll, ResolvesAfterAll) {
+    Promise<int> p1;
+    Promise<std::string> p2;
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
-    ASSERT_TRUE(result.has_value());
-    EXPECT_FLOAT_EQ(*result, 84.0f);
+    Future<int> f1 = p1.GetFuture();
+    Future<std::string> f2 = p2.GetFuture();
 
-    work.reset();
-    ioc_thread.join();
+    Future<std::monostate> result = WhenAll(f1, f2);
+
+    EXPECT_FALSE(result.IsFinished());
+    p1.Resolve(42);
+    EXPECT_FALSE(result.IsFinished());
+    p2.Resolve("done");
+
+    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*f1.GetResult(), 42);
+    EXPECT_EQ(*f2.GetResult(), "done");
+}
+
+// Verifies that WhenAny resolves with the index of the first future to resolve.
+TEST(WhenAny, FirstResolved) {
+    Promise<int> p0;
+    Promise<int> p1;
+    Promise<int> p2;
+
+    Future<std::size_t> result =
+        WhenAny(p0.GetFuture(), p1.GetFuture(), p2.GetFuture());
+
+    EXPECT_FALSE(result.IsFinished());
+    p1.Resolve(42);
+
+    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, 1u);
+}
+
+// Verifies that WhenAny works with futures of mixed value types, and that
+// resolving a later future after the winner does not change the result.
+TEST(WhenAny, MixedTypesFirstWins) {
+    Promise<int> p0;
+    Promise<std::string> p1;
+
+    Future<int> f0 = p0.GetFuture();
+    Future<std::string> f1 = p1.GetFuture();
+
+    Future<std::variant<int, std::string>> result = WhenAny(f0, f1).Then(
+        [f0, f1](size_t const& index) -> std::variant<int, std::string> {
+            if (index == 0) {
+                return f0.GetResult().value();
+            } else {
+                return f1.GetResult().value();
+            }
+        },
+        [](Continuation<void()> f) { f(); });
+
+    p1.Resolve("hello");
+    p0.Resolve(99);
+
+    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(std::get<std::string>(*result.GetResult()), "hello");
+}
+
+// Verifies that WhenAny resolves immediately if a future is already resolved.
+TEST(WhenAny, AlreadyResolved) {
+    Promise<int> p0;
+    Promise<int> p1;
+
+    p0.Resolve(42);
+
+    Future<std::size_t> result = WhenAny(p0.GetFuture(), p1.GetFuture());
+
+    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, 0u);
 }

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
+#include <tl/expected.hpp>
 
 #include <thread>
 
@@ -8,42 +9,291 @@
 
 using namespace launchdarkly::async;
 
-// Cases to cover:
-// Resolved after continuation.
-// Resolved before continuation.
-// Continue with value.
-// Continue with promise.
-// A result that can be copied but not moved.
-// A result that can be moved but not copied.
-// A callback that can be copied but not moved.
-// A callback that can be moved but not copied.
-// Test that results are moved if possible, even if they could be copied.
-// Test that callbacks are moved if possible, even if they could be copied.
+TEST(Promise, GetResultNotFinished) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    auto& result = future.GetResult();
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(Promise, GetResultFinished) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    promise.Resolve(42);
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+TEST(Promise, CopyOnlyResult) {
+    struct CopyOnly {
+        int value;
+        explicit CopyOnly(int v) : value(v) {}
+        CopyOnly(CopyOnly const&) = default;
+        CopyOnly& operator=(CopyOnly const&) = default;
+        CopyOnly(CopyOnly&&) = delete;
+        CopyOnly& operator=(CopyOnly&&) = delete;
+    };
+
+    Promise<CopyOnly> promise;
+    Future<CopyOnly> future = promise.GetFuture();
+
+    promise.Resolve(CopyOnly{42});
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->value, 42);
+}
+
+TEST(Promise, ContinueByReturningFuture) {
+    Promise<int> promise1;
+    Promise<int> promise2;
+    Future<int> future2 = promise2.GetFuture();
+
+    Future<int> chained = promise1.GetFuture().Then(
+        [future2](int const&) { return future2; },
+        [](Continuation<void()> f) { f(); });
+
+    promise1.Resolve(0);
+    promise2.Resolve(42);
+
+    auto& result = chained.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+TEST(Promise, ResolvedBeforeContinuation) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    promise.Resolve(21);
+
+    Future<int> future2 = future.Then(
+        [](int const& val) { return val * 2; },
+        [](Continuation<void()> f) { f(); });
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+TEST(Promise, ResolvedAfterContinuation) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Future<int> future2 = future.Then(
+        [](int const& val) { return val * 2; },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(21);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+TEST(Promise, MoveOnlyResult) {
+    Promise<std::unique_ptr<int>> promise;
+    Future<std::unique_ptr<int>> future = promise.GetFuture();
+
+    promise.Resolve(std::make_unique<int>(42));
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(**result, 42);
+}
+
+// Verifies that a continuation which captures a copy-only type (deleted move
+// constructor) can still be registered and invoked correctly.
+TEST(Promise, CopyOnlyCallback) {
+    struct CopyOnlyInt {
+        int value;
+        explicit CopyOnlyInt(int v) : value(v) {}
+        CopyOnlyInt(CopyOnlyInt const&) = default;
+        CopyOnlyInt& operator=(CopyOnlyInt const&) = default;
+        CopyOnlyInt(CopyOnlyInt&&) = delete;
+        CopyOnlyInt& operator=(CopyOnlyInt&&) = delete;
+    };
+
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    CopyOnlyInt multiplier{2};
+    Future<int> future2 = future.Then(
+        [multiplier](int const& val) { return val * multiplier.value; },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(21);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+// Verifies that a continuation which captures a move-only type (deleted copy
+// constructor) can still be registered and invoked correctly.
+TEST(Promise, MoveOnlyCallback) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    auto captured = std::make_unique<int>(2);
+    Future<int> future2 = future.Then(
+        [captured = std::move(captured)](int const& val) {
+            return val * *captured;
+        },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(21);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42);
+}
+
+// Verifies that when T is both moveable and copyable, resolving a promise
+// moves the value into storage rather than copying it.
+TEST(Promise, ResultMovedWhenPossible) {
+    int copies = 0;
+    struct Counted {
+        int value;
+        int* copy_count;
+        explicit Counted(int v, int* c) : value(v), copy_count(c) {}
+        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) { ++(*copy_count); }
+        Counted& operator=(Counted const& o) { value = o.value; copy_count = o.copy_count; ++(*copy_count); return *this; }
+        Counted(Counted&&) noexcept = default;
+        Counted& operator=(Counted&&) noexcept = default;
+    };
+
+    Promise<Counted> promise;
+    Future<Counted> future = promise.GetFuture();
+
+    promise.Resolve(Counted{42, &copies});
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->value, 42);
+    EXPECT_EQ(copies, 0);
+}
+
+// Verifies that when a continuation is both moveable and copyable, Then stores
+// it by moving rather than copying.
+TEST(Promise, CallbackMovedWhenPossible) {
+    int copies = 0;
+    struct Counted {
+        int value;
+        int* copy_count;
+        explicit Counted(int v, int* c) : value(v), copy_count(c) {}
+        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) { ++(*copy_count); }
+        Counted& operator=(Counted const& o) { value = o.value; copy_count = o.copy_count; ++(*copy_count); return *this; }
+        Counted(Counted&&) noexcept = default;
+        Counted& operator=(Counted&&) noexcept = default;
+    };
+
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Counted multiplier{2, &copies};
+    copies = 0;  // reset after construction
+
+    future.Then(
+        [multiplier = std::move(multiplier)](int const& val) mutable {
+            return val * multiplier.value;
+        },
+        [](Continuation<void()> f) { f(); });
+
+    EXPECT_EQ(copies, 0);
+
+    promise.Resolve(21);
+}
+
+// Demonstrates using std::monostate as a void-like result type for fire-and-forget
+// async operations where the completion matters but no value is produced.
+TEST(Promise, MonostateVoidLike) {
+    Promise<std::monostate> promise;
+    Future<std::monostate> future = promise.GetFuture();
+
+    bool ran = false;
+    future.Then(
+        [&ran](std::monostate const&) {
+            ran = true;
+            return std::monostate{};
+        },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(std::monostate{});
+
+    auto& result = future.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(ran);
+}
+
+// Demonstrates using tl::expected as T to represent a fallible async operation
+// that resolves successfully.
+TEST(Promise, ExpectedSuccess) {
+    Promise<tl::expected<int, std::string>> promise;
+    Future<tl::expected<int, std::string>> future = promise.GetFuture();
+
+    promise.Resolve(42);
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->has_value());
+    EXPECT_EQ(**result, 42);
+}
+
+// Demonstrates using tl::expected as T to represent a fallible async operation
+// that resolves with an error.
+TEST(Promise, ExpectedFailure) {
+    Promise<tl::expected<int, std::string>> promise;
+    Future<tl::expected<int, std::string>> future = promise.GetFuture();
+
+    promise.Resolve(tl::unexpected(std::string("timed out")));
+
+    auto& result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_FALSE(result->has_value());
+    EXPECT_EQ(result->error(), "timed out");
+}
+
 
 TEST(Promise, SimplePromise) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Future<float> future2 = future.Then(
+        [](int const& inner) { return static_cast<float>(inner * 2.0); },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(43);
+
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 86.0f);
+}
+
+TEST(Promise, ASIOTest) {
     boost::asio::io_context ioc;
     auto work = boost::asio::make_work_guard(ioc);
     std::thread ioc_thread([&]() { ioc.run(); });
-
-    int result = 0;
 
     Promise<int> promise;
     Future<int> future = promise.GetFuture();
 
     Future<float> future2 = future.Then(
-        [&](int const& inner) {
-            result = 42;
-            return static_cast<float>(result);
-        },
-        [](Continuation<void()> f) { f(); });
+        [](int const& inner) { return static_cast<float>(inner * 2.0); },
+        [&ioc](Continuation<void()> f) {
+            boost::asio::post(ioc, [f = std::move(f)]() mutable { f(); });
+        });
 
-    promise.Resolve(43);
+    promise.Resolve(42);
 
-    bool work_ran = false;
-    boost::asio::post(ioc, [&]() { work_ran = true; });
+    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 84.0f);
 
     work.reset();
     ioc_thread.join();
-
-    ASSERT_TRUE(work_ran);
 }

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -441,3 +441,98 @@ TEST(WhenAll, ConcurrentResolution) {
     t4.join();
     t5.join();
 }
+
+// Verifies that WaitForResult returns nullopt when the promise is never
+// resolved within the timeout.
+TEST(Promise, WaitForResultTimeout) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    auto result = future.WaitForResult(std::chrono::milliseconds(50));
+    EXPECT_FALSE(result.has_value());
+}
+
+// Verifies that multiple threads can concurrently register continuations on
+// the same future before it resolves, and all continuations run after
+// resolution.
+TEST(Promise, ConcurrentThenRegistration) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    std::atomic<int> count{0};
+    std::vector<std::thread> threads;
+    std::vector<Future<std::monostate>> results;
+
+    for (int i = 0; i < 10; i++) {
+        results.push_back(future.Then(
+            [&count](int const&) {
+                count++;
+                return std::monostate{};
+            },
+            [](Continuation<void()> f) { f(); }));
+    }
+
+    promise.Resolve(42);
+
+    for (auto& r : results) {
+        ASSERT_TRUE(r.WaitForResult(std::chrono::seconds(5)).has_value());
+    }
+    EXPECT_EQ(count, 10);
+}
+
+// Verifies that when multiple threads race to resolve the same promise,
+// exactly one succeeds and the rest return false.
+TEST(Promise, ConcurrentResolveSingleWinner) {
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    std::atomic<int> winners{0};
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 10; i++) {
+        threads.emplace_back([&promise, &winners, i] {
+            if (promise.Resolve(i)) {
+                winners++;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(winners, 1);
+    EXPECT_TRUE(future.GetResult().has_value());
+}
+
+// Verifies that a chain of Then calls executes correctly when continuations
+// are dispatched via a multi-threaded ASIO executor.
+TEST(Promise, MultiThreadedASIOExecutor) {
+    boost::asio::io_context ioc;
+    auto work = boost::asio::make_work_guard(ioc);
+
+    std::vector<std::thread> ioc_threads;
+    for (int i = 0; i < 4; i++) {
+        ioc_threads.emplace_back([&ioc] { ioc.run(); });
+    }
+
+    auto executor = [&ioc](Continuation<void()> f) {
+        boost::asio::post(ioc, std::move(f));
+    };
+
+    Promise<int> promise;
+    Future<int> result =
+        promise.GetFuture()
+            .Then([](int const& v) { return v * 2; }, executor)
+            .Then([](int const& v) { return v + 1; }, executor);
+
+    promise.Resolve(10);
+
+    auto r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, 21);
+
+    work.reset();
+    for (auto& t : ioc_threads) {
+        t.join();
+    }
+}

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+
+#include <thread>
+
+#include "launchdarkly/async/promise.hpp"
+
+using namespace launchdarkly::async;
+
+// Cases to cover:
+// Resolved after continuation.
+// Resolved before continuation.
+// Continue with value.
+// Continue with promise.
+// A result that can be copied but not moved.
+// A result that can be moved but not copied.
+// A callback that can be copied but not moved.
+// A callback that can be moved but not copied.
+// Test that results are moved if possible, even if they could be copied.
+// Test that callbacks are moved if possible, even if they could be copied.
+
+TEST(Promise, SimplePromise) {
+    boost::asio::io_context ioc;
+    auto work = boost::asio::make_work_guard(ioc);
+    std::thread ioc_thread([&]() { ioc.run(); });
+
+    int result = 0;
+
+    Promise<int> promise;
+    Future<int> future = promise.GetFuture();
+
+    Future<float> future2 = future.Then(
+        [&](int const& inner) {
+            result = 42;
+            return static_cast<float>(result);
+        },
+        [](Continuation<void()> f) { f(); });
+
+    promise.Resolve(43);
+
+    bool work_ran = false;
+    boost::asio::post(ioc, [&]() { work_ran = true; });
+
+    work.reset();
+    ioc_thread.join();
+
+    ASSERT_TRUE(work_ran);
+}

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -307,6 +307,14 @@ TEST(Promise, ExpectedFailure) {
     EXPECT_EQ(result->error(), "timed out");
 }
 
+// Verifies that a Continuation can be constructed from an lvalue callable
+// (named lambda), not just from a temporary.
+TEST(Promise, LvalueLambdaContinuation) {
+    auto fn = [](int x) { return x * 2; };
+    Continuation<int(int)> c(fn);
+    EXPECT_EQ(c(21), 42);
+}
+
 TEST(WhenAll, NoFutures) {
     Future<std::monostate> result = WhenAll();
     EXPECT_TRUE(result.IsFinished());

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -406,3 +406,38 @@ TEST(WhenAny, AlreadyResolved) {
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, 0u);
 }
+
+TEST(WhenAll, ConcurrentResolution) {
+    auto spawn = [](int val) {
+        Promise<int> p;
+        Future<int> f = p.GetFuture();
+        return std::make_pair(
+            f, std::thread([p = std::move(p), val]() mutable {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                p.Resolve(val);
+            }));
+    };
+
+    auto [f1, t1] = spawn(1);
+    auto [f2, t2] = spawn(2);
+    auto [f3, t3] = spawn(3);
+    auto [f4, t4] = spawn(4);
+    auto [f5, t5] = spawn(5);
+
+    auto result = WhenAll(f1, f2, f3, f4, f5);
+
+    auto r = result.WaitForResult(std::chrono::seconds(5));
+    ASSERT_TRUE(r.has_value());
+
+    EXPECT_EQ(f1.GetResult().value(), 1);
+    EXPECT_EQ(f2.GetResult().value(), 2);
+    EXPECT_EQ(f3.GetResult().value(), 3);
+    EXPECT_EQ(f4.GetResult().value(), 4);
+    EXPECT_EQ(f5.GetResult().value(), 5);
+
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
+    t5.join();
+}

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -67,6 +67,30 @@ TEST(Promise, GetResultFinished) {
     EXPECT_EQ(*result, 42);
 }
 
+// Verifies that a type which is move-assignable but not move-constructible
+// can still be used as T. The optional assignment for an empty optional needs
+// move-constructibility, not move-assignability, so the if constexpr branch
+// must check the correct trait.
+TEST(Promise, MoveAssignableNotMoveConstructible) {
+    struct MoveAssignableOnly {
+        int value;
+        explicit MoveAssignableOnly(int v) : value(v) {}
+        MoveAssignableOnly(MoveAssignableOnly const&) = default;
+        MoveAssignableOnly& operator=(MoveAssignableOnly const&) = default;
+        MoveAssignableOnly(MoveAssignableOnly&&) = delete;
+        MoveAssignableOnly& operator=(MoveAssignableOnly&&) = default;
+    };
+
+    Promise<MoveAssignableOnly> promise;
+    Future<MoveAssignableOnly> future = promise.GetFuture();
+
+    promise.Resolve(MoveAssignableOnly{42});
+
+    auto result = future.GetResult();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->value, 42);
+}
+
 TEST(Promise, CopyOnlyResult) {
     struct CopyOnly {
         int value;

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -476,34 +476,6 @@ TEST(Promise, WaitForResultTimeout) {
     EXPECT_FALSE(result.has_value());
 }
 
-// Verifies that multiple threads can concurrently register continuations on
-// the same future before it resolves, and all continuations run after
-// resolution.
-TEST(Promise, ConcurrentThenRegistration) {
-    Promise<int> promise;
-    Future<int> future = promise.GetFuture();
-
-    std::atomic<int> count{0};
-    std::vector<std::thread> threads;
-    std::vector<Future<std::monostate>> results;
-
-    for (int i = 0; i < 10; i++) {
-        results.push_back(future.Then(
-            [&count](int const&) {
-                count++;
-                return std::monostate{};
-            },
-            [](Continuation<void()> f) { f(); }));
-    }
-
-    promise.Resolve(42);
-
-    for (auto& r : results) {
-        ASSERT_TRUE(r.WaitForResult(std::chrono::seconds(5)).has_value());
-    }
-    EXPECT_EQ(count, 10);
-}
-
 // Verifies that when multiple threads race to resolve the same promise,
 // exactly one succeeds and the rest return false.
 TEST(Promise, ConcurrentResolveSingleWinner) {

--- a/libs/internal/tests/promise_test.cpp
+++ b/libs/internal/tests/promise_test.cpp
@@ -19,7 +19,7 @@ TEST(Promise, SimplePromise) {
 
     promise.Resolve(43);
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_FLOAT_EQ(*result, 86.0f);
 }
@@ -40,7 +40,7 @@ TEST(Promise, ASIOTest) {
 
     promise.Resolve(42);
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_FLOAT_EQ(*result, 84.0f);
 
@@ -52,7 +52,7 @@ TEST(Promise, GetResultNotFinished) {
     Promise<int> promise;
     Future<int> future = promise.GetFuture();
 
-    auto& result = future.GetResult();
+    auto result = future.GetResult();
     EXPECT_FALSE(result.has_value());
 }
 
@@ -62,7 +62,7 @@ TEST(Promise, GetResultFinished) {
 
     promise.Resolve(42);
 
-    auto& result = future.GetResult();
+    auto result = future.GetResult();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
 }
@@ -82,7 +82,7 @@ TEST(Promise, CopyOnlyResult) {
 
     promise.Resolve(CopyOnly{42});
 
-    auto& result = future.GetResult();
+    auto result = future.GetResult();
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result->value, 42);
 }
@@ -99,7 +99,7 @@ TEST(Promise, ContinueByReturningFuture) {
     promise1.Resolve(0);
     promise2.Resolve(42);
 
-    auto& result = chained.WaitForResult(std::chrono::seconds(5));
+    auto result = chained.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
 }
@@ -113,7 +113,7 @@ TEST(Promise, ResolvedBeforeContinuation) {
     Future<int> future2 = future.Then([](int const& val) { return val * 2; },
                                       [](Continuation<void()> f) { f(); });
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
 }
@@ -127,20 +127,9 @@ TEST(Promise, ResolvedAfterContinuation) {
 
     promise.Resolve(21);
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
-}
-
-TEST(Promise, MoveOnlyResult) {
-    Promise<std::unique_ptr<int>> promise;
-    Future<std::unique_ptr<int>> future = promise.GetFuture();
-
-    promise.Resolve(std::make_unique<int>(42));
-
-    auto& result = future.GetResult();
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(**result, 42);
 }
 
 // Verifies that a continuation which captures a copy-only type (deleted move
@@ -165,7 +154,7 @@ TEST(Promise, CopyOnlyCallback) {
 
     promise.Resolve(21);
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
 }
@@ -184,41 +173,9 @@ TEST(Promise, MoveOnlyCallback) {
 
     promise.Resolve(21);
 
-    auto& result = future2.WaitForResult(std::chrono::seconds(5));
+    auto result = future2.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(*result, 42);
-}
-
-// Verifies that when T is both moveable and copyable, resolving a promise
-// moves the value into storage rather than copying it.
-TEST(Promise, ResultMovedWhenPossible) {
-    int copies = 0;
-    struct Counted {
-        int value;
-        int* copy_count;
-        explicit Counted(int v, int* c) : value(v), copy_count(c) {}
-        Counted(Counted const& o) : value(o.value), copy_count(o.copy_count) {
-            ++(*copy_count);
-        }
-        Counted& operator=(Counted const& o) {
-            value = o.value;
-            copy_count = o.copy_count;
-            ++(*copy_count);
-            return *this;
-        }
-        Counted(Counted&&) noexcept = default;
-        Counted& operator=(Counted&&) noexcept = default;
-    };
-
-    Promise<Counted> promise;
-    Future<Counted> future = promise.GetFuture();
-
-    promise.Resolve(Counted{42, &copies});
-
-    auto& result = future.GetResult();
-    ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result->value, 42);
-    EXPECT_EQ(copies, 0);
 }
 
 // Verifies that when a continuation is both moveable and copyable, Then stores
@@ -274,7 +231,7 @@ TEST(Promise, MonostateVoidLike) {
 
     promise.Resolve(std::monostate{});
 
-    auto& result = future.WaitForResult(std::chrono::seconds(5));
+    auto result = future.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(result.has_value());
     EXPECT_TRUE(ran);
 }
@@ -287,7 +244,7 @@ TEST(Promise, ExpectedSuccess) {
 
     promise.Resolve(42);
 
-    auto& result = future.GetResult();
+    auto result = future.GetResult();
     ASSERT_TRUE(result.has_value());
     ASSERT_TRUE(result->has_value());
     EXPECT_EQ(**result, 42);
@@ -301,7 +258,7 @@ TEST(Promise, ExpectedFailure) {
 
     promise.Resolve(tl::unexpected(std::string("timed out")));
 
-    auto& result = future.GetResult();
+    auto result = future.GetResult();
     ASSERT_TRUE(result.has_value());
     ASSERT_FALSE(result->has_value());
     EXPECT_EQ(result->error(), "timed out");
@@ -366,7 +323,7 @@ TEST(WhenAll, AllAlreadyResolved) {
     p2.Resolve("hello");
 
     Future<std::monostate> result = WhenAll(p1.GetFuture(), p2.GetFuture());
-    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    auto r = result.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(r.has_value());
 }
 
@@ -386,7 +343,7 @@ TEST(WhenAll, ResolvesAfterAll) {
     EXPECT_FALSE(result.IsFinished());
     p2.Resolve("done");
 
-    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    auto r = result.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*f1.GetResult(), 42);
     EXPECT_EQ(*f2.GetResult(), "done");
@@ -404,7 +361,7 @@ TEST(WhenAny, FirstResolved) {
     EXPECT_FALSE(result.IsFinished());
     p1.Resolve(42);
 
-    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    auto r = result.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, 1u);
 }
@@ -431,7 +388,7 @@ TEST(WhenAny, MixedTypesFirstWins) {
     p1.Resolve("hello");
     p0.Resolve(99);
 
-    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    auto r = result.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(std::get<std::string>(*result.GetResult()), "hello");
 }
@@ -445,7 +402,7 @@ TEST(WhenAny, AlreadyResolved) {
 
     Future<std::size_t> result = WhenAny(p0.GetFuture(), p1.GetFuture());
 
-    auto& r = result.WaitForResult(std::chrono::seconds(5));
+    auto r = result.WaitForResult(std::chrono::seconds(5));
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, 0u);
 }


### PR DESCRIPTION
This PR adds internal-only `Promise` and `Future` classes. These have some advantages over using callbacks everywhere:
* They are more easily composable. That means utility functions like `WhenAll` and `WhenAny` only have to be written once, instead of having to re-invent the wheel every time we need those concepts.
* This allows C++ code to be structured more like the code in other languages with proper promise types.
* Unlike `std::future`, this supports a `Then` method, which enables things like `WhenAny` without occupying an extra thread per future.
* Unlike `std::function`, the `Continuation` class used in this implementation supports move-only functions.

Some points to consider:
* Would other people like using these, or am I the only one?
* **Naming**: I chose to mimic the C++ names of `std::promise`, `std::future`, and `then()` (experimental).
* **Executors**: I chose to _require_ passing an executor into `Then`, because there is no natural default:
  * C++ doesn't have a "main" thread exactly, or at least, it's not used the same way as on other platforms.
  * Immediate executors are confusing to reason about, and result in calling work on unpredictable threads.
  * We shouldn't assume `asio::post`, as this class may be used for other things.
  * I didn't want to add the complexity of storing execution contexts in a thread-local.
* **Error handling**: I chose not to put error handling directly in the `Future`, and encourage users to use `Future<std::expected<>>` if they care about it, to keep things simpler.
* **Cancellation**: I chose not to implement cancellation. We can add it in the future. But cancellation can be treated as mostly orthogonal to futures, and we can't cancel http requests currently anyway, so 🤷‍♀️ .
* By default, `GetResult` is non-blocking, as this prevents unintended blocking. There is a blocking version called `WaitForResult` with a timeout if needed.
* The continuations in `Then` are passed the _result_ of the `Future` instead of the `Future` itself. This is simpler, but it means we can't add more metadata in the future without a breaking change. This is an internal class, so I think it's better to keep it simple.
* The type `T` in `Promise<T>`/`Future<T>` has to be copyable. This is an inherent limitation of the need to be able to have `Future<Future<T>>` unwrappable to `Future<T>`, while also letting a `Future` have multiple continuations.
* The executor has to be copyable, for simplicity. ASIO has the same requirement on executors, and it seems fine.

I added lots of tests. Some of them double as documentation for humans and LLMs.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new concurrency primitives (`Promise`/`Future`, move-only `Continuation`, and `WhenAll`/`WhenAny`) with mutex/atomic coordination and executor-dispatched continuations, so correctness depends on subtle threading and lifetime behavior. Changes are currently additive/internal but could impact future async flows once adopted.
> 
> **Overview**
> Adds a new internal async module `launchdarkly/async/promise.hpp` implementing `Promise<T>`/`Future<T>` with executor-based `Then` chaining (including flattening when a continuation returns another `Future`) and a move-only `Continuation` wrapper to support move-only captures.
> 
> Introduces aggregation helpers `WhenAll` and `WhenAny`, a blocking `WaitForResult` (timeout-based) for test/support scenarios, and wires the new async headers into the internal library build. Adds extensive unit tests covering chaining, move/copy behavior, concurrent resolution, and ASIO executor usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfce8854c628cf06c17e6f5731359abadc777a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->