### PR TITLE
docs: clarify lifetime and ownership rules for C hook callback parameters

### DIFF
--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/hook.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/hook.h
@@ -10,8 +10,15 @@
  * - The function pointers and UserData pointer are copied when the hook is
  *   registered with the config builder
  * - UserData lifetime must extend for the entire lifetime of the SDK client
- * - All context parameters passed to callbacks are temporary - valid only
- *   during the callback execution
+ *
+ * WARNING: All pointers passed to callbacks by the SDK (series_context, data,
+ * detail, etc.) are owned by the SDK and may be freed after the callback
+ * returns. You MUST NOT retain, cache, or store these pointers, or any
+ * references to data within them, beyond the scope of the callback invocation.
+ * Any data needed outside the duration of a callback must be copied during the
+ * callback. Accessing a stored pointer or reference after the callback has
+ * returned results in undefined behavior.
+ *
  * - EvaluationSeriesData returned from callbacks transfers ownership to the SDK
  */
 // NOLINTBEGIN(modernize-use-using)
@@ -49,7 +56,8 @@ typedef struct p_LDServerSDKTrackSeriesContext* LDServerSDKTrackSeriesContext;
  *
  * LIFETIME:
  * - series_context: Valid only during callback execution - do not store
- * - data: Ownership transfers to SDK
+ * - data: Valid only during callback execution - do not store. Ownership of
+ *         the returned value transfers to the SDK.
  * - user_data: Managed by caller - must remain valid for SDK lifetime
  */
 typedef LDServerSDKEvaluationSeriesData (*LDServerSDKHook_BeforeEvaluation)(
@@ -77,10 +85,11 @@ typedef LDServerSDKEvaluationSeriesData (*LDServerSDKHook_BeforeEvaluation)(
  * If NULL is returned, an empty data object will be created.
  *
  * LIFETIME:
- * - series_context: Valid only during callback execution
- * - data: Ownership transfers to SDK
- * - detail: Valid only during callback execution
- * - user_data: Managed by caller
+ * - series_context: Valid only during callback execution - do not store
+ * - data: Valid only during callback execution - do not store. Ownership of
+ *         the returned value transfers to the SDK.
+ * - detail: Valid only during callback execution - do not store
+ * - user_data: Managed by caller - must remain valid for SDK lifetime
  */
 typedef LDServerSDKEvaluationSeriesData (*LDServerSDKHook_AfterEvaluation)(
     LDServerSDKEvaluationSeriesContext series_context,
@@ -102,8 +111,8 @@ typedef LDServerSDKEvaluationSeriesData (*LDServerSDKHook_AfterEvaluation)(
  * RETURNS: void (no data is passed between track stages)
  *
  * LIFETIME:
- * - series_context: Valid only during callback execution
- * - user_data: Managed by caller
+ * - series_context: Valid only during callback execution - do not store
+ * - user_data: Managed by caller - must remain valid for SDK lifetime
  */
 typedef void (*LDServerSDKHook_AfterTrack)(LDServerSDKTrackSeriesContext series_context,
                                            void* user_data);

--- a/libs/server-sdk/include/launchdarkly/server_side/bindings/c/hook.h
+++ b/libs/server-sdk/include/launchdarkly/server_side/bindings/c/hook.h
@@ -51,7 +51,8 @@ typedef struct p_LDServerSDKTrackSeriesContext* LDServerSDKTrackSeriesContext;
  *
  * RETURNS:
  * EvaluationSeriesData to pass to afterEvaluation. Return the input data
- * unmodified if you don't need to add anything. Ownership transfers to SDK.
+ * unmodified if you don't need to add anything. Ownership transfers to SDK;
+ * the caller must not retain or access the returned pointer after returning.
  * If NULL is returned, an empty data object will be created.
  *
  * LIFETIME:
@@ -81,7 +82,8 @@ typedef LDServerSDKEvaluationSeriesData (*LDServerSDKHook_BeforeEvaluation)(
  *
  * RETURNS:
  * EvaluationSeriesData for potential future stages. Return the input data
- * unmodified if you don't need to modify it. Ownership transfers to SDK.
+ * unmodified if you don't need to modify it. Ownership transfers to SDK;
+ * the caller must not retain or access the returned pointer after returning.
  * If NULL is returned, an empty data object will be created.
  *
  * LIFETIME:


### PR DESCRIPTION
Strengthen the documentation in hook.h to make it explicit that all SDK-provided pointers (series_context, data, detail, etc.) must not be retained, cached, or stored beyond the scope of the callback invocation, and that any data needed outside the callback must be copied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify ownership/lifetime rules for SDK-provided callback parameters; no runtime behavior changes.
> 
> **Overview**
> Adds explicit *lifetime/ownership* warnings to the C hook API docs (`hook.h`), stating that all SDK-provided pointers (`series_context`, `data`, `detail`, etc.) are temporary and must not be retained beyond the callback.
> 
> Tightens the per-callback `LIFETIME`/`RETURNS` sections to consistently note that any needed data must be copied within the callback and that returned `EvaluationSeriesData` ownership transfers to the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb08ab51230510c3170b88245dadfdf1ced87a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->