### PR TITLE
feat: scaffold libs/server-sdk-dynamodb-source

### DIFF
--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -16,6 +16,7 @@ on:
           - libs/client-sdk:launchdarkly-cpp-client
           - libs/server-sdk:launchdarkly-cpp-server
           - libs/server-sdk-redis-source:launchdarkly-cpp-server-redis-source
+          - libs/server-sdk-dynamodb-source:launchdarkly-cpp-server-dynamodb-source
 
 name: Publish SDK Artifacts
 

--- a/.github/workflows/server-dynamodb.yml
+++ b/.github/workflows/server-dynamodb.yml
@@ -1,0 +1,60 @@
+name: libs/server-sdk-dynamodb-source
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md' # Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [ "main", "feat/**" ]
+    paths-ignore:
+      - '**.md'
+  schedule:
+    # Run daily at midnight PST
+    - cron: '0 8 * * *'
+
+jobs:
+  build-dynamodb:
+    runs-on: ubuntu-22.04
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: ./.github/actions/ci
+        with:
+          cmake_target: launchdarkly-cpp-server-dynamodb-source
+          # No tests yet; PR 1 is scaffold-only and proves the AWS SDK builds.
+          run_tests: false
+          # AWS C++ SDK requires libcurl at link time on Linux/macOS.
+          install_curl: true
+          simulate_release: false
+  build-dynamodb-mac:
+    runs-on: macos-15
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: ./.github/actions/ci
+        with:
+          cmake_target: launchdarkly-cpp-server-dynamodb-source
+          platform_version: 12
+          run_tests: false
+          install_curl: true
+          simulate_release: false
+  build-dynamodb-windows:
+    runs-on: windows-2022
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      # https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      - uses: ./.github/actions/ci
+        env:
+          BOOST_LIBRARY_DIR: 'C:\local\boost_1_87_0\lib64-msvc-14.3'
+          BOOST_LIBRARYDIR: 'C:\local\boost_1_87_0\lib64-msvc-14.3'
+          Boost_DIR: 'C:\local\boost_1_87_0\lib64-msvc-14.3\cmake\Boost-1.87.0'
+        with:
+          cmake_target: launchdarkly-cpp-server-dynamodb-source
+          platform_version: 2022
+          toolset: msvc
+          run_tests: false
+          install_curl: true
+          simulate_windows_release: false

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,6 +5,7 @@
   "libs/internal": "0.13.0",
   "libs/server-sdk": "3.10.1",
   "libs/server-sdk-redis-source": "2.2.2",
+  "libs/server-sdk-dynamodb-source": "0.1.0",
   "libs/server-sdk-otel": "0.1.1",
   "libs/networking": "0.2.0"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,8 @@ option(LD_BUILD_EXAMPLES "Build hello-world examples." ON)
 
 option(LD_BUILD_REDIS_SUPPORT "Build redis support." OFF)
 
+option(LD_BUILD_DYNAMODB_SUPPORT "Build DynamoDB support." OFF)
+
 option(LD_BUILD_OTEL_SUPPORT "Build OpenTelemetry integration." OFF)
 
 option(LD_CURL_NETWORKING "Enable CURL-based networking for SSE client (alternative to Boost.Beast/Foxy)" OFF)
@@ -221,6 +223,11 @@ add_subdirectory(libs/server-sent-events)
 if (LD_BUILD_REDIS_SUPPORT)
     message("LaunchDarkly: building server-side redis support")
     add_subdirectory(libs/server-sdk-redis-source)
+endif ()
+
+if (LD_BUILD_DYNAMODB_SUPPORT)
+    message("LaunchDarkly: building server-side DynamoDB support")
+    add_subdirectory(libs/server-sdk-dynamodb-source)
 endif ()
 
 if (LD_BUILD_OTEL_SUPPORT)

--- a/cmake/aws-sdk-cpp.cmake
+++ b/cmake/aws-sdk-cpp.cmake
@@ -10,11 +10,6 @@ set(BUILD_ONLY "dynamodb" CACHE STRING "" FORCE)
 set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(AUTORUN_UNIT_TESTS OFF CACHE BOOL "" FORCE)
 
-# Match the static-library default the rest of the SDK uses. When LD_BUILD_SHARED_LIBS
-# is ON at the top level, the surrounding CMake script may flip BUILD_SHARED_LIBS;
-# this cache entry only sets the default.
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
 # Don't install the AWS SDK headers/libs alongside our own.
 set(AWS_SDK_WARNINGS_ARE_ERRORS OFF CACHE BOOL "" FORCE)
 

--- a/cmake/aws-sdk-cpp.cmake
+++ b/cmake/aws-sdk-cpp.cmake
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.11)
+
+include(FetchContent)
+
+# Limit the AWS SDK build to just the DynamoDB service client.
+# Without this, the SDK builds ~50 service clients and CI time becomes untenable.
+set(BUILD_ONLY "dynamodb" CACHE STRING "" FORCE)
+
+# We don't want to build or run the AWS SDK's own tests.
+set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(AUTORUN_UNIT_TESTS OFF CACHE BOOL "" FORCE)
+
+# Match the static-library default the rest of the SDK uses. When LD_BUILD_SHARED_LIBS
+# is ON at the top level, the surrounding CMake script may flip BUILD_SHARED_LIBS;
+# this cache entry only sets the default.
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+# Don't install the AWS SDK headers/libs alongside our own.
+set(AWS_SDK_WARNINGS_ARE_ERRORS OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(aws-sdk-cpp
+        GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
+        # 1.11.805
+        GIT_TAG ecae762dfdddf9b538c1b490007f4dd5aa16a9bb
+        # aws-sdk-cpp uses git submodules for aws-crt-cpp and the underlying
+        # AWS C SDK libraries; FetchContent must clone them recursively.
+        GIT_SUBMODULES_RECURSE TRUE
+        OVERRIDE_FIND_PACKAGE
+)
+
+FetchContent_MakeAvailable(aws-sdk-cpp)

--- a/libs/server-sdk-dynamodb-source/CHANGELOG.md
+++ b/libs/server-sdk-dynamodb-source/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/libs/server-sdk-dynamodb-source/CMakeLists.txt
+++ b/libs/server-sdk-dynamodb-source/CMakeLists.txt
@@ -1,0 +1,29 @@
+# This project aims to follow modern cmake guidelines, e.g.
+# https://cliutils.gitlab.io/modern-cmake
+
+# Required for Apple Silicon support.
+cmake_minimum_required(VERSION 3.19)
+
+project(
+        LaunchDarklyCPPServerDynamoDBSource
+        VERSION 0.1.0 # {x-release-please-version}
+        DESCRIPTION "LaunchDarkly C++ Server SDK DynamoDB Source"
+        LANGUAGES CXX C
+)
+
+set(LIBNAME "launchdarkly-cpp-server-dynamodb-source")
+
+# If this project is the main CMake project (as opposed to being included via add_subdirectory)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Disable C++ extensions for portability.
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    # Enable folder support in IDEs.
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+endif ()
+
+# Needed to fetch external dependencies.
+include(FetchContent)
+
+include(${CMAKE_FILES}/aws-sdk-cpp.cmake)
+
+add_subdirectory(src)

--- a/libs/server-sdk-dynamodb-source/Doxyfile
+++ b/libs/server-sdk-dynamodb-source/Doxyfile
@@ -1,0 +1,94 @@
+# Doxyfile 1.8.17
+
+# This file describes the settings to be used by the documentation system
+# doxygen (www.doxygen.org) for a project.
+#
+# All text after a double hash (##) is considered a comment and is placed in
+# front of the TAG it is preceding.
+#
+# All text after a single hash (#) is considered a comment and will be ignored.
+# The format is:
+# TAG = value [value, ...]
+# For lists, items can also be appended using:
+# TAG += value [value, ...]
+# Values that contain spaces should be placed between quotes (\" \").
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+
+# This tag specifies the encoding used for all characters in the configuration
+# file that follow. The default is UTF-8 which is also the encoding used for all
+# text before the first occurrence of this tag. Doxygen uses libiconv (or the
+# iconv built into libc) for the transcoding. See
+# https://www.gnu.org/software/libiconv/ for the list of possible encodings.
+# The default value is: UTF-8.
+
+DOXYFILE_ENCODING      = UTF-8
+
+# The PROJECT_NAME tag is a single word (or a sequence of words surrounded by
+# double-quotes, unless you are using Doxywizard) that should identify the
+# project for which the documentation is generated. This name is used in the
+# title of most generated pages and in a few other places.
+# The default value is: My Project.
+
+PROJECT_NAME           = "C++ Server-Side SDK DynamoDB Source"
+
+# Using the PROJECT_BRIEF tag one can provide an optional one line description
+# for a project that appears at the top of each page and should give viewer a
+# quick idea about the purpose of the project. Keep the description short.
+
+PROJECT_BRIEF          = "Provide SDK data via DynamoDB"
+
+# The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
+# into which the generated documentation will be written. If a relative path is
+# entered, it will be relative to the location where doxygen was started. If
+# left blank the current directory will be used.
+
+OUTPUT_DIRECTORY       = docs
+
+# If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
+# to include (a tag file for) the STL sources as input, then you should set this
+# tag to YES in order to let doxygen match functions declarations and
+# definitions whose arguments contain STL classes (e.g. func(std::string);
+# versus func(std::string) {}). This also make the inheritance and collaboration
+# diagrams that involve STL classes more complete and accurate.
+# The default value is: NO.
+
+BUILTIN_STL_SUPPORT    = YES
+
+# When TYPEDEF_HIDES_STRUCT tag is enabled, a typedef of a struct, union, or
+# enum is documented as struct, union, or enum with the name of the typedef. So
+# typedef struct TypeS {} TypeT, will appear in the documentation as a struct
+# with name TypeT. When disabled the typedef will appear as a member of a file,
+# namespace, or class. And the struct will be named TypeS. This can typically be
+# useful for C code in case the coding convention dictates that all compound
+# types are typedef'ed and only the typedef is referenced, never the tag name.
+# The default value is: NO.
+
+TYPEDEF_HIDES_STRUCT   = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+
+# The INPUT tag is used to specify the files and/or directories that contain
+# documented source files. You may enter file names like myfile.cpp or
+# directories like /usr/src/myproject. Separate the files or directories with
+# spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
+# Note: If this tag is empty the current directory is searched.
+
+INPUT                  = include src docs
+
+# The RECURSIVE tag can be used to specify whether or not subdirectories should
+# be searched for input files as well.
+# The default value is: NO.
+
+RECURSIVE              = YES
+
+# If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
+# is part of the input, its contents will be placed on the main page
+# (index.html). This can be useful if you have a project on for instance GitHub
+# and want to reuse the introduction page also for the doxygen output.
+
+USE_MDFILE_AS_MAINPAGE = ./docs/doc.md

--- a/libs/server-sdk-dynamodb-source/README.md
+++ b/libs/server-sdk-dynamodb-source/README.md
@@ -1,0 +1,129 @@
+LaunchDarkly Server-Side SDK - DynamoDB Source for C/C++
+===================================
+
+[![Actions Status](https://github.com/launchdarkly/cpp-sdks/actions/workflows/server-dynamodb.yml/badge.svg)](https://github.com/launchdarkly/cpp-sdks/actions/workflows/server-dynamodb.yml)
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/cpp-sdks/libs/server-sdk-dynamodb-source/docs/html/)
+
+The LaunchDarkly Server-Side SDK DynamoDB Source for C/C++ is designed for use with the Server-Side SDK.
+
+This component will allow the Server-Side SDK to retrieve feature flag configurations from DynamoDB, rather than
+from LaunchDarkly.
+
+> [!NOTE]
+> This library currently contains only scaffolding. The functional `DynamoDBDataSource` and Big Segments store
+> implementation will land in subsequent releases.
+
+LaunchDarkly overview
+-------------------------
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves trillions of feature flags
+daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started)
+using LaunchDarkly today!
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
+
+Compatibility
+-------------------------
+
+This component is compatible with POSIX environments (Linux, OS X, BSD) and Windows.
+
+Getting started
+---------------
+
+Download a release archive from
+the [Github releases](https://github.com/launchdarkly/cpp-sdks/releases?q=cpp-server-dynamodb&expanded=true) for use in
+your project.
+
+Refer to the [SDK documentation][reference-guide] for complete instructions on
+installing and using the SDK.
+
+### Incorporating the DynamoDB Source
+
+The component can be used via a C++ or C interface and can be incorporated via a static library or shared object. The
+static library and shared object each have their own use cases and limitations.
+
+The static library supports both the C++ and C interface. When using the static library, you should ensure that it is
+compiled using a compatible configuration and toolchain. For instance, when using MSVC, it needs to be using the same
+runtime library.
+
+The C++ API does not have a stable ABI, so if this is important to you, consider using the shared object with the C API.
+
+The shared library (so, DLL, dylib), only supports the C interface.
+
+The examples here are to help with getting started, but generally speaking this component should be incorporated using
+your
+build system (CMake for instance).
+
+### CMake Usage
+
+When configuring the SDK via CMake, you need to explicitly enable this component (example):
+
+```
+cmake -GNinja -D LD_BUILD_DYNAMODB_SUPPORT=ON ..
+```
+
+It is disabled by default to avoid pulling in the `aws-sdk-cpp` dependency that this component is
+implemented with.
+
+This will expose the `launchdarkly::server_dynamodb_source` target.
+
+Next, link the target to your executable or library:
+
+```cmake
+target_link_libraries(my-target PRIVATE launchdarkly::server_dynamodb_source)
+```
+
+This will cause `launchdarkly::server` to be linked as well.
+
+Learn more
+-----------
+
+Read our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly.
+You can also head straight to
+the [complete reference guide for this SDK][reference-guide].
+
+Testing
+-------
+
+We run integration tests for all our SDKs using a centralized test harness. This approach gives us the ability to test
+for consistency across SDKs, as well as test networking behavior in a long-running application. These tests cover each
+method in the SDK, and verify that event sending, flag evaluation, stream reconnection, and other aspects of the SDK all
+behave correctly.
+
+Contributing
+------------
+
+We encourage pull requests and other contributions from the community. Read
+our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
+
+Verifying SDK build provenance with the SLSA framework
+------------
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](../../PROVENANCE.md).
+
+About LaunchDarkly
+-----------
+
+* LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to
+  iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.
+  With LaunchDarkly, you can:
+    * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group),
+      gathering feedback and bug reports from real-world use cases.
+    * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on
+      key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+    * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy,
+      or even restart the application with a changed configuration file.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get
+      access to more features than users in the 'silver' plan). Disable parts of your application to facilitate
+      maintenance, without taking everything offline.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies.
+  Read [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
+* Explore LaunchDarkly
+    * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
+    * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and
+      SDK reference guides
+    * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API
+      documentation
+    * [blog.launchdarkly.com](https://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product
+      updates
+
+[reference-guide]: https://docs.launchdarkly.com/sdk/server-side/c-c--

--- a/libs/server-sdk-dynamodb-source/docs/doc.md
+++ b/libs/server-sdk-dynamodb-source/docs/doc.md
@@ -1,0 +1,7 @@
+# Overview
+
+The Server-side SDK DynamoDB Source can be used as a source of SDK data
+instead of the normal LaunchDarkly Streaming or Polling data sources.
+
+This library is currently a scaffold; the public API will land in a
+subsequent release.

--- a/libs/server-sdk-dynamodb-source/include/launchdarkly/server_side/integrations/dynamodb/dynamodb_source.hpp
+++ b/libs/server-sdk-dynamodb-source/include/launchdarkly/server_side/integrations/dynamodb/dynamodb_source.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace launchdarkly::server_side::integrations {
+
+// Scaffold-only entry point. The real DynamoDBDataSource class will replace
+// this in a subsequent PR; this declaration exists so the smoke .cpp has
+// something to define and the library produces a non-empty archive.
+void DynamoDBSourceLinkSmoke();
+
+}  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk-dynamodb-source/package.json
+++ b/libs/server-sdk-dynamodb-source/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@launchdarkly/cpp-server-dynamodb-source",
+  "description": "This package.json exists for modeling dependencies for the release process.",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@launchdarkly/cpp-server": "3.10.1"
+  }
+}

--- a/libs/server-sdk-dynamodb-source/src/CMakeLists.txt
+++ b/libs/server-sdk-dynamodb-source/src/CMakeLists.txt
@@ -1,0 +1,55 @@
+file(GLOB HEADER_LIST CONFIGURE_DEPENDS
+        "${LaunchDarklyCPPServerDynamoDBSource_SOURCE_DIR}/include/launchdarkly/server_side/integrations/dynamodb/*.hpp"
+)
+
+if (LD_BUILD_SHARED_LIBS)
+    message(STATUS "LaunchDarkly: building server-sdk-dynamodb-source as shared library")
+    add_library(${LIBNAME} SHARED)
+else ()
+    message(STATUS "LaunchDarkly: building server-sdk-dynamodb-source as static library")
+    add_library(${LIBNAME} STATIC)
+endif ()
+
+target_sources(${LIBNAME}
+        PRIVATE
+        ${HEADER_LIST}
+        dynamodb_source.cpp
+)
+
+
+target_link_libraries(${LIBNAME}
+        PUBLIC launchdarkly::server
+        PRIVATE
+        aws-cpp-sdk-dynamodb
+        aws-cpp-sdk-core
+)
+
+
+add_library(launchdarkly::server_dynamodb_source ALIAS ${LIBNAME})
+
+if (LD_BUILD_SHARED_LIBS AND MSVC)
+    install(FILES $<TARGET_PDB_FILE:${LIBNAME}> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
+endif ()
+
+# Using PUBLIC_HEADERS would flatten the include.
+# This will preserve it, but dependencies must do the same.
+
+install(DIRECTORY "${LaunchDarklyCPPServerDynamoDBSource_SOURCE_DIR}/include/launchdarkly"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Need the public headers to build.
+target_include_directories(${LIBNAME}
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Minimum C++ standard needed for consuming the public API is C++17.
+target_compile_features(${LIBNAME} PUBLIC cxx_std_17)
+
+
+install(
+        TARGETS ${LIBNAME} OPTIONAL
+        EXPORT ${LD_TARGETS_EXPORT_NAME}
+)

--- a/libs/server-sdk-dynamodb-source/src/dynamodb_source.cpp
+++ b/libs/server-sdk-dynamodb-source/src/dynamodb_source.cpp
@@ -1,0 +1,15 @@
+#include <launchdarkly/server_side/integrations/dynamodb/dynamodb_source.hpp>
+
+#include <aws/dynamodb/DynamoDBClient.h>
+
+namespace launchdarkly::server_side::integrations {
+
+// Touch an Aws::DynamoDB type so the linker actually pulls in the AWS SDK and
+// we prove the dependency wires up. This function is intentionally never
+// called; it exists solely to validate the CMake/CI scaffolding.
+void DynamoDBSourceLinkSmoke() {
+    Aws::DynamoDB::DynamoDBClient* unused = nullptr;
+    (void)unused;
+}
+
+}  // namespace launchdarkly::server_side::integrations

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,6 +27,13 @@
         "CMakeLists.txt"
       ]
     },
+    "libs/server-sdk-dynamodb-source": {
+      "component": "launchdarkly-cpp-server-dynamodb-source",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        "CMakeLists.txt"
+      ]
+    },
     "libs/server-sdk-otel": {
       "component": "launchdarkly-cpp-server-otel",
       "bump-minor-pre-major": true,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,6 +25,12 @@ if [ "$1" == "launchdarkly-cpp-server-redis-source" ] || [ "$1" == "gtest_launch
   build_redis="ON"
 fi
 
+# Special case: enabling DynamoDB support fetches the AWS C++ SDK at configuration time. Only enable when asked.
+build_dynamodb="OFF"
+if [ "$1" == "launchdarkly-cpp-server-dynamodb-source" ] || [ "$1" == "gtest_launchdarkly-cpp-server-dynamodb-source" ]; then
+  build_dynamodb="ON"
+fi
+
 # Check for CURL networking option
 build_curl="OFF"
 if [ "$3" == "true" ]; then
@@ -53,6 +59,7 @@ echo "BUILD_TESTING: $2"
 echo "LD_BUILD_UNIT_TESTS: $2"
 echo "LD_BUILD_CONTRACT_TESTS: $2"
 echo "LD_BUILD_REDIS_SUPPORT: $build_redis"
+echo "LD_BUILD_DYNAMODB_SUPPORT: $build_dynamodb"
 echo "LD_CURL_NETWORKING: $build_curl"
 echo "LD_BUILD_OTEL_SUPPORT: $build_otel"
 echo "LD_BUILD_OTEL_FETCH_DEPS: $build_otel_fetch_deps"
@@ -64,6 +71,7 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE="$build_type" \
                -D LD_BUILD_UNIT_TESTS="$2" \
                -D LD_BUILD_CONTRACT_TESTS="$2" \
                -D LD_BUILD_REDIS_SUPPORT="$build_redis" \
+               -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" \
                -D LD_CURL_NETWORKING="$build_curl" \
                -D LD_BUILD_OTEL_SUPPORT="$build_otel" \
                -D LD_BUILD_OTEL_FETCH_DEPS="$build_otel_fetch_deps" ..


### PR DESCRIPTION
  ## Summary

  Scaffolds a new `libs/server-sdk-dynamodb-source` library that mirrors `libs/server-sdk-redis-source`, plus the `aws-sdk-cpp` dependency wiring.

  **No functional code.** Proves that the AWS C++ SDK builds cleanly in our CMake/CI setup.
  
  ## What's in the box

  - **`cmake/aws-sdk-cpp.cmake`** — FetchContent for `aws-sdk-cpp@1.11.805` with `BUILD_ONLY=dynamodb`, `ENABLE_TESTING=OFF`, and `GIT_SUBMODULES_RECURSE TRUE` (the SDK still uses submodules for `aws-crt-cpp` and the underlying AWS C runtime libs). Build pruned to `aws-cpp-sdk-dynamodb` + `aws-cpp-sdk-core` + the CRT stack — no other AWS service clients compile.
  - **`libs/server-sdk-dynamodb-source/`** — CMake / package / Doxygen / README skeleton paralleling `server-sdk-redis-source`. The lone `dynamodb_source.cpp` references `Aws::DynamoDB::DynamoDBClient` inside a never-called function so the link against `aws-cpp-sdk-dynamodb` is exercised by this PR rather than deferred.
  - **`LD_BUILD_DYNAMODB_SUPPORT`** CMake option (default OFF) wired into the top-level `CMakeLists.txt`.
  - **`scripts/build.sh`** — special-cases the new target to flip `LD_BUILD_DYNAMODB_SUPPORT=ON`, matching the existing redis/otel pattern that the `.github/actions/ci` composite already uses.
  - **`.github/workflows/server-dynamodb.yml`** — build-only CI matrix on `ubuntu-22.04` / `macos-15` / `windows-2022`, so "AWS SDK builds cleanly in CI" is actually verified by this PR.
  - **`release-please-config.json`** + **`.release-please-manifest.json`** — new package registered at `0.1.0` with `bump-minor-pre-major: true` (matching `server-sdk-otel`, the only other pre-stable package).
  - **`.github/workflows/manual-sdk-release-artifacts.yml`** — new package added to the manual release `options`.

  ## Out of scope (deferred to later PRs)

  - `DynamoDBDataSource` implementation
  - `IBigSegmentStore` interface + DynamoDB/Redis big-segment implementations
  - Per-package release / SLSA-provenance jobs in `.github/workflows/release-please.yml` — deferred until the package has functional artifacts to release.

  ## Test plan
  
  - [x] CI is green on Linux, macOS, and Windows. Linux is verified locally; **Mac and Windows are first verified by CI on this PR**
  - [x] Local build sanity-check passes: `cmake -G Ninja -B build -DLD_BUILD_DYNAMODB_SUPPORT=ON .` then `cmake --build build --target 
  launchdarkly-cpp-server-dynamodb-source` produces `liblaunchdarkly-cpp-server-dynamodb-source.a`.
  - [x] Default-off check: a vanilla `cmake -G Ninja -B build .` produces no `dynamodb` or `aws-sdk` targets in `ninja -t targets all`.

  ## Risks / things reviewers should look at
  
  - The `aws-sdk-cpp` tag pin (`1.11.805`) is recent.
  - AWS SDK adds noticeable cold-build time; ccache/sccache in CI will absorb subsequent runs. If this becomes a problem we can revisit pre-built artifacts later.
  - `scripts/build.sh` now has three "special-case" branches (redis, otel, dynamodb).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new optional build path that fetches and links the AWS C++ SDK via CMake/FetchContent, which can impact build times and CI stability across platforms. Functional behavior is minimal, but release/CI plumbing changes could affect packaging if misconfigured.
> 
> **Overview**
> Adds a new **scaffold** library, `libs/server-sdk-dynamodb-source`, with a placeholder API and CMake target (`launchdarkly::server_dynamodb_source`) that links against `aws-sdk-cpp` (DynamoDB-only) to validate dependency wiring.
> 
> Wires this component into the repo’s build and release tooling: new `LD_BUILD_DYNAMODB_SUPPORT` toggle in the top-level `CMakeLists.txt`, `scripts/build.sh` special-casing to enable it only for the DynamoDB targets, a dedicated CI workflow (`server-dynamodb.yml`) for Linux/macOS/Windows build-only checks, and updates to `release-please` + the manual artifact release workflow to recognize the new package at version `0.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72555dee0aa70c267dcbf2efea65c43691d2cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->