### PR TITLE
ci: update OpenSSL Chocolatey package version from 3.6.1 to 3.6.2

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 3.6.1 -y --no-progress
+        choco install openssl --version 3.6.2 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
## Summary

Updates the OpenSSL version installed via Chocolatey on Windows CI runners from 3.6.1 to 3.6.2.

OpenSSL 3.6.1 has been removed from Chocolatey's community repository, causing all 9 Windows CI jobs to fail with a 404 when attempting to download `Win64OpenSSL-3_6_1.exe`. The latest available version is 3.6.2.

## Review & Testing Checklist for Human

- [x] Verify that all Windows CI jobs pass with the updated version
- [x] Confirm 3.6.2 is the desired target version (vs pinning to a different release)

### Notes

This unblocks PR #520 and any other PRs currently blocked by Windows CI failures.

Link to Devin session: https://app.devin.ai/sessions/d009d787eaa84d67813ec46d4cd3c382
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that updates a pinned dependency version on Windows runners; potential impact is limited to Windows build/test behavior if 3.6.2 differs from 3.6.1.
> 
> **Overview**
> Updates the Windows CI OpenSSL install step in `.github/actions/install-openssl/action.yml` to pin Chocolatey OpenSSL from `3.6.1` to `3.6.2`, unblocking Windows jobs that fail due to the removed `3.6.1` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab815f5866099393a24e9cfa421ffdc34d32f347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->