### PR TITLE
feat: orchestrator switches to FDv1 fallback on directive

### DIFF
--- a/libs/internal/include/launchdarkly/serialization/json_fdv2_events.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_fdv2_events.hpp
@@ -47,8 +47,6 @@ struct Goodbye {
     std::optional<std::string> reason;
     // If set, indicates an FDv1 fallback directive with this TTL in seconds.
     std::optional<std::int64_t> protocol_fallback_ttl;
-    // If set, indicates a Retry-After equivalent in seconds.
-    std::optional<std::int64_t> retry_after;
 };
 
 struct FDv2Error {

--- a/libs/internal/include/launchdarkly/serialization/json_fdv2_events.hpp
+++ b/libs/internal/include/launchdarkly/serialization/json_fdv2_events.hpp
@@ -45,6 +45,10 @@ struct PayloadTransferred {
 
 struct Goodbye {
     std::optional<std::string> reason;
+    // If set, indicates an FDv1 fallback directive with this TTL in seconds.
+    std::optional<std::int64_t> protocol_fallback_ttl;
+    // If set, indicates a Retry-After equivalent in seconds.
+    std::optional<std::int64_t> retry_after;
 };
 
 struct FDv2Error {

--- a/libs/internal/src/serialization/json_fdv2_events.cpp
+++ b/libs/internal/src/serialization/json_fdv2_events.cpp
@@ -132,6 +132,9 @@ tl::expected<std::optional<Goodbye>, JsonError> tag_invoke(
     Goodbye goodbye{};
 
     PARSE_CONDITIONAL_FIELD(goodbye.reason, obj, "reason");
+    PARSE_CONDITIONAL_FIELD(goodbye.protocol_fallback_ttl, obj,
+                            "protocolFallbackTTL");
+    PARSE_CONDITIONAL_FIELD(goodbye.retry_after, obj, "retryAfter");
 
     return goodbye;
 }

--- a/libs/internal/src/serialization/json_fdv2_events.cpp
+++ b/libs/internal/src/serialization/json_fdv2_events.cpp
@@ -134,7 +134,6 @@ tl::expected<std::optional<Goodbye>, JsonError> tag_invoke(
     PARSE_CONDITIONAL_FIELD(goodbye.reason, obj, "reason");
     PARSE_CONDITIONAL_FIELD(goodbye.protocol_fallback_ttl, obj,
                             "protocolFallbackTTL");
-    PARSE_CONDITIONAL_FIELD(goodbye.retry_after, obj, "retryAfter");
 
     return goodbye;
 }

--- a/libs/internal/tests/fdv2_serialization_test.cpp
+++ b/libs/internal/tests/fdv2_serialization_test.cpp
@@ -373,16 +373,6 @@ TEST(GoodbyeTests, DeserializesWithProtocolFallbackTtl) {
     ASSERT_EQ(60, *result.value()->protocol_fallback_ttl);
 }
 
-TEST(GoodbyeTests, DeserializesWithRetryAfter) {
-    auto result =
-        boost::json::value_to<tl::expected<std::optional<Goodbye>, JsonError>>(
-            boost::json::parse(R"({"retryAfter":5})"));
-    ASSERT_TRUE(result);
-    ASSERT_TRUE(result.value());
-    ASSERT_TRUE(result.value()->retry_after);
-    ASSERT_EQ(5, *result.value()->retry_after);
-}
-
 TEST(GoodbyeTests, WrongTypeReturnsSchemaFailure) {
     auto result =
         boost::json::value_to<tl::expected<std::optional<Goodbye>, JsonError>>(

--- a/libs/internal/tests/fdv2_serialization_test.cpp
+++ b/libs/internal/tests/fdv2_serialization_test.cpp
@@ -363,6 +363,26 @@ TEST(GoodbyeTests, DeserializesWithoutReason) {
     ASSERT_FALSE(result.value()->reason);
 }
 
+TEST(GoodbyeTests, DeserializesWithProtocolFallbackTtl) {
+    auto result =
+        boost::json::value_to<tl::expected<std::optional<Goodbye>, JsonError>>(
+            boost::json::parse(R"({"protocolFallbackTTL":60})"));
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result.value());
+    ASSERT_TRUE(result.value()->protocol_fallback_ttl);
+    ASSERT_EQ(60, *result.value()->protocol_fallback_ttl);
+}
+
+TEST(GoodbyeTests, DeserializesWithRetryAfter) {
+    auto result =
+        boost::json::value_to<tl::expected<std::optional<Goodbye>, JsonError>>(
+            boost::json::parse(R"({"retryAfter":5})"));
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(result.value());
+    ASSERT_TRUE(result.value()->retry_after);
+    ASSERT_EQ(5, *result.value()->retry_after);
+}
+
 TEST(GoodbyeTests, WrongTypeReturnsSchemaFailure) {
     auto result =
         boost::json::value_to<tl::expected<std::optional<Goodbye>, JsonError>>(

--- a/libs/server-sdk/src/data_interfaces/source/fdv2_source_result.hpp
+++ b/libs/server-sdk/src/data_interfaces/source/fdv2_source_result.hpp
@@ -5,11 +5,50 @@
 #include <launchdarkly/data_model/change_set.hpp>
 #include <launchdarkly/data_sources/data_source_status_error_info.hpp>
 
+#include <charconv>
+#include <chrono>
+#include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <variant>
 
 namespace launchdarkly::server_side::data_interfaces {
+
+/**
+ * Server-directed instruction to fall back to FDv1, carried alongside any
+ * FDv2 source result whose underlying transport observed it (e.g. an
+ * X-LD-FD-Fallback: true response header).
+ */
+struct FDv1FallbackDirective {
+    /** Default TTL used when the directive carries no TTL of its own. */
+    static constexpr std::chrono::seconds kDefaultTtl = std::chrono::hours(1);
+
+    /**
+     * Parse the value of an X-LD-FD-Fallback-TTL header (or equivalent
+     * protocolFallbackTTL field from a goodbye message). Returns
+     * std::nullopt if the value is malformed.
+     */
+    static std::optional<std::chrono::seconds> ParseTtl(
+        std::string_view value) {
+        std::uint64_t seconds = 0;
+        auto const* begin = value.data();
+        auto const* end = begin + value.size();
+        auto const [ptr, ec] = std::from_chars(begin, end, seconds);
+        if (ec != std::errc{} || ptr != end) {
+            return std::nullopt;
+        }
+        return std::chrono::seconds(seconds);
+    }
+
+    /**
+     * How long to stay on FDv1 before attempting to recover to FDv2.
+     * A value of 0 seconds means the SDK should remain on FDv1
+     * indefinitely.
+     */
+    std::chrono::seconds ttl = kDefaultTtl;
+};
 
 /**
  * Result returned by IFDv2Initializer::Run and IFDv2Synchronizer::Next.
@@ -56,10 +95,9 @@ struct FDv2SourceResult {
     Value value;
 
     /**
-     * If true, the server signaled (via the X-LD-FD-Fallback response header)
-     * that the client should fall back to FDv1.
+     * Set if the underlying transport observed an FDv1 fallback directive.
      */
-    bool fdv1_fallback = false;
+    std::optional<FDv1FallbackDirective> fdv1_fallback;
 };
 
 }  // namespace launchdarkly::server_side::data_interfaces

--- a/libs/server-sdk/src/data_interfaces/source/ifdv2_synchronizer_factory.hpp
+++ b/libs/server-sdk/src/data_interfaces/source/ifdv2_synchronizer_factory.hpp
@@ -14,6 +14,8 @@ class IFDv2SynchronizerFactory {
    public:
     virtual std::unique_ptr<IFDv2Synchronizer> Build() = 0;
 
+    [[nodiscard]] virtual bool IsFDv1Fallback() const { return false; }
+
     virtual ~IFDv2SynchronizerFactory() = default;
     IFDv2SynchronizerFactory(IFDv2SynchronizerFactory const&) = delete;
     IFDv2SynchronizerFactory(IFDv2SynchronizerFactory&&) = delete;

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -191,9 +191,16 @@ void FDv2DataSystem::OnInitializerResult(
             return;
         }
         if (result.fdv1_fallback) {
-            LD_LOG(logger_, LogLevel::kInfo)
-                << Identity() << ": FDv1 fallback engaged";
             source_manager_.SwitchToFDv1Fallback();
+            if (source_manager_.AvailableSynchronizerCount() > 0) {
+                LD_LOG(logger_, LogLevel::kInfo)
+                    << Identity() << ": FDv1 fallback engaged";
+            } else {
+                LD_LOG(logger_, LogLevel::kWarn)
+                    << Identity()
+                    << ": FDv1 fallback directive received; no FDv1 "
+                       "fallback synchronizer configured";
+            }
             got_basis = true;
         }
     }
@@ -369,9 +376,16 @@ void FDv2DataSystem::OnSynchronizerResult(
             return;
         }
         if (result.fdv1_fallback) {
-            LD_LOG(logger_, LogLevel::kInfo)
-                << Identity() << ": FDv1 fallback engaged";
             source_manager_.SwitchToFDv1Fallback();
+            if (source_manager_.AvailableSynchronizerCount() > 0) {
+                LD_LOG(logger_, LogLevel::kInfo)
+                    << Identity() << ": FDv1 fallback engaged";
+            } else {
+                LD_LOG(logger_, LogLevel::kWarn)
+                    << Identity()
+                    << ": FDv1 fallback directive received; no FDv1 "
+                       "fallback synchronizer configured";
+            }
             active_synchronizer_.reset();
             active_conditions_.reset();
             advance = true;

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -68,7 +68,6 @@ void FDv2DataSystem::Close() {
     if (active_conditions_) {
         active_conditions_->Close();
     }
-    status_manager_->SetState(DataSourceStatus::DataSourceState::kOff);
 }
 
 std::shared_ptr<data_model::FlagDescriptor> FDv2DataSystem::GetFlag(

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -198,6 +198,9 @@ void FDv2DataSystem::OnInitializerResult(
             if (source_manager_.AvailableSynchronizerCount() > 0) {
                 LD_LOG(logger_, LogLevel::kInfo)
                     << Identity() << ": FDv1 fallback engaged";
+                // No basis yet; reuse the flag to fall through to
+                // StartSynchronizers so the FDv1 fallback synchronizer can
+                // produce it.
                 got_basis = true;
             } else {
                 LD_LOG(logger_, LogLevel::kWarn)

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -185,6 +185,12 @@ void FDv2DataSystem::OnInitializerResult(
         if (closed_ || got_shutdown) {
             return;
         }
+        if (result.fdv1_fallback) {
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": FDv1 fallback engaged";
+            source_manager_.SwitchToFDv1Fallback();
+            got_basis = true;
+        }
     }
 
     if (got_basis) {
@@ -349,7 +355,14 @@ void FDv2DataSystem::OnSynchronizerResult(
             active_conditions_.reset();
             return;
         }
-        if (advance) {
+        if (result.fdv1_fallback) {
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": FDv1 fallback engaged";
+            source_manager_.SwitchToFDv1Fallback();
+            active_synchronizer_.reset();
+            active_conditions_.reset();
+            advance = true;
+        } else if (advance) {
             source_manager_.BlockCurrentSynchronizer();
             active_synchronizer_.reset();
             active_conditions_.reset();

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -43,6 +43,7 @@ FDv2DataSystem::FDv2DataSystem(
       store_(),
       change_notifier_(store_, store_),
       initialize_called_(false),
+      last_logged_synchronizer_interrupted_(false),
       closed_(false),
       selector_(),
       initializer_index_(0),
@@ -121,6 +122,9 @@ void FDv2DataSystem::RunNextInitializer() {
         } else {
             auto& factory = initializer_factories_[initializer_index_++];
             active_initializer_ = factory->Build();
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": starting initializer "
+                << active_initializer_->Identity();
             active_initializer_->Run().Then(
                 [this](data_interfaces::FDv2SourceResult const& result)
                     -> std::monostate {
@@ -152,6 +156,8 @@ void FDv2DataSystem::OnInitializerResult(
                     cs.change_set.selector.value.has_value();
                 ApplyChangeSet(std::move(cs.change_set));
                 if (has_selector) {
+                    LD_LOG(logger_, LogLevel::kInfo)
+                        << Identity() << ": initializer succeeded";
                     got_basis = true;
                 }
             },
@@ -211,6 +217,10 @@ void FDv2DataSystem::StartSynchronizers() {
         }
         active_synchronizer_ = source_manager_.NextSynchronizer();
         if (active_synchronizer_) {
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": starting synchronizer "
+                << active_synchronizer_->Identity();
+            last_logged_synchronizer_interrupted_.store(false);
             active_conditions_ = BuildActiveConditions();
         } else {
             exhausted = true;
@@ -320,33 +330,37 @@ void FDv2DataSystem::OnSynchronizerResult(
     bool got_shutdown = false;
     bool advance = false;
 
-    std::visit(overloaded{
-                   [&](Result::ChangeSet& cs) {
-                       ApplyChangeSet(std::move(cs.change_set));
-                   },
-                   [&](Result::Shutdown&) { got_shutdown = true; },
-                   [&](Result::Interrupted const& iv) {
-                       LD_LOG(logger_, LogLevel::kWarn)
-                           << Identity() << ": synchronizer interrupted: "
-                           << iv.error.Message();
-                       status_manager_->SetState(
-                           DataSourceStatus::DataSourceState::kInterrupted,
-                           iv.error.Kind(), iv.error.Message());
-                   },
-                   [&](Result::TerminalError const& te) {
-                       LD_LOG(logger_, LogLevel::kWarn)
-                           << Identity() << ": synchronizer terminal error: "
-                           << te.error.Message();
-                       status_manager_->SetState(
-                           DataSourceStatus::DataSourceState::kInterrupted,
-                           te.error.Kind(), te.error.Message());
-                       advance = true;
-                   },
-                   [&](Result::Goodbye const&) {
-                       // The synchronizer handles this internally.
-                   },
-               },
-               result.value);
+    std::visit(
+        overloaded{
+            [&](Result::ChangeSet& cs) {
+                last_logged_synchronizer_interrupted_.store(false);
+                ApplyChangeSet(std::move(cs.change_set));
+            },
+            [&](Result::Shutdown&) { got_shutdown = true; },
+            [&](Result::Interrupted const& iv) {
+                if (!last_logged_synchronizer_interrupted_.exchange(true)) {
+                    LD_LOG(logger_, LogLevel::kInfo)
+                        << Identity()
+                        << ": synchronizer interrupted: " << iv.error.Message();
+                }
+                status_manager_->SetState(
+                    DataSourceStatus::DataSourceState::kInterrupted,
+                    iv.error.Kind(), iv.error.Message());
+            },
+            [&](Result::TerminalError const& te) {
+                LD_LOG(logger_, LogLevel::kWarn)
+                    << Identity()
+                    << ": synchronizer terminal error: " << te.error.Message();
+                status_manager_->SetState(
+                    DataSourceStatus::DataSourceState::kInterrupted,
+                    te.error.Kind(), te.error.Message());
+                advance = true;
+            },
+            [&](Result::Goodbye const&) {
+                // The synchronizer handles this internally.
+            },
+        },
+        result.value);
 
     {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -433,6 +433,11 @@ void FDv2DataSystem::ScheduleFDv2RetryLocked(std::chrono::seconds ttl) {
     if (ttl == std::chrono::seconds::zero()) {
         return;
     }
+    // Cancel any in-flight retry and start fresh; CancellationSource is
+    // one-shot, so reusing the same source for successive schedules would
+    // leak prior timers.
+    fdv1_fallback_retry_cancel_.Cancel();
+    fdv1_fallback_retry_cancel_ = async::CancellationSource{};
     LD_LOG(logger_, LogLevel::kInfo)
         << Identity() << ": FDv2 retry scheduled in " << ttl.count() << "s";
     async::Delay(ioc_, ttl, fdv1_fallback_retry_cancel_.GetToken())

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -375,7 +375,8 @@ void FDv2DataSystem::OnSynchronizerResult(
             active_conditions_.reset();
             return;
         }
-        if (result.fdv1_fallback) {
+        if (result.fdv1_fallback &&
+            !source_manager_.IsCurrentSynchronizerFDv1Fallback()) {
             source_manager_.SwitchToFDv1Fallback();
             if (source_manager_.AvailableSynchronizerCount() > 0) {
                 LD_LOG(logger_, LogLevel::kInfo)

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -1,6 +1,7 @@
 #include "fdv2_data_system.hpp"
 
 #include <launchdarkly/async/promise.hpp>
+#include <launchdarkly/async/timer.hpp>
 
 #include <boost/asio/post.hpp>
 
@@ -59,6 +60,7 @@ FDv2DataSystem::~FDv2DataSystem() {
 void FDv2DataSystem::Close() {
     std::lock_guard<std::mutex> lock(mutex_);
     closed_ = true;
+    fdv1_fallback_retry_cancel_.Cancel();
     if (active_initializer_) {
         active_initializer_->Close();
     }
@@ -147,6 +149,7 @@ void FDv2DataSystem::OnInitializerResult(
 
     bool got_basis = false;
     bool got_shutdown = false;
+    bool disconnected = false;
 
     std::visit(
         overloaded{
@@ -195,16 +198,25 @@ void FDv2DataSystem::OnInitializerResult(
             if (source_manager_.AvailableSynchronizerCount() > 0) {
                 LD_LOG(logger_, LogLevel::kInfo)
                     << Identity() << ": FDv1 fallback engaged";
+                got_basis = true;
             } else {
                 LD_LOG(logger_, LogLevel::kWarn)
                     << Identity()
                     << ": FDv1 fallback directive received; no FDv1 "
                        "fallback synchronizer configured";
+                disconnected = true;
             }
-            got_basis = true;
+            ScheduleFDv2RetryLocked(result.fdv1_fallback->ttl);
         }
     }
 
+    if (disconnected) {
+        status_manager_->SetState(
+            DataSourceStatus::DataSourceState::kInterrupted,
+            DataSourceStatus::ErrorInfo::ErrorKind::kUnknown,
+            "FDv1 fallback directive received; no FDv1 fallback configured");
+        return;
+    }
     if (got_basis) {
         StartSynchronizers();
     } else {
@@ -335,6 +347,7 @@ void FDv2DataSystem::OnSynchronizerResult(
 
     bool got_shutdown = false;
     bool advance = false;
+    bool disconnected = false;
 
     std::visit(
         overloaded{
@@ -378,18 +391,20 @@ void FDv2DataSystem::OnSynchronizerResult(
         if (result.fdv1_fallback &&
             !source_manager_.IsCurrentSynchronizerFDv1Fallback()) {
             source_manager_.SwitchToFDv1Fallback();
+            active_synchronizer_.reset();
+            active_conditions_.reset();
             if (source_manager_.AvailableSynchronizerCount() > 0) {
                 LD_LOG(logger_, LogLevel::kInfo)
                     << Identity() << ": FDv1 fallback engaged";
+                advance = true;
             } else {
                 LD_LOG(logger_, LogLevel::kWarn)
                     << Identity()
                     << ": FDv1 fallback directive received; no FDv1 "
                        "fallback synchronizer configured";
+                disconnected = true;
             }
-            active_synchronizer_.reset();
-            active_conditions_.reset();
-            advance = true;
+            ScheduleFDv2RetryLocked(result.fdv1_fallback->ttl);
         } else if (advance) {
             source_manager_.BlockCurrentSynchronizer();
             active_synchronizer_.reset();
@@ -397,11 +412,55 @@ void FDv2DataSystem::OnSynchronizerResult(
         }
     }
 
+    if (disconnected) {
+        status_manager_->SetState(
+            DataSourceStatus::DataSourceState::kInterrupted,
+            DataSourceStatus::ErrorInfo::ErrorKind::kUnknown,
+            "FDv1 fallback directive received; no FDv1 fallback configured");
+        return;
+    }
     if (advance) {
         StartSynchronizers();
     } else {
         RunSynchronizerNext();
     }
+}
+
+void FDv2DataSystem::ScheduleFDv2RetryLocked(std::chrono::seconds ttl) {
+    if (ttl == std::chrono::seconds::zero()) {
+        return;
+    }
+    LD_LOG(logger_, LogLevel::kInfo)
+        << Identity() << ": FDv2 retry scheduled in " << ttl.count() << "s";
+    async::Delay(ioc_, ttl, fdv1_fallback_retry_cancel_.GetToken())
+        .Then(
+            [this](bool fired) -> std::monostate {
+                if (fired) {
+                    OnFDv1RetryTimer();
+                }
+                return {};
+            },
+            [ioc = ioc_](async::Continuation<void()> work) {
+                boost::asio::post(ioc, std::move(work));
+            });
+}
+
+void FDv2DataSystem::OnFDv1RetryTimer() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (closed_) {
+            return;
+        }
+        LD_LOG(logger_, LogLevel::kInfo)
+            << Identity() << ": FDv2 retry timer fired; re-engaging FDv2";
+        source_manager_.SwitchBackToFDv2();
+        if (active_synchronizer_) {
+            active_synchronizer_->Close();
+            active_synchronizer_.reset();
+        }
+        active_conditions_.reset();
+    }
+    StartSynchronizers();
 }
 
 void FDv2DataSystem::ApplyChangeSet(

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
@@ -51,9 +51,8 @@ namespace launchdarkly::server_side::data_systems {
  * Destruction protocol:
  *
  *   The destructor cancels in-flight orchestration (closes the active
- *   source, emits status kOff), but does NOT block to drain executor
- *   callbacks that may already be queued. Before destroying, the caller
- *   must ensure both of:
+ *   source) but does NOT block to drain executor callbacks that may
+ *   already be queued. Before destroying, the caller must ensure both of:
  *
  *     1. The executor that orchestration callbacks run on has been stopped
  *        AND any thread running it has been joined. Otherwise a previously-
@@ -120,8 +119,6 @@ namespace launchdarkly::server_side::data_systems {
  *               v
  *     [Done; final status preserved]
  *
- *     Calling the destructor at any time -> [Closed; status kOff].
- *
  * Status transitions:
  *
  *   kInitializing (initial) -> kValid on first successful ChangeSet apply.
@@ -130,11 +127,10 @@ namespace launchdarkly::server_side::data_systems {
  *                              the initializer phase if not yet Valid).
  *                              kOff if all initializers exhaust without data
  *                              and no synchronizers are configured.
- *   kValid                  -> kInterrupted on errors; kOff in destructor or
- *                              when synchronizers cycle through and exhaust.
+ *   kValid                  -> kInterrupted on errors; kOff when
+ *                              synchronizers cycle through and exhaust.
  *   kInterrupted            -> kValid on next successful ChangeSet apply;
- *                              kOff in destructor or on synchronizer
- *                              exhaustion.
+ *                              kOff on synchronizer exhaustion.
  *   kOff                    -> terminal.
  */
 class FDv2DataSystem final : public data_interfaces::IDataSystem {

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
@@ -283,6 +283,9 @@ class FDv2DataSystem final : public data_interfaces::IDataSystem {
     // Set by Initialize() to detect repeat or concurrent calls.
     std::atomic_bool initialize_called_;
 
+    // Suppresses consecutive "interrupted" logs from the active synchronizer.
+    std::atomic_bool last_logged_synchronizer_interrupted_;
+
     // Orchestration state, guarded by mutex_.
     std::mutex mutex_;
     bool closed_;

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
@@ -10,12 +10,14 @@
 #include "conditions.hpp"
 #include "source_manager.hpp"
 
+#include <launchdarkly/async/cancellation.hpp>
 #include <launchdarkly/data_model/selector.hpp>
 #include <launchdarkly/logging/logger.hpp>
 
 #include <boost/asio/any_io_executor.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -247,6 +249,14 @@ class FDv2DataSystem final : public data_interfaces::IDataSystem {
     void OnSynchronizerResult(data_interfaces::FDv2SourceResult result);
     void OnConditionFired(data_interfaces::IFDv2Condition::Type type);
 
+    // Schedules an FDv2 recovery attempt after the given TTL. Called with
+    // mutex_ held. TTL of 0 disables the recovery and is a no-op.
+    void ScheduleFDv2RetryLocked(std::chrono::seconds ttl);
+
+    // Invoked when the FDv1 fallback TTL expires. Switches the source list
+    // back to FDv2 and restarts the synchronizer phase.
+    void OnFDv1RetryTimer();
+
     // Builds the conditions to apply to the currently active synchronizer.
     // Must be called with mutex_ held; reads source_manager_ state.
     std::unique_ptr<Conditions> BuildActiveConditions() const;
@@ -291,6 +301,9 @@ class FDv2DataSystem final : public data_interfaces::IDataSystem {
     std::unique_ptr<data_interfaces::IFDv2Initializer> active_initializer_;
     std::unique_ptr<data_interfaces::IFDv2Synchronizer> active_synchronizer_;
     std::unique_ptr<Conditions> active_conditions_;
+
+    // Cancelled in Close() to abort any pending FDv1 fallback retry delay.
+    async::CancellationSource fdv1_fallback_retry_cancel_;
 };
 
 }  // namespace launchdarkly::server_side::data_systems

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_polling_impl.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_polling_impl.cpp
@@ -129,7 +129,12 @@ static FDv2SourceResult ParseFDv2PollEvents(
                 FDv2SourceResult::ChangeSet{std::move(*typed)}};
         }
         if (auto* goodbye = std::get_if<Goodbye>(&result)) {
-            return FDv2SourceResult{FDv2SourceResult::Goodbye{goodbye->reason}};
+            FDv2SourceResult result{FDv2SourceResult::Goodbye{goodbye->reason}};
+            if (goodbye->protocol_fallback_ttl) {
+                result.fdv1_fallback = data_interfaces::FDv1FallbackDirective{
+                    std::chrono::seconds(*goodbye->protocol_fallback_ttl)};
+            }
+            return result;
         }
         if (auto* error = std::get_if<FDv2ProtocolHandler::Error>(&result)) {
             if (error->kind == FDv2ProtocolHandler::Error::Kind::kServerError) {
@@ -228,7 +233,11 @@ data_interfaces::FDv2SourceResult HandleFDv2PollResponse(
                     << identity << ": " << interrupted->error.Message();
             }
         }
-        result.fdv1_fallback = fdv1_fallback;
+        // An explicit directive parsed from the response body (e.g. via a
+        // goodbye event) takes precedence over the HTTP response header.
+        if (!result.fdv1_fallback) {
+            result.fdv1_fallback = fdv1_fallback;
+        }
         return result;
     }
 

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_polling_impl.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_polling_impl.cpp
@@ -13,6 +13,7 @@
 namespace launchdarkly::server_side::data_systems {
 
 static char const* const kFDv1FallbackHeader = "X-LD-FD-Fallback";
+static char const* const kFDv1FallbackTtlHeader = "X-LD-FD-Fallback-TTL";
 
 static char const* const kErrorParsingBody =
     "Could not parse FDv2 polling response";
@@ -34,10 +35,22 @@ static ErrorInfo MakeError(ErrorKind kind,
                      std::chrono::system_clock::now()};
 }
 
-static bool ReadFDv1FallbackDirective(
-    network::HttpResult::HeadersType const& headers) {
+static std::optional<data_interfaces::FDv1FallbackDirective>
+ReadFDv1FallbackDirective(network::HttpResult::HeadersType const& headers) {
     auto const it = headers.find(kFDv1FallbackHeader);
-    return it != headers.end() && boost::iequals(it->second, "true");
+    if (it == headers.end() || !boost::iequals(it->second, "true")) {
+        return std::nullopt;
+    }
+    data_interfaces::FDv1FallbackDirective directive;
+    auto const ttl_it = headers.find(kFDv1FallbackTtlHeader);
+    if (ttl_it != headers.end()) {
+        auto const ttl =
+            data_interfaces::FDv1FallbackDirective::ParseTtl(ttl_it->second);
+        if (ttl) {
+            directive.ttl = *ttl;
+        }
+    }
+    return directive;
 }
 
 network::HttpRequest MakeFDv2PollRequest(
@@ -183,7 +196,7 @@ data_interfaces::FDv2SourceResult HandleFDv2PollResponse(
             MakeError(ErrorKind::kNetworkError, 0, std::move(error_msg))}};
     }
 
-    bool const fdv1_fallback = ReadFDv1FallbackDirective(res.Headers());
+    auto fdv1_fallback = ReadFDv1FallbackDirective(res.Headers());
 
     if (res.Status() == 304) {
         return FDv2SourceResult{

--- a/libs/server-sdk/src/data_systems/fdv2/source_manager.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/source_manager.cpp
@@ -54,6 +54,14 @@ void SourceManager::SwitchToFDv1Fallback() {
     synchronizer_index_ = -1;
 }
 
+void SourceManager::SwitchBackToFDv2() {
+    for (auto& entry : synchronizers_) {
+        entry.state =
+            entry.is_fdv1_fallback ? State::kBlocked : State::kAvailable;
+    }
+    synchronizer_index_ = -1;
+}
+
 bool SourceManager::IsPrimeSynchronizer() const {
     for (std::size_t i = 0; i < synchronizers_.size(); ++i) {
         if (synchronizers_[i].state == State::kAvailable) {

--- a/libs/server-sdk/src/data_systems/fdv2/source_manager.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/source_manager.cpp
@@ -11,9 +11,11 @@ SourceManager::SourceManager(
     std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories) {
     synchronizers_.reserve(factories.size());
     for (auto& factory : factories) {
-        synchronizers_.push_back(
-            SynchronizerFactoryWithState{std::move(factory), State::kAvailable,
-                                         /*is_fdv1_fallback=*/false});
+        bool const is_fdv1_fallback = factory->IsFDv1Fallback();
+        synchronizers_.push_back(SynchronizerFactoryWithState{
+            std::move(factory),
+            is_fdv1_fallback ? State::kBlocked : State::kAvailable,
+            is_fdv1_fallback});
     }
 }
 
@@ -41,6 +43,14 @@ void SourceManager::BlockCurrentSynchronizer() {
 }
 
 void SourceManager::ResetSourceIndex() {
+    synchronizer_index_ = -1;
+}
+
+void SourceManager::SwitchToFDv1Fallback() {
+    for (auto& entry : synchronizers_) {
+        entry.state =
+            entry.is_fdv1_fallback ? State::kAvailable : State::kBlocked;
+    }
     synchronizer_index_ = -1;
 }
 

--- a/libs/server-sdk/src/data_systems/fdv2/source_manager.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/source_manager.hpp
@@ -62,6 +62,12 @@ class SourceManager {
     void SwitchToFDv1Fallback();
 
     /**
+     * Returns synchronizer state to the initial configuration, including
+     * unblocking factories previously blocked by terminal errors.
+     */
+    void SwitchBackToFDv2();
+
+    /**
      * Returns true if the currently tracked factory is the first Available
      * factory in the list. Returns false if no factory is currently tracked.
      */

--- a/libs/server-sdk/src/data_systems/fdv2/source_manager.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/source_manager.hpp
@@ -23,8 +23,7 @@ namespace launchdarkly::server_side::data_systems {
  * by recovery, which wants to fall back to the most-preferred Available
  * synchronizer.
  *
- * Each factory also carries an is_fdv1_fallback flag, currently always
- * false. TODO: populate when the FDv1 fallback directive is implemented.
+ * Factories whose IsFDv1Fallback() returns true start in the Blocked state.
  *
  * Not thread-safe. The caller is responsible for serializing all calls.
  */
@@ -55,6 +54,14 @@ class SourceManager {
     void ResetSourceIndex();
 
     /**
+     * Blocks every non-FDv1 factory and unblocks the FDv1 fallback factory,
+     * if one was configured. Resets the iteration cursor so the next call to
+     * NextSynchronizer returns the FDv1 fallback. If no FDv1 fallback factory
+     * was configured, every factory is left blocked.
+     */
+    void SwitchToFDv1Fallback();
+
+    /**
      * Returns true if the currently tracked factory is the first Available
      * factory in the list. Returns false if no factory is currently tracked.
      */
@@ -73,9 +80,8 @@ class SourceManager {
     [[nodiscard]] std::size_t SynchronizerCount() const;
 
     /**
-     * Returns true if the currently tracked factory was configured as the
-     * FDv1 fallback synchronizer. Always false until the FDv1 fallback
-     * directive is implemented.
+     * Returns true if the currently tracked factory is the FDv1 fallback
+     * synchronizer.
      */
     [[nodiscard]] bool IsCurrentSynchronizerFDv1Fallback() const;
 

--- a/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.cpp
@@ -187,8 +187,21 @@ void FDv2StreamingSynchronizer::State::OnConnect(HttpRequest* req) {
 void FDv2StreamingSynchronizer::State::OnResponse(
     HttpResponseHeader const& headers) {
     auto const it = headers.find("X-LD-FD-Fallback");
-    bool const directive =
-        it != headers.end() && boost::iequals(it->value(), "true");
+    if (it == headers.end() || !boost::iequals(it->value(), "true")) {
+        std::lock_guard lock(mutex_);
+        latest_fdv1_fallback_.reset();
+        return;
+    }
+    data_interfaces::FDv1FallbackDirective directive;
+    auto const ttl_it = headers.find("X-LD-FD-Fallback-TTL");
+    if (ttl_it != headers.end()) {
+        auto const value = ttl_it->value();
+        auto const ttl = data_interfaces::FDv1FallbackDirective::ParseTtl(
+            std::string_view{value.data(), value.size()});
+        if (ttl) {
+            directive.ttl = *ttl;
+        }
+    }
     std::lock_guard lock(mutex_);
     latest_fdv1_fallback_ = directive;
 }

--- a/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.cpp
@@ -253,7 +253,14 @@ void FDv2StreamingSynchronizer::State::OnEvent(sse::Event const& event) {
                     << ": Goodbye was received from the LaunchDarkly "
                        "connection with reason: '"
                     << r.reason.value_or("") << "'.";
-                Notify(FDv2SourceResult{FDv2SourceResult::Goodbye{r.reason}});
+                FDv2SourceResult goodbye_result{
+                    FDv2SourceResult::Goodbye{r.reason}};
+                if (r.protocol_fallback_ttl) {
+                    goodbye_result.fdv1_fallback =
+                        data_interfaces::FDv1FallbackDirective{
+                            std::chrono::seconds(*r.protocol_fallback_ttl)};
+                }
+                Notify(std::move(goodbye_result));
                 // Drop the current connection and reconnect; the protocol
                 // handler is reset so the new connection starts in a clean
                 // state.
@@ -324,7 +331,12 @@ void FDv2StreamingSynchronizer::State::Notify(FDv2SourceResult result) {
     std::optional<async::Promise<FDv2SourceResult>> promise;
     {
         std::lock_guard lock(mutex_);
-        result.fdv1_fallback = latest_fdv1_fallback_;
+        // An explicit directive on the result (e.g. parsed from a goodbye
+        // message) takes precedence over the most recent HTTP response
+        // header.
+        if (!result.fdv1_fallback) {
+            result.fdv1_fallback = latest_fdv1_fallback_;
+        }
         if (pending_promise_) {
             promise = std::move(pending_promise_);
             pending_promise_.reset();

--- a/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/streaming_synchronizer.hpp
@@ -147,7 +147,8 @@ class FDv2StreamingSynchronizer final
         bool started_ = false;
         bool closed_ = false;
         // FDv1 fallback directive from the most recent SSE response.
-        bool latest_fdv1_fallback_ = false;
+        std::optional<data_interfaces::FDv1FallbackDirective>
+            latest_fdv1_fallback_;
         data_model::Selector latest_selector_;
         std::optional<boost::urls::url> base_url_;
         std::shared_ptr<sse::Client> sse_client_;

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -1203,6 +1203,67 @@ TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
     EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
 }
 
+TEST(FDv2DataSystemTest,
+     InitializerChangeSetWithDirectiveAppliesBasisThenSwitches) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // Initializer returns a Full changeset carrying a flag AND the directive.
+    // The basis must be applied to the store before the orchestrator
+    // transitions to the FDv1 fallback.
+    data_model::Flag flag_a;
+    flag_a.key = "flagA";
+    flag_a.version = 1;
+
+    FDv2SourceResult init_result = MakeFullChangeSetResult(
+        ChangeSetData{
+            ItemChange{"flagA", data_model::FlagDescriptor(flag_a)},
+        },
+        MakeSelector(1, "state-1"));
+    init_result.fdv1_fallback = true;
+
+    auto initializer =
+        std::make_unique<MockInitializer>(std::move(init_result));
+
+    std::vector<std::unique_ptr<IFDv2InitializerFactory>> initializers;
+    initializers.push_back(
+        std::make_unique<OneShotInitializerFactory>(std::move(initializer)));
+
+    auto fdv2_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+    auto fdv2_factory =
+        std::make_unique<OneShotSynchronizerFactory>(std::move(fdv2_sync));
+    auto* fdv2_factory_ptr = fdv2_factory.get();
+
+    auto fdv1_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+    auto fdv1_factory =
+        std::make_unique<FDv1FallbackOneShotFactory>(std::move(fdv1_sync));
+    auto* fdv1_factory_ptr = fdv1_factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(fdv2_factory));
+    synchronizers.push_back(std::move(fdv1_factory));
+
+    FDv2DataSystem ds(std::move(initializers), std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    // Basis applied before the switch.
+    EXPECT_TRUE(ds.Initialized());
+    auto fetched = ds.GetFlag("flagA");
+    ASSERT_TRUE(fetched);
+    EXPECT_EQ(1u, fetched->version);
+
+    // FDv2 synchronizer skipped; FDv1 adapter built and ran.
+    EXPECT_EQ(0, fdv2_factory_ptr->build_count_);
+    EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
+}
+
 TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
     auto logger = MakeNullLogger();
     boost::asio::io_context ioc;

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -145,6 +145,15 @@ class OneShotSynchronizerFactory : public IFDv2SynchronizerFactory {
     std::unique_ptr<IFDv2Synchronizer> source_;
 };
 
+class FDv1FallbackOneShotFactory : public OneShotSynchronizerFactory {
+   public:
+    explicit FDv1FallbackOneShotFactory(
+        std::unique_ptr<IFDv2Synchronizer> source)
+        : OneShotSynchronizerFactory(std::move(source)) {}
+
+    bool IsFDv1Fallback() const override { return true; }
+};
+
 // Returns each pre-supplied source in order on successive Build() calls.
 // Returns nullptr once the supply is exhausted. Used in tests that exercise
 // wrap-around or recovery, where the same factory is built more than once.
@@ -1088,6 +1097,129 @@ TEST(FDv2DataSystemTest, SingleSynchronizerHasNoFallbackArmed) {
 
     EXPECT_EQ(DataSourceStatus::DataSourceState::kInterrupted,
               status_manager.Status().State());
+}
+
+// ============================================================================
+// FDv1 fallback directive
+// ============================================================================
+
+TEST(FDv2DataSystemTest, SynchronizerFdv1FlagSwitchesToFdv1Adapter) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // FDv2 synchronizer emits a ChangeSet with the directive, then closes.
+    auto fdv2_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{FDv2SourceResult::ChangeSet{
+                data_model::ChangeSet<ChangeSetData>{
+                    data_model::ChangeSetType::kNone,
+                    {},
+                    data_model::Selector{}}}};
+            r.fdv1_fallback = true;
+            return r;
+        }()});
+    auto fdv2_factory =
+        std::make_unique<OneShotSynchronizerFactory>(std::move(fdv2_sync));
+
+    // FDv1 adapter returns Shutdown when reached, ending orchestration.
+    auto fdv1_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+    auto fdv1_factory =
+        std::make_unique<FDv1FallbackOneShotFactory>(std::move(fdv1_sync));
+    auto* fdv1_factory_ptr = fdv1_factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(fdv2_factory));
+    synchronizers.push_back(std::move(fdv1_factory));
+
+    FDv2DataSystem ds({}, std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
+}
+
+TEST(FDv2DataSystemTest, SynchronizerFdv1FlagWithoutAdapterTransitionsOff) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    auto fdv2_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{
+                FDv2SourceResult::Interrupted{FDv2SourceResult::ErrorInfo{
+                    FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
+                    /*status_code=*/418, "directive",
+                    std::chrono::system_clock::now()}}};
+            r.fdv1_fallback = true;
+            return r;
+        }()});
+    auto fdv2_factory =
+        std::make_unique<OneShotSynchronizerFactory>(std::move(fdv2_sync));
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(fdv2_factory));
+
+    FDv2DataSystem ds({}, std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    EXPECT_EQ(DataSourceStatus::DataSourceState::kOff,
+              status_manager.Status().State());
+}
+
+TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // Initializer returns Interrupted with the directive set.
+    FDv2SourceResult init_result{
+        FDv2SourceResult::Interrupted{FDv2SourceResult::ErrorInfo{
+            FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
+            /*status_code=*/418, "directive",
+            std::chrono::system_clock::now()}}};
+    init_result.fdv1_fallback = true;
+    auto initializer =
+        std::make_unique<MockInitializer>(std::move(init_result));
+
+    std::vector<std::unique_ptr<IFDv2InitializerFactory>> initializers;
+    initializers.push_back(
+        std::make_unique<OneShotInitializerFactory>(std::move(initializer)));
+
+    auto fdv2_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+    auto fdv2_factory =
+        std::make_unique<OneShotSynchronizerFactory>(std::move(fdv2_sync));
+    auto* fdv2_factory_ptr = fdv2_factory.get();
+
+    auto fdv1_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+    auto fdv1_factory =
+        std::make_unique<FDv1FallbackOneShotFactory>(std::move(fdv1_sync));
+    auto* fdv1_factory_ptr = fdv1_factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(fdv2_factory));
+    synchronizers.push_back(std::move(fdv1_factory));
+
+    FDv2DataSystem ds(std::move(initializers), std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    // FDv2 synchronizer was skipped; FDv1 adapter was built and ran.
+    EXPECT_EQ(0, fdv2_factory_ptr->build_count_);
+    EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
 }
 
 // ============================================================================

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -272,25 +272,6 @@ TEST(FDv2DataSystemTest, OfflineMode_NoFactories_StatusValid) {
     EXPECT_FALSE(ds.Initialized());
 }
 
-TEST(FDv2DataSystemTest, Destructor_TransitionsStatusToOff) {
-    auto logger = MakeNullLogger();
-    boost::asio::io_context ioc;
-    data_components::DataSourceStatusManager status_manager;
-
-    {
-        FDv2DataSystem ds({}, {}, /*fallback_condition_factory=*/nullptr,
-                          /*recovery_condition_factory=*/nullptr,
-                          ioc.get_executor(), &status_manager, logger);
-        ds.Initialize();
-        ASSERT_EQ(status_manager.Status().State(),
-                  DataSourceStatus::DataSourceState::kValid);
-    }
-
-    // After ~FDv2DataSystem, status is Off.
-    EXPECT_EQ(status_manager.Status().State(),
-              DataSourceStatus::DataSourceState::kOff);
-}
-
 // ============================================================================
 // Initializer phase
 // ============================================================================
@@ -1227,14 +1208,13 @@ TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
 // ============================================================================
 //
 // The destructor contract (fdv2_data_system.hpp) requires the destructor to
-// cancel in-flight orchestration (close the active source, transition status
-// to kOff) without firing any continuation against the destroyed object. The
-// caller's responsibility is to ensure the executor is no longer running by
-// the time destruction begins; the orchestrator's responsibility is to leave
-// nothing dangling. These two tests pin that contract for both phases.
+// cancel in-flight orchestration (close the active source) without firing
+// any continuation against the destroyed object. The caller's responsibility
+// is to ensure the executor is no longer running by the time destruction
+// begins; the orchestrator's responsibility is to leave nothing dangling.
+// These two tests pin that contract for both phases.
 
-TEST(FDv2DataSystemTest,
-     Destructor_WithInFlightInitializer_ClosesSourceAndStatusOff) {
+TEST(FDv2DataSystemTest, Destructor_WithInFlightInitializer_ClosesSource) {
     auto logger = MakeNullLogger();
     boost::asio::io_context ioc;
     data_components::DataSourceStatusManager status_manager;
@@ -1261,12 +1241,9 @@ TEST(FDv2DataSystemTest,
     // ~FDv2DataSystem ran with the initializer's Future still unresolved.
 
     EXPECT_TRUE(initializer_closed);
-    EXPECT_EQ(status_manager.Status().State(),
-              DataSourceStatus::DataSourceState::kOff);
 }
 
-TEST(FDv2DataSystemTest,
-     Destructor_WithInFlightSynchronizer_ClosesSourceAndStatusOff) {
+TEST(FDv2DataSystemTest, Destructor_WithInFlightSynchronizer_ClosesSource) {
     auto logger = MakeNullLogger();
     boost::asio::io_context ioc;
     data_components::DataSourceStatusManager status_manager;
@@ -1292,6 +1269,4 @@ TEST(FDv2DataSystemTest,
     }
 
     EXPECT_TRUE(synchronizer_closed);
-    EXPECT_EQ(status_manager.Status().State(),
-              DataSourceStatus::DataSourceState::kOff);
 }

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -1097,7 +1097,8 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagSwitchesToFdv1Adapter) {
                     data_model::ChangeSetType::kNone,
                     {},
                     data_model::Selector{}}}};
-            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
             return r;
         }()});
     auto fdv2_factory =
@@ -1124,11 +1125,13 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagSwitchesToFdv1Adapter) {
     EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
 }
 
-TEST(FDv2DataSystemTest, SynchronizerFdv1FlagWithoutAdapterTransitionsOff) {
+TEST(FDv2DataSystemTest,
+     SynchronizerFdv1FlagWithoutAdapterDoesNotTransitionToOff) {
     auto logger = MakeNullLogger();
     boost::asio::io_context ioc;
     data_components::DataSourceStatusManager status_manager;
 
+    // Directive with TTL=0: indefinite, no automatic FDv2 retry.
     auto fdv2_sync =
         std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
             FDv2SourceResult r{
@@ -1136,7 +1139,8 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagWithoutAdapterTransitionsOff) {
                     FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
                     /*status_code=*/418, "directive",
                     std::chrono::system_clock::now()}}};
-            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
             return r;
         }()});
     auto fdv2_factory =
@@ -1152,7 +1156,7 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagWithoutAdapterTransitionsOff) {
     ds.Initialize();
     ioc.run();
 
-    EXPECT_EQ(DataSourceStatus::DataSourceState::kOff,
+    EXPECT_NE(DataSourceStatus::DataSourceState::kOff,
               status_manager.Status().State());
 }
 
@@ -1167,7 +1171,8 @@ TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
             FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
             /*status_code=*/418, "directive",
             std::chrono::system_clock::now()}}};
-    init_result.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+    init_result.fdv1_fallback =
+        data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
     auto initializer =
         std::make_unique<MockInitializer>(std::move(init_result));
 
@@ -1221,7 +1226,8 @@ TEST(FDv2DataSystemTest,
             ItemChange{"flagA", data_model::FlagDescriptor(flag_a)},
         },
         MakeSelector(1, "state-1"));
-    init_result.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+    init_result.fdv1_fallback =
+        data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
 
     auto initializer =
         std::make_unique<MockInitializer>(std::move(init_result));
@@ -1264,6 +1270,105 @@ TEST(FDv2DataSystemTest,
     EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
 }
 
+TEST(FDv2DataSystemTest, DirectiveTtlElapseRebuildsFDv2) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // First build: source emits the directive with a 1s TTL. Second build
+    // (after the TTL elapses): source returns no results, so MockSynchronizer
+    // emits Shutdown and orchestration ends.
+    auto first_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{
+                FDv2SourceResult::Interrupted{FDv2SourceResult::ErrorInfo{
+                    FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
+                    /*status_code=*/418, "directive",
+                    std::chrono::system_clock::now()}}};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{1}};
+            return r;
+        }()});
+    auto second_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{});
+
+    std::vector<std::unique_ptr<IFDv2Synchronizer>> sources;
+    sources.push_back(std::move(first_sync));
+    sources.push_back(std::move(second_sync));
+    auto factory =
+        std::make_unique<MultiShotSynchronizerFactory>(std::move(sources));
+    auto* factory_ptr = factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(factory));
+
+    FDv2DataSystem ds({}, std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    EXPECT_EQ(2, factory_ptr->build_count_);
+}
+
+TEST(FDv2DataSystemTest, FDv2RecoveryAfterTtlAcceptsValidData) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // First build: emits directive with 1s TTL. Second build (recovery):
+    // emits a valid ChangeSet without the directive.
+    auto first_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{
+                FDv2SourceResult::Interrupted{FDv2SourceResult::ErrorInfo{
+                    FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
+                    /*status_code=*/418, "directive",
+                    std::chrono::system_clock::now()}}};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{1}};
+            return r;
+        }()});
+
+    data_model::Flag flag_a;
+    flag_a.key = "flagA";
+    flag_a.version = 1;
+
+    auto second_sync = std::make_unique<MockSynchronizer>(
+        std::vector<FDv2SourceResult>{MakeFullChangeSetResult(
+            ChangeSetData{
+                ItemChange{"flagA", data_model::FlagDescriptor(flag_a)},
+            },
+            MakeSelector(1, "state-1"))});
+
+    std::vector<std::unique_ptr<IFDv2Synchronizer>> sources;
+    sources.push_back(std::move(first_sync));
+    sources.push_back(std::move(second_sync));
+    auto factory =
+        std::make_unique<MultiShotSynchronizerFactory>(std::move(sources));
+    auto* factory_ptr = factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(factory));
+
+    FDv2DataSystem ds({}, std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    // FDv2 was rebuilt after the TTL elapsed, the new ChangeSet was applied,
+    // and the data system is in the valid state.
+    EXPECT_EQ(2, factory_ptr->build_count_);
+    EXPECT_TRUE(ds.Initialized());
+    EXPECT_EQ(DataSourceStatus::DataSourceState::kValid,
+              status_manager.Status().State());
+    auto fetched = ds.GetFlag("flagA");
+    ASSERT_TRUE(fetched);
+}
+
 TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
     auto logger = MakeNullLogger();
     boost::asio::io_context ioc;
@@ -1278,7 +1383,8 @@ TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
                     data_model::ChangeSetType::kNone,
                     {},
                     data_model::Selector{}}}};
-            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
             return r;
         }()});
     auto fdv2_factory =
@@ -1294,7 +1400,8 @@ TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
                     FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
                     /*status_code=*/418, "self-trigger",
                     std::chrono::system_clock::now()}}};
-            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
+            r.fdv1_fallback =
+                data_interfaces::FDv1FallbackDirective{std::chrono::seconds{0}};
             return r;
         }()});
     auto fdv1_factory =

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -1097,7 +1097,7 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagSwitchesToFdv1Adapter) {
                     data_model::ChangeSetType::kNone,
                     {},
                     data_model::Selector{}}}};
-            r.fdv1_fallback = true;
+            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
             return r;
         }()});
     auto fdv2_factory =
@@ -1136,7 +1136,7 @@ TEST(FDv2DataSystemTest, SynchronizerFdv1FlagWithoutAdapterTransitionsOff) {
                     FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
                     /*status_code=*/418, "directive",
                     std::chrono::system_clock::now()}}};
-            r.fdv1_fallback = true;
+            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
             return r;
         }()});
     auto fdv2_factory =
@@ -1167,7 +1167,7 @@ TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
             FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
             /*status_code=*/418, "directive",
             std::chrono::system_clock::now()}}};
-    init_result.fdv1_fallback = true;
+    init_result.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
     auto initializer =
         std::make_unique<MockInitializer>(std::move(init_result));
 
@@ -1221,7 +1221,7 @@ TEST(FDv2DataSystemTest,
             ItemChange{"flagA", data_model::FlagDescriptor(flag_a)},
         },
         MakeSelector(1, "state-1"));
-    init_result.fdv1_fallback = true;
+    init_result.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
 
     auto initializer =
         std::make_unique<MockInitializer>(std::move(init_result));
@@ -1278,7 +1278,7 @@ TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
                     data_model::ChangeSetType::kNone,
                     {},
                     data_model::Selector{}}}};
-            r.fdv1_fallback = true;
+            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
             return r;
         }()});
     auto fdv2_factory =
@@ -1294,7 +1294,7 @@ TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
                     FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
                     /*status_code=*/418, "self-trigger",
                     std::chrono::system_clock::now()}}};
-            r.fdv1_fallback = true;
+            r.fdv1_fallback = data_interfaces::FDv1FallbackDirective{};
             return r;
         }()});
     auto fdv1_factory =

--- a/libs/server-sdk/tests/fdv2_data_system_test.cpp
+++ b/libs/server-sdk/tests/fdv2_data_system_test.cpp
@@ -1203,6 +1203,57 @@ TEST(FDv2DataSystemTest, InitializerFdv1FlagSwitchesToFdv1Adapter) {
     EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
 }
 
+TEST(FDv2DataSystemTest, FDv1SourceSelfDirectiveDoesNotRebuildFDv1) {
+    auto logger = MakeNullLogger();
+    boost::asio::io_context ioc;
+    data_components::DataSourceStatusManager status_manager;
+
+    // FDv2 source emits a ChangeSet with the directive, switching to the
+    // FDv1 fallback.
+    auto fdv2_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{FDv2SourceResult::ChangeSet{
+                data_model::ChangeSet<ChangeSetData>{
+                    data_model::ChangeSetType::kNone,
+                    {},
+                    data_model::Selector{}}}};
+            r.fdv1_fallback = true;
+            return r;
+        }()});
+    auto fdv2_factory =
+        std::make_unique<OneShotSynchronizerFactory>(std::move(fdv2_sync));
+
+    // FDv1 source then emits a result also carrying the directive. Once
+    // FDv1 is active, the directive is silently ignored and the source is
+    // not rebuilt.
+    auto fdv1_sync =
+        std::make_unique<MockSynchronizer>(std::vector<FDv2SourceResult>{[]() {
+            FDv2SourceResult r{
+                FDv2SourceResult::Interrupted{FDv2SourceResult::ErrorInfo{
+                    FDv2SourceResult::ErrorInfo::ErrorKind::kErrorResponse,
+                    /*status_code=*/418, "self-trigger",
+                    std::chrono::system_clock::now()}}};
+            r.fdv1_fallback = true;
+            return r;
+        }()});
+    auto fdv1_factory =
+        std::make_unique<FDv1FallbackOneShotFactory>(std::move(fdv1_sync));
+    auto* fdv1_factory_ptr = fdv1_factory.get();
+
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> synchronizers;
+    synchronizers.push_back(std::move(fdv2_factory));
+    synchronizers.push_back(std::move(fdv1_factory));
+
+    FDv2DataSystem ds({}, std::move(synchronizers),
+                      /*fallback_condition_factory=*/nullptr,
+                      /*recovery_condition_factory=*/nullptr,
+                      ioc.get_executor(), &status_manager, logger);
+    ds.Initialize();
+    ioc.run();
+
+    EXPECT_EQ(1, fdv1_factory_ptr->build_count_);
+}
+
 // ============================================================================
 // Destruction protocol: in-flight orchestration
 // ============================================================================

--- a/libs/server-sdk/tests/fdv2_polling_impl_test.cpp
+++ b/libs/server-sdk/tests/fdv2_polling_impl_test.cpp
@@ -98,6 +98,29 @@ TEST(HandleFDv2PollResponseTest, HeaderValueOtherThanTrueDoesNotSetFlag) {
     EXPECT_FALSE(result.fdv1_fallback);
 }
 
+TEST(HandleFDv2PollResponseTest, DirectiveWithoutTtlHeaderUsesDefault) {
+    auto result =
+        HandleResponse(304, std::nullopt, {{"X-LD-FD-Fallback", "true"}});
+    ASSERT_TRUE(result.fdv1_fallback);
+    EXPECT_EQ(FDv1FallbackDirective::kDefaultTtl, result.fdv1_fallback->ttl);
+}
+
+TEST(HandleFDv2PollResponseTest, DirectiveWithTtlHeaderParsesValue) {
+    auto result = HandleResponse(
+        304, std::nullopt,
+        {{"X-LD-FD-Fallback", "true"}, {"X-LD-FD-Fallback-TTL", "60"}});
+    ASSERT_TRUE(result.fdv1_fallback);
+    EXPECT_EQ(std::chrono::seconds{60}, result.fdv1_fallback->ttl);
+}
+
+TEST(HandleFDv2PollResponseTest, DirectiveWithMalformedTtlFallsBackToDefault) {
+    auto result = HandleResponse(304, std::nullopt,
+                                 {{"X-LD-FD-Fallback", "true"},
+                                  {"X-LD-FD-Fallback-TTL", "not-a-number"}});
+    ASSERT_TRUE(result.fdv1_fallback);
+    EXPECT_EQ(FDv1FallbackDirective::kDefaultTtl, result.fdv1_fallback->ttl);
+}
+
 TEST(HandleFDv2PollResponseTest, NetworkErrorDoesNotSetFlag) {
     auto logger = MakeNullLogger();
     FDv2ProtocolHandler handler;

--- a/libs/server-sdk/tests/fdv2_streaming_synchronizer_test.cpp
+++ b/libs/server-sdk/tests/fdv2_streaming_synchronizer_test.cpp
@@ -854,3 +854,60 @@ TEST(FDv2StreamingSynchronizerTest, ErrorAfterDirectiveCarriesFlag) {
         std::holds_alternative<FDv2SourceResult::Interrupted>(result->value));
     EXPECT_TRUE(result->fdv1_fallback);
 }
+
+TEST(FDv2StreamingSynchronizerTest, DirectiveWithTtlHeaderParsesValue) {
+    auto logger = MakeNullLogger();
+    IoContextRunner runner;
+
+    FDv2StreamingSynchronizer synchronizer(
+        runner.context().get_executor(), logger,
+        MakeEndpoints("http://localhost"), MakeHttpProperties(), std::nullopt,
+        1s);
+    FDv2StreamingSynchronizerTestPeer::MarkStarted(synchronizer);
+
+    // Server sends the directive with an explicit TTL.
+    boost::beast::http::response_header<> headers;
+    headers.result(200);
+    headers.set("X-LD-FD-Fallback", "true");
+    headers.set("X-LD-FD-Fallback-TTL", "60");
+    FDv2StreamingSynchronizerTestPeer::OnResponse(synchronizer, headers);
+
+    // Drive the source to surface the directive on its next result.
+    FDv2StreamingSynchronizerTestPeer::OnError(
+        synchronizer,
+        sse::Error{sse::errors::ReadTimeout{std::chrono::milliseconds(0)}});
+    auto result = synchronizer.Next(data_model::Selector{}).WaitForResult(2s);
+
+    // The parsed TTL is propagated on the result.
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->fdv1_fallback);
+    EXPECT_EQ(std::chrono::seconds{60}, result->fdv1_fallback->ttl);
+}
+
+TEST(FDv2StreamingSynchronizerTest, DirectiveWithoutTtlHeaderUsesDefault) {
+    auto logger = MakeNullLogger();
+    IoContextRunner runner;
+
+    FDv2StreamingSynchronizer synchronizer(
+        runner.context().get_executor(), logger,
+        MakeEndpoints("http://localhost"), MakeHttpProperties(), std::nullopt,
+        1s);
+    FDv2StreamingSynchronizerTestPeer::MarkStarted(synchronizer);
+
+    // Server sends the directive with no TTL header.
+    boost::beast::http::response_header<> headers;
+    headers.result(200);
+    headers.set("X-LD-FD-Fallback", "true");
+    FDv2StreamingSynchronizerTestPeer::OnResponse(synchronizer, headers);
+
+    // Drive the source to surface the directive on its next result.
+    FDv2StreamingSynchronizerTestPeer::OnError(
+        synchronizer,
+        sse::Error{sse::errors::ReadTimeout{std::chrono::milliseconds(0)}});
+    auto result = synchronizer.Next(data_model::Selector{}).WaitForResult(2s);
+
+    // The result carries the default TTL.
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->fdv1_fallback);
+    EXPECT_EQ(FDv1FallbackDirective::kDefaultTtl, result->fdv1_fallback->ttl);
+}

--- a/libs/server-sdk/tests/source_manager_test.cpp
+++ b/libs/server-sdk/tests/source_manager_test.cpp
@@ -255,3 +255,44 @@ TEST(SourceManagerTest, SwitchToFDv1FallbackUnblocksPreviouslyBlockedFDv2) {
     EXPECT_EQ(1, fdv1_ptr->build_count);
     EXPECT_TRUE(mgr.IsCurrentSynchronizerFDv1Fallback());
 }
+
+TEST(SourceManagerTest, SwitchBackToFDv2UnblocksFDv2AndBlocksFDv1) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    auto* fdv2_ptr = fdv2.get();
+    auto fdv1 = std::make_unique<FDv1FallbackFactory>();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    factories.push_back(std::move(fdv1));
+    SourceManager mgr(std::move(factories));
+
+    // Switch to FDv1 first, then back to FDv2.
+    mgr.SwitchToFDv1Fallback();
+    mgr.SwitchBackToFDv2();
+
+    EXPECT_EQ(1u, mgr.AvailableSynchronizerCount());
+    auto sync = mgr.NextSynchronizer();
+    ASSERT_NE(sync, nullptr);
+    EXPECT_EQ(1, fdv2_ptr->build_count);
+    EXPECT_FALSE(mgr.IsCurrentSynchronizerFDv1Fallback());
+}
+
+TEST(SourceManagerTest, SwitchBackToFDv2UnblocksTerminallyFailedFDv2Factory) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    auto* fdv2_ptr = fdv2.get();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    SourceManager mgr(std::move(factories));
+
+    // Simulate a terminal error blocking the FDv2 factory.
+    mgr.NextSynchronizer();
+    mgr.BlockCurrentSynchronizer();
+    EXPECT_EQ(0u, mgr.AvailableSynchronizerCount());
+
+    mgr.SwitchBackToFDv2();
+
+    // Previously-blocked FDv2 factory is now available again.
+    EXPECT_EQ(1u, mgr.AvailableSynchronizerCount());
+    auto sync = mgr.NextSynchronizer();
+    ASSERT_NE(sync, nullptr);
+    EXPECT_EQ(2, fdv2_ptr->build_count);
+}

--- a/libs/server-sdk/tests/source_manager_test.cpp
+++ b/libs/server-sdk/tests/source_manager_test.cpp
@@ -43,6 +43,11 @@ class CountingFactory : public IFDv2SynchronizerFactory {
     int build_count = 0;
 };
 
+class FDv1FallbackFactory : public CountingFactory {
+   public:
+    bool IsFDv1Fallback() const override { return true; }
+};
+
 }  // namespace
 
 TEST(SourceManagerTest, EmptyManagerReportsZeroAvailable) {
@@ -176,7 +181,7 @@ TEST(SourceManagerTest, ResetSourceIndexSkipsBlockedFirstFactory) {
     EXPECT_EQ(1, f1_ptr->build_count);
 }
 
-TEST(SourceManagerTest, IsCurrentSynchronizerFDv1FallbackAlwaysFalse) {
+TEST(SourceManagerTest, IsCurrentSynchronizerFDv1FallbackFalseForFDv2Factory) {
     auto f0 = std::make_unique<CountingFactory>();
     std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
     factories.push_back(std::move(f0));
@@ -184,4 +189,69 @@ TEST(SourceManagerTest, IsCurrentSynchronizerFDv1FallbackAlwaysFalse) {
 
     mgr.NextSynchronizer();
     EXPECT_FALSE(mgr.IsCurrentSynchronizerFDv1Fallback());
+}
+
+TEST(SourceManagerTest, FDv1FallbackFactoryStartsBlockedAndIsSkipped) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    auto fdv1 = std::make_unique<FDv1FallbackFactory>();
+    auto* fdv1_ptr = fdv1.get();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    factories.push_back(std::move(fdv1));
+    SourceManager mgr(std::move(factories));
+
+    EXPECT_EQ(1u, mgr.AvailableSynchronizerCount());
+    mgr.NextSynchronizer();
+    EXPECT_FALSE(mgr.IsCurrentSynchronizerFDv1Fallback());
+    EXPECT_EQ(0, fdv1_ptr->build_count);
+}
+
+TEST(SourceManagerTest, SwitchToFDv1FallbackBlocksFDv2AndUnblocksFDv1) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    auto fdv1 = std::make_unique<FDv1FallbackFactory>();
+    auto* fdv1_ptr = fdv1.get();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    factories.push_back(std::move(fdv1));
+    SourceManager mgr(std::move(factories));
+
+    mgr.SwitchToFDv1Fallback();
+
+    EXPECT_EQ(1u, mgr.AvailableSynchronizerCount());
+    auto sync = mgr.NextSynchronizer();
+    ASSERT_NE(sync, nullptr);
+    EXPECT_EQ(1, fdv1_ptr->build_count);
+    EXPECT_TRUE(mgr.IsCurrentSynchronizerFDv1Fallback());
+}
+
+TEST(SourceManagerTest, SwitchToFDv1FallbackWithoutAdapterBlocksEverything) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    SourceManager mgr(std::move(factories));
+
+    mgr.SwitchToFDv1Fallback();
+
+    EXPECT_EQ(0u, mgr.AvailableSynchronizerCount());
+    EXPECT_EQ(nullptr, mgr.NextSynchronizer());
+}
+
+TEST(SourceManagerTest, SwitchToFDv1FallbackUnblocksPreviouslyBlockedFDv2) {
+    auto fdv2 = std::make_unique<CountingFactory>();
+    auto fdv1 = std::make_unique<FDv1FallbackFactory>();
+    auto* fdv1_ptr = fdv1.get();
+    std::vector<std::unique_ptr<IFDv2SynchronizerFactory>> factories;
+    factories.push_back(std::move(fdv2));
+    factories.push_back(std::move(fdv1));
+    SourceManager mgr(std::move(factories));
+
+    mgr.NextSynchronizer();
+    mgr.BlockCurrentSynchronizer();
+    mgr.SwitchToFDv1Fallback();
+
+    EXPECT_EQ(1u, mgr.AvailableSynchronizerCount());
+    auto sync = mgr.NextSynchronizer();
+    ASSERT_NE(sync, nullptr);
+    EXPECT_EQ(1, fdv1_ptr->build_count);
+    EXPECT_TRUE(mgr.IsCurrentSynchronizerFDv1Fallback());
 }


### PR DESCRIPTION
## Summary

Implements the FDv1 fallback directive in the FDv2 data system with TTL-based recovery.

- `FDv2SourceResult` carries `std::optional<FDv1FallbackDirective>` with a TTL (default 1h, 0 = indefinite).
- Sources parse `X-LD-FD-Fallback-TTL` (header) and `protocolFallbackTTL` (goodbye).
- On directive: switch to FDv1 if configured, otherwise disconnect (`kInterrupted`). Schedule retry after TTL.
- On TTL elapse: `SourceManager::SwitchBackToFDv2()` re-enables FDv2 (including previously terminal-error-blocked factories), blocks FDv1, restarts synchronizers.

End-to-end fallback will work once an FDv1 streaming source is wrapped as an `IFDv2Synchronizer` (#540).

## Test plan

- [x] `SourceManager` tests cover the new block/unblock semantics
- [x] Source-level tests cover TTL parsing (HTTP + goodbye), default, malformed
- [x] Orchestrator tests cover directive flows in initializer/synchronizer paths, TTL elapse rebuild, FDv2 recovery
- [x] Full server suite green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag-data orchestration and protocol fallback behavior; mis-handling could leave clients on the wrong protocol or retry timing, though behavior is heavily tested.
> 
> **Overview**
> Adds **server-directed FDv1 fallback** for the FDv2 data path: results now carry an optional `FDv1FallbackDirective` (TTL, default 1h; **0 = stay on FDv1 indefinitely**) instead of a boolean flag.
> 
> **Parsing:** Goodbye JSON gains `protocolFallbackTTL`; polling and streaming read `X-LD-FD-Fallback` / `X-LD-FD-Fallback-TTL`, with body/goodbye directives overriding headers.
> 
> **Orchestration:** On directive, `SourceManager` blocks FDv2 factories and selects an `IsFDv1Fallback()` synchronizer; missing adapter → `kInterrupted` without forcing `kOff`. A cancellable timer calls `SwitchBackToFDv2()` (re-enabling FDv2 factories blocked for terminal errors) and restarts synchronizers. Destructor/`Close()` no longer sets status to `kOff`; retry timers are cancelled on close.
> 
> **Other:** Logging tweaks (initializer/synchronizer start, deduped synchronizer interrupts). Broad unit/orchestrator tests cover TTL parsing, switching, recovery, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b1c7fa7f95c2f1365680b5d48f3d07ae8025c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->