### PR TITLE
feat: add internal BigSegmentStoreWrapper with caching and status polling

### DIFF
--- a/libs/internal/include/launchdarkly/async/promise.hpp
+++ b/libs/internal/include/launchdarkly/async/promise.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <variant>
 #include <vector>
 
 namespace launchdarkly::async {

--- a/libs/internal/include/launchdarkly/encoding/base_64.hpp
+++ b/libs/internal/include/launchdarkly/encoding/base_64.hpp
@@ -13,4 +13,13 @@ namespace launchdarkly::encoding {
  */
 std::string Base64UrlEncode(std::string const& input);
 
+/**
+ * Return a standard base64 encoded version of the input string, using the
+ * RFC 4648 section 4 alphabet (with '+' and '/'). Unlike @ref Base64UrlEncode,
+ * this is NOT URL-safe.
+ * @param input The string to Base64 encode.
+ * @return The encoded value.
+ */
+std::string Base64Encode(std::string const& input);
+
 }  // namespace launchdarkly::encoding

--- a/libs/internal/src/encoding/base_64.cpp
+++ b/libs/internal/src/encoding/base_64.cpp
@@ -1,10 +1,13 @@
 #include <launchdarkly/encoding/base_64.hpp>
 
+#include <openssl/evp.h>
+
 #include <algorithm>
 #include <array>
 #include <bitset>
 #include <climits>
 #include <cstddef>
+#include <vector>
 
 static unsigned char const kEncodeSize = 4;
 static unsigned char const kInputBytesPerEncodeSize = 3;
@@ -73,6 +76,19 @@ std::string Base64UrlEncode(std::string const& input) {
         out.append(kEncodeSize - (out.size()) % kEncodeSize, '=');
     }
     return out;
+}
+
+std::string Base64Encode(std::string const& input) {
+    if (input.empty()) {
+        return {};
+    }
+    // EVP_EncodeBlock writes 4 output characters per 3 input bytes (rounded up)
+    // plus a NUL terminator.
+    std::vector<unsigned char> out(4 * ((input.size() + 2) / 3) + 1);
+    int const written = EVP_EncodeBlock(
+        out.data(), reinterpret_cast<unsigned char const*>(input.data()),
+        static_cast<int>(input.size()));
+    return std::string(reinterpret_cast<char const*>(out.data()), written);
 }
 
 }  // namespace launchdarkly::encoding

--- a/libs/internal/tests/base_64_test.cpp
+++ b/libs/internal/tests/base_64_test.cpp
@@ -6,7 +6,7 @@ using launchdarkly::encoding::Base64Encode;
 using launchdarkly::encoding::Base64UrlEncode;
 
 TEST(Base64Encoding, CanEncodeString) {
-    // Test vectors from RFC4668
+    // Test vectors from RFC4648
     // https://datatracker.ietf.org/doc/html/rfc4648#section-10
     EXPECT_EQ("", Base64UrlEncode(""));
     EXPECT_EQ("Zg==", Base64UrlEncode("f"));
@@ -18,7 +18,7 @@ TEST(Base64Encoding, CanEncodeString) {
 }
 
 TEST(Base64Encoding, StandardCanEncodeString) {
-    // Test vectors from RFC4668
+    // Test vectors from RFC4648
     // https://datatracker.ietf.org/doc/html/rfc4648#section-10
     EXPECT_EQ("", Base64Encode(""));
     EXPECT_EQ("Zg==", Base64Encode("f"));

--- a/libs/internal/tests/base_64_test.cpp
+++ b/libs/internal/tests/base_64_test.cpp
@@ -2,6 +2,7 @@
 
 #include "launchdarkly/encoding/base_64.hpp"
 
+using launchdarkly::encoding::Base64Encode;
 using launchdarkly::encoding::Base64UrlEncode;
 
 TEST(Base64Encoding, CanEncodeString) {
@@ -14,4 +15,25 @@ TEST(Base64Encoding, CanEncodeString) {
     EXPECT_EQ("Zm9vYg==", Base64UrlEncode("foob"));
     EXPECT_EQ("Zm9vYmE=", Base64UrlEncode("fooba"));
     EXPECT_EQ("Zm9vYmFy", Base64UrlEncode("foobar"));
+}
+
+TEST(Base64Encoding, StandardCanEncodeString) {
+    // Test vectors from RFC4668
+    // https://datatracker.ietf.org/doc/html/rfc4648#section-10
+    EXPECT_EQ("", Base64Encode(""));
+    EXPECT_EQ("Zg==", Base64Encode("f"));
+    EXPECT_EQ("Zm8=", Base64Encode("fo"));
+    EXPECT_EQ("Zm9v", Base64Encode("foo"));
+    EXPECT_EQ("Zm9vYg==", Base64Encode("foob"));
+    EXPECT_EQ("Zm9vYmE=", Base64Encode("fooba"));
+    EXPECT_EQ("Zm9vYmFy", Base64Encode("foobar"));
+}
+
+TEST(Base64Encoding, StandardUsesNonUrlSafeAlphabet) {
+    // "???" encodes to a value ending in '/' under the standard alphabet and
+    // '_' under the URL-safe one; ">>>" exercises '+' versus '-'.
+    EXPECT_EQ("Pz8/", Base64Encode("???"));
+    EXPECT_EQ("Pz8_", Base64UrlEncode("???"));
+    EXPECT_EQ("Pj4+", Base64Encode(">>>"));
+    EXPECT_EQ("Pj4-", Base64UrlEncode(">>>"));
 }

--- a/libs/server-sdk-dynamodb-source/include/launchdarkly/server_side/integrations/dynamodb/dynamodb_big_segment_store.hpp
+++ b/libs/server-sdk-dynamodb-source/include/launchdarkly/server_side/integrations/dynamodb/dynamodb_big_segment_store.hpp
@@ -61,8 +61,8 @@ class DynamoDBBigSegmentStore final : public IBigSegmentStore {
            DynamoDBClientOptions options = {});
 
     [[nodiscard]] GetMembershipResult GetMembership(
-        std::string const& context_hash) const override;
-    [[nodiscard]] GetMetadataResult GetMetadata() const override;
+        std::string const& context_hash) const noexcept override;
+    [[nodiscard]] GetMetadataResult GetMetadata() const noexcept override;
 
     ~DynamoDBBigSegmentStore() override;
 

--- a/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
+++ b/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
@@ -65,99 +65,114 @@ DynamoDBBigSegmentStore::~DynamoDBBigSegmentStore() = default;
 
 IBigSegmentStore::GetMembershipResult DynamoDBBigSegmentStore::GetMembership(
     std::string const& context_hash) const noexcept {
-    Aws::DynamoDB::Model::GetItemRequest request;
-    request.SetTableName(table_name_);
-    request.SetConsistentRead(true);
-    request.AddKey(kPartitionKey,
-                   Aws::DynamoDB::Model::AttributeValue{user_namespace_});
-    request.AddKey(kSortKey,
-                   Aws::DynamoDB::Model::AttributeValue{context_hash});
+    try {
+        Aws::DynamoDB::Model::GetItemRequest request;
+        request.SetTableName(table_name_);
+        request.SetConsistentRead(true);
+        request.AddKey(kPartitionKey,
+                       Aws::DynamoDB::Model::AttributeValue{user_namespace_});
+        request.AddKey(kSortKey,
+                       Aws::DynamoDB::Model::AttributeValue{context_hash});
 
-    auto outcome = client_->GetItem(request);
-    if (!outcome.IsSuccess()) {
-        return tl::make_unexpected(outcome.GetError().GetMessage());
+        auto outcome = client_->GetItem(request);
+        if (!outcome.IsSuccess()) {
+            return tl::make_unexpected(outcome.GetError().GetMessage());
+        }
+
+        auto const& item = outcome.GetResult().GetItem();
+
+        std::vector<std::string> included;
+        std::vector<std::string> excluded;
+
+        // GetSS() silently returns an empty vector if the attribute is not
+        // actually a String Set, so check the type explicitly before reading.
+        if (auto const it = item.find(kBigSegmentsIncludedAttribute);
+            it != item.end()) {
+            if (it->second.GetType() !=
+                Aws::DynamoDB::Model::ValueType::STRING_SET) {
+                return tl::make_unexpected(
+                    std::string("DynamoDB Big Segments '") +
+                    kBigSegmentsIncludedAttribute +
+                    "' is not of type STRING_SET");
+            }
+            for (auto const& ref : it->second.GetSS()) {
+                included.emplace_back(ref);
+            }
+        }
+        if (auto const it = item.find(kBigSegmentsExcludedAttribute);
+            it != item.end()) {
+            if (it->second.GetType() !=
+                Aws::DynamoDB::Model::ValueType::STRING_SET) {
+                return tl::make_unexpected(
+                    std::string("DynamoDB Big Segments '") +
+                    kBigSegmentsExcludedAttribute +
+                    "' is not of type STRING_SET");
+            }
+            for (auto const& ref : it->second.GetSS()) {
+                excluded.emplace_back(ref);
+            }
+        }
+
+        return Membership::FromSegmentRefs(included, excluded);
+    } catch (std::exception const& e) {
+        return tl::make_unexpected(e.what());
     }
-
-    auto const& item = outcome.GetResult().GetItem();
-
-    std::vector<std::string> included;
-    std::vector<std::string> excluded;
-
-    // GetSS() silently returns an empty vector if the attribute is not
-    // actually a String Set, so check the type explicitly before reading.
-    if (auto const it = item.find(kBigSegmentsIncludedAttribute);
-        it != item.end()) {
-        if (it->second.GetType() !=
-            Aws::DynamoDB::Model::ValueType::STRING_SET) {
-            return tl::make_unexpected(std::string("DynamoDB Big Segments '") +
-                                       kBigSegmentsIncludedAttribute +
-                                       "' is not of type STRING_SET");
-        }
-        for (auto const& ref : it->second.GetSS()) {
-            included.emplace_back(ref);
-        }
-    }
-    if (auto const it = item.find(kBigSegmentsExcludedAttribute);
-        it != item.end()) {
-        if (it->second.GetType() !=
-            Aws::DynamoDB::Model::ValueType::STRING_SET) {
-            return tl::make_unexpected(std::string("DynamoDB Big Segments '") +
-                                       kBigSegmentsExcludedAttribute +
-                                       "' is not of type STRING_SET");
-        }
-        for (auto const& ref : it->second.GetSS()) {
-            excluded.emplace_back(ref);
-        }
-    }
-
-    return Membership::FromSegmentRefs(included, excluded);
 }
 
 IBigSegmentStore::GetMetadataResult DynamoDBBigSegmentStore::GetMetadata()
     const noexcept {
-    Aws::DynamoDB::Model::GetItemRequest request;
-    request.SetTableName(table_name_);
-    request.SetConsistentRead(true);
-    request.AddKey(kPartitionKey,
-                   Aws::DynamoDB::Model::AttributeValue{metadata_namespace_});
-    request.AddKey(kSortKey,
-                   Aws::DynamoDB::Model::AttributeValue{metadata_namespace_});
+    try {
+        Aws::DynamoDB::Model::GetItemRequest request;
+        request.SetTableName(table_name_);
+        request.SetConsistentRead(true);
+        request.AddKey(
+            kPartitionKey,
+            Aws::DynamoDB::Model::AttributeValue{metadata_namespace_});
+        request.AddKey(
+            kSortKey,
+            Aws::DynamoDB::Model::AttributeValue{metadata_namespace_});
 
-    auto outcome = client_->GetItem(request);
-    if (!outcome.IsSuccess()) {
-        return tl::make_unexpected(outcome.GetError().GetMessage());
+        auto outcome = client_->GetItem(request);
+        if (!outcome.IsSuccess()) {
+            return tl::make_unexpected(outcome.GetError().GetMessage());
+        }
+
+        auto const& item = outcome.GetResult().GetItem();
+        if (item.empty()) {
+            return std::nullopt;
+        }
+
+        auto const it = item.find(kBigSegmentsSyncTimeAttribute);
+        if (it == item.end()) {
+            // "absent" sync time is treated as never synchronized rather than
+            // an error; the wrapper marks the store stale based on the
+            // resulting nullopt.
+            return std::nullopt;
+        }
+
+        auto const& raw = it->second.GetN();
+        if (raw.empty()) {
+            return tl::make_unexpected(
+                "DynamoDB Big Segments 'synchronizedOn' is empty or not type "
+                "N");
+        }
+
+        errno = 0;
+        char* end = nullptr;
+        long long const parsed = std::strtoll(raw.c_str(), &end, 10);
+        if (errno != 0 || end == raw.c_str() || *end != '\0') {
+            return tl::make_unexpected(
+                "DynamoDB Big Segments 'synchronizedOn' is not a valid "
+                "integer");
+        }
+
+        // The stored value is a Unix-epoch millisecond count: system_clock's
+        // epoch.
+        return StoreMetadata{std::chrono::system_clock::time_point{
+            std::chrono::milliseconds{parsed}}};
+    } catch (std::exception const& e) {
+        return tl::make_unexpected(e.what());
     }
-
-    auto const& item = outcome.GetResult().GetItem();
-    if (item.empty()) {
-        return std::nullopt;
-    }
-
-    auto const it = item.find(kBigSegmentsSyncTimeAttribute);
-    if (it == item.end()) {
-        // "absent" sync time is treated as never synchronized rather than
-        // an error; the wrapper marks the store stale based on the
-        // resulting nullopt.
-        return std::nullopt;
-    }
-
-    auto const& raw = it->second.GetN();
-    if (raw.empty()) {
-        return tl::make_unexpected(
-            "DynamoDB Big Segments 'synchronizedOn' is empty or not type N");
-    }
-
-    errno = 0;
-    char* end = nullptr;
-    long long const parsed = std::strtoll(raw.c_str(), &end, 10);
-    if (errno != 0 || end == raw.c_str() || *end != '\0') {
-        return tl::make_unexpected(
-            "DynamoDB Big Segments 'synchronizedOn' is not a valid integer");
-    }
-
-    // The stored value is a Unix-epoch millisecond count: system_clock's epoch.
-    return StoreMetadata{std::chrono::system_clock::time_point{
-        std::chrono::milliseconds{parsed}}};
 }
 
 }  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
+++ b/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
@@ -64,7 +64,7 @@ DynamoDBBigSegmentStore::DynamoDBBigSegmentStore(
 DynamoDBBigSegmentStore::~DynamoDBBigSegmentStore() = default;
 
 IBigSegmentStore::GetMembershipResult DynamoDBBigSegmentStore::GetMembership(
-    std::string const& context_hash) const {
+    std::string const& context_hash) const noexcept {
     Aws::DynamoDB::Model::GetItemRequest request;
     request.SetTableName(table_name_);
     request.SetConsistentRead(true);
@@ -114,7 +114,7 @@ IBigSegmentStore::GetMembershipResult DynamoDBBigSegmentStore::GetMembership(
 }
 
 IBigSegmentStore::GetMetadataResult DynamoDBBigSegmentStore::GetMetadata()
-    const {
+    const noexcept {
     Aws::DynamoDB::Model::GetItemRequest request;
     request.SetTableName(table_name_);
     request.SetConsistentRead(true);

--- a/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
+++ b/libs/server-sdk-dynamodb-source/src/dynamodb_big_segment_store.cpp
@@ -89,10 +89,9 @@ IBigSegmentStore::GetMembershipResult DynamoDBBigSegmentStore::GetMembership(
         it != item.end()) {
         if (it->second.GetType() !=
             Aws::DynamoDB::Model::ValueType::STRING_SET) {
-            return tl::make_unexpected(
-                std::string("DynamoDB Big Segments '") +
-                kBigSegmentsIncludedAttribute +
-                "' is not of type STRING_SET");
+            return tl::make_unexpected(std::string("DynamoDB Big Segments '") +
+                                       kBigSegmentsIncludedAttribute +
+                                       "' is not of type STRING_SET");
         }
         for (auto const& ref : it->second.GetSS()) {
             included.emplace_back(ref);
@@ -102,10 +101,9 @@ IBigSegmentStore::GetMembershipResult DynamoDBBigSegmentStore::GetMembership(
         it != item.end()) {
         if (it->second.GetType() !=
             Aws::DynamoDB::Model::ValueType::STRING_SET) {
-            return tl::make_unexpected(
-                std::string("DynamoDB Big Segments '") +
-                kBigSegmentsExcludedAttribute +
-                "' is not of type STRING_SET");
+            return tl::make_unexpected(std::string("DynamoDB Big Segments '") +
+                                       kBigSegmentsExcludedAttribute +
+                                       "' is not of type STRING_SET");
         }
         for (auto const& ref : it->second.GetSS()) {
             excluded.emplace_back(ref);
@@ -157,7 +155,9 @@ IBigSegmentStore::GetMetadataResult DynamoDBBigSegmentStore::GetMetadata()
             "DynamoDB Big Segments 'synchronizedOn' is not a valid integer");
     }
 
-    return StoreMetadata{std::chrono::milliseconds{parsed}};
+    // The stored value is a Unix-epoch millisecond count: system_clock's epoch.
+    return StoreMetadata{std::chrono::system_clock::time_point{
+        std::chrono::milliseconds{parsed}}};
 }
 
 }  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk-dynamodb-source/tests/dynamodb_big_segment_store_test.cpp
+++ b/libs/server-sdk-dynamodb-source/tests/dynamodb_big_segment_store_test.cpp
@@ -163,7 +163,8 @@ TEST_F(DynamoDBBigSegmentTests, GetMetadataWithEmptyPrefix) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->has_value());
     ASSERT_EQ(result->value().last_up_to_date,
-              std::chrono::milliseconds{1700000000000LL});
+              std::chrono::system_clock::time_point{
+                  std::chrono::milliseconds{1700000000000LL}});
 }
 
 TEST_F(DynamoDBBigSegmentTests, GetMembershipRejectsMalformedIncluded) {
@@ -182,7 +183,8 @@ TEST_F(DynamoDBBigSegmentTests, GetMetadataReturnsSyncTime) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->has_value());
     ASSERT_EQ(result->value().last_up_to_date,
-              std::chrono::milliseconds{1700000000000LL});
+              std::chrono::system_clock::time_point{
+                  std::chrono::milliseconds{1700000000000LL}});
 }
 
 TEST_F(DynamoDBBigSegmentTests, GetMetadataAbsentSyncTimeReturnsNoMetadata) {

--- a/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_big_segment_store.hpp
+++ b/libs/server-sdk-redis-source/include/launchdarkly/server_side/integrations/redis/redis_big_segment_store.hpp
@@ -55,8 +55,8 @@ class RedisBigSegmentStore final : public IBigSegmentStore {
     Create(std::string uri, std::string prefix);
 
     [[nodiscard]] GetMembershipResult GetMembership(
-        std::string const& context_hash) const override;
-    [[nodiscard]] GetMetadataResult GetMetadata() const override;
+        std::string const& context_hash) const noexcept override;
+    [[nodiscard]] GetMetadataResult GetMetadata() const noexcept override;
 
     ~RedisBigSegmentStore() override;
 

--- a/libs/server-sdk-redis-source/src/redis_big_segment_store.cpp
+++ b/libs/server-sdk-redis-source/src/redis_big_segment_store.cpp
@@ -57,7 +57,7 @@ RedisBigSegmentStore::RedisBigSegmentStore(
 RedisBigSegmentStore::~RedisBigSegmentStore() = default;
 
 IBigSegmentStore::GetMembershipResult RedisBigSegmentStore::GetMembership(
-    std::string const& context_hash) const {
+    std::string const& context_hash) const noexcept {
     std::string const include_key = include_key_prefix_ + context_hash;
     std::string const exclude_key = exclude_key_prefix_ + context_hash;
 
@@ -76,7 +76,8 @@ IBigSegmentStore::GetMembershipResult RedisBigSegmentStore::GetMembership(
     return Membership::FromSegmentRefs(included, excluded);
 }
 
-IBigSegmentStore::GetMetadataResult RedisBigSegmentStore::GetMetadata() const {
+IBigSegmentStore::GetMetadataResult RedisBigSegmentStore::GetMetadata()
+    const noexcept {
     sw::redis::OptionalString raw;
     try {
         raw = redis_->get(sync_time_key_);

--- a/libs/server-sdk-redis-source/src/redis_big_segment_store.cpp
+++ b/libs/server-sdk-redis-source/src/redis_big_segment_store.cpp
@@ -98,7 +98,9 @@ IBigSegmentStore::GetMetadataResult RedisBigSegmentStore::GetMetadata() const {
             "Redis Big Segments synchronized_on is not a valid integer");
     }
 
-    return StoreMetadata{std::chrono::milliseconds{parsed}};
+    // The stored value is a Unix-epoch millisecond count: system_clock's epoch.
+    return StoreMetadata{std::chrono::system_clock::time_point{
+        std::chrono::milliseconds{parsed}}};
 }
 
 }  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk-redis-source/tests/redis_big_segment_store_test.cpp
+++ b/libs/server-sdk-redis-source/tests/redis_big_segment_store_test.cpp
@@ -143,7 +143,8 @@ TEST_F(RedisBigSegmentTests, GetMetadataWithEmptyPrefix) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->has_value());
     ASSERT_EQ(result->value().last_up_to_date,
-              std::chrono::milliseconds{1700000000000LL});
+              std::chrono::system_clock::time_point{
+                  std::chrono::milliseconds{1700000000000LL}});
 }
 
 TEST_F(RedisBigSegmentTests, GetMetadataReturnsSyncTime) {
@@ -153,7 +154,8 @@ TEST_F(RedisBigSegmentTests, GetMetadataReturnsSyncTime) {
     ASSERT_TRUE(result);
     ASSERT_TRUE(result->has_value());
     ASSERT_EQ(result->value().last_up_to_date,
-              std::chrono::milliseconds{1700000000000LL});
+              std::chrono::system_clock::time_point{
+                  std::chrono::milliseconds{1700000000000LL}});
 }
 
 TEST_F(RedisBigSegmentTests, GetMetadataRejectsMalformedSyncTime) {

--- a/libs/server-sdk/include/launchdarkly/server_side/integrations/big_segments/big_segment_store_types.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/integrations/big_segments/big_segment_store_types.hpp
@@ -87,11 +87,11 @@ class Membership {
  */
 struct StoreMetadata {
     /**
-     * @brief Wall-clock timestamp (Unix epoch) at which the data populator
-     * (e.g. the LaunchDarkly Relay Proxy) last confirmed it had pushed all
-     * pending Big Segments updates to the store.
+     * @brief Wall-clock instant at which the data populator (e.g. the
+     * LaunchDarkly Relay Proxy) last confirmed it had pushed all pending Big
+     * Segments updates to the store.
      */
-    std::chrono::milliseconds last_up_to_date;
+    std::chrono::system_clock::time_point last_up_to_date;
 };
 
 }  // namespace launchdarkly::server_side::integrations

--- a/libs/server-sdk/include/launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp
@@ -54,7 +54,7 @@ class IBigSegmentStore {
      * `std::nullopt`). Returns an error if the lookup itself failed.
      */
     [[nodiscard]] virtual GetMembershipResult GetMembership(
-        std::string const& context_hash) const = 0;
+        std::string const& context_hash) const noexcept = 0;
 
     /**
      * @brief Returns store-level metadata used by the SDK to detect staleness.
@@ -63,7 +63,7 @@ class IBigSegmentStore {
      * `std::nullopt` if no metadata has ever been written (the store was
      * never populated), or an error if the lookup itself failed.
      */
-    [[nodiscard]] virtual GetMetadataResult GetMetadata() const = 0;
+    [[nodiscard]] virtual GetMetadataResult GetMetadata() const noexcept = 0;
 
    protected:
     IBigSegmentStore() = default;

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -44,6 +44,11 @@ target_sources(${LIBNAME}
         data_components/dependency_tracker/dependency_tracker.cpp
         data_components/expiration_tracker/expiration_tracker.hpp
         data_components/expiration_tracker/expiration_tracker.cpp
+        data_components/big_segments/big_segments_status.hpp
+        data_components/big_segments/membership_cache.hpp
+        data_components/big_segments/membership_cache.cpp
+        data_components/big_segments/big_segment_store_wrapper.hpp
+        data_components/big_segments/big_segment_store_wrapper.cpp
         data_interfaces/destination/itransactional_destination.hpp
         data_components/memory_store/memory_store.hpp
         data_components/memory_store/memory_store.cpp

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
@@ -53,7 +53,6 @@ BigSegmentStoreWrapper::GetMembership(std::string const& context_key) {
             return {integrations::Membership::FromSegmentRefs({}, {}),
                     BigSegmentsStatus::kStoreError};
         }
-        cache_.Set(context_key, *result);
         membership = *result;
     }
 
@@ -87,6 +86,9 @@ BigSegmentStoreWrapper::StoreMembership BigSegmentStoreWrapper::LoadMembership(
     // Query the store outside any lock, then publish the result to waiters and
     // drop the in-flight entry.
     auto result = store_->GetMembership(HashContextKey(context_key));
+    if (result.has_value()) {
+        cache_.Set(context_key, *result);
+    }
     {
         std::lock_guard lock(load_mutex_);
         in_flight_.erase(context_key);

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
@@ -83,21 +83,46 @@ BigSegmentStoreWrapper::StoreMembership BigSegmentStoreWrapper::LoadMembership(
         return *query->result;
     }
 
-    // Query the store outside any lock, then publish the result to waiters and
-    // drop the in-flight entry.
+    // Ensures the in-flight entry is removed and waiters are notified on every
+    // leader exit, including throws. If the leader exits without completing,
+    // waiters receive a sentinel error rather than blocking forever.
+    struct QueryCleanup {
+        std::mutex& load_mutex;
+        std::unordered_map<std::string, std::shared_ptr<InFlightQuery>>&
+            in_flight;
+        std::string const& key;
+        std::shared_ptr<InFlightQuery> query;
+        bool completed = false;
+
+        ~QueryCleanup() {
+            {
+                std::lock_guard lock(load_mutex);
+                in_flight.erase(key);
+            }
+            if (!completed) {
+                std::lock_guard lock(query->mutex);
+                if (!query->result.has_value()) {
+                    query->result = tl::make_unexpected(std::string(
+                        "Big Segment lookup leader exited without setting a "
+                        "result"));
+                }
+            }
+            query->cv.notify_all();
+        }
+    };
+    QueryCleanup cleanup{load_mutex_, in_flight_, context_key, query};
+
+    // Query the store outside any lock, then publish the result. The cleanup
+    // drops the in-flight entry on return (or throw).
     auto result = store_->GetMembership(HashContextKey(context_key));
     if (result.has_value()) {
         cache_.Set(context_key, *result);
     }
     {
-        std::lock_guard lock(load_mutex_);
-        in_flight_.erase(context_key);
-    }
-    {
         std::lock_guard lock(query->mutex);
         query->result = result;
+        cleanup.completed = true;
     }
-    query->cv.notify_all();
     return result;
 }
 

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
@@ -1,0 +1,192 @@
+#include "big_segment_store_wrapper.hpp"
+
+#include <launchdarkly/async/timer.hpp>
+#include <launchdarkly/encoding/base_64.hpp>
+#include <launchdarkly/encoding/sha_256.hpp>
+#include <launchdarkly/signals/boost_signal_connection.hpp>
+
+#include <chrono>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace launchdarkly::server_side::data_components {
+
+namespace {
+// The store is keyed by base64(sha256(contextKey)), matching what the Relay
+// Proxy writes; raw context keys are never sent to the store.
+std::string HashContextKey(std::string const& context_key) {
+    auto const digest = encoding::Sha256String(context_key);
+    return encoding::Base64Encode(std::string(
+        reinterpret_cast<char const*>(digest.data()), digest.size()));
+}
+}  // namespace
+
+BigSegmentStoreWrapper::BigSegmentStoreWrapper(
+    config::built::BigSegmentsConfig const& config,
+    boost::asio::any_io_executor executor,
+    Logger const& logger)
+    : store_(config.store),
+      stale_after_(config.stale_after),
+      poll_interval_(config.status_poll_interval),
+      logger_(logger),
+      executor_(std::move(executor)),
+      cache_(config.context_cache_size, config.context_cache_time) {}
+
+BigSegmentStoreWrapper::~BigSegmentStoreWrapper() {
+    poll_cancel_.Cancel();
+}
+
+void BigSegmentStoreWrapper::Start() {
+    ScheduleNextPoll();
+}
+
+BigSegmentStoreWrapper::GetMembershipResult
+BigSegmentStoreWrapper::GetMembership(std::string const& context_key) {
+    auto membership = cache_.Get(context_key);
+    if (!membership.has_value()) {
+        auto const result = LoadMembership(context_key);
+        if (!result.has_value()) {
+            LD_LOG(logger_, LogLevel::kError)
+                << "Big Segment store returned error: " << result.error();
+            MarkStoreUnavailable();
+            return {integrations::Membership::FromSegmentRefs({}, {}),
+                    BigSegmentsStatus::kStoreError};
+        }
+        cache_.Set(context_key, *result);
+        membership = *result;
+    }
+
+    auto const status = GetStatus().stale ? BigSegmentsStatus::kStale
+                                          : BigSegmentsStatus::kHealthy;
+    return {std::move(*membership), status};
+}
+
+BigSegmentStoreWrapper::StoreMembership BigSegmentStoreWrapper::LoadMembership(
+    std::string const& context_key) {
+    std::shared_ptr<InFlightQuery> query;
+    bool is_leader = false;
+    {
+        std::lock_guard lock(load_mutex_);
+        auto const it = in_flight_.find(context_key);
+        if (it != in_flight_.end()) {
+            query = it->second;
+        } else {
+            query = std::make_shared<InFlightQuery>();
+            in_flight_.emplace(context_key, query);
+            is_leader = true;
+        }
+    }
+
+    if (!is_leader) {
+        std::unique_lock lock(query->mutex);
+        query->cv.wait(lock, [&query] { return query->result.has_value(); });
+        return *query->result;
+    }
+
+    // Query the store outside any lock, then publish the result to waiters and
+    // drop the in-flight entry.
+    auto result = store_->GetMembership(HashContextKey(context_key));
+    {
+        std::lock_guard lock(load_mutex_);
+        in_flight_.erase(context_key);
+    }
+    {
+        std::lock_guard lock(query->mutex);
+        query->result = result;
+    }
+    query->cv.notify_all();
+    return result;
+}
+
+void BigSegmentStoreWrapper::MarkStoreUnavailable() {
+    BigSegmentStoreStatus new_status;
+    bool changed;
+    {
+        std::lock_guard lock(status_mutex_);
+        new_status.available = false;
+        new_status.stale = last_status_.has_value() && last_status_->stale;
+        changed = !last_status_.has_value() || *last_status_ != new_status;
+        last_status_ = new_status;
+    }
+    if (changed) {
+        status_signal_(new_status);
+    }
+}
+
+void BigSegmentStoreWrapper::ScheduleNextPoll() {
+    auto weak_self = weak_from_this();
+    async::Delay(executor_, poll_interval_, poll_cancel_.GetToken())
+        .Then(
+            [weak_self](bool const& fired_normally) -> std::monostate {
+                if (!fired_normally) {
+                    // Cancelled (wrapper destroyed); stop polling.
+                    return {};
+                }
+                if (auto self = weak_self.lock()) {
+                    self->PollStoreAndUpdateStatus();
+                    self->ScheduleNextPoll();
+                }
+                return {};
+            },
+            async::kInlineExecutor);
+}
+
+BigSegmentStoreStatus BigSegmentStoreWrapper::GetStatus() {
+    {
+        std::lock_guard lock(status_mutex_);
+        if (last_status_.has_value()) {
+            return *last_status_;
+        }
+    }
+    // No poll has completed yet; do one now so the caller gets an accurate
+    // staleness reading rather than a default.
+    return PollStoreAndUpdateStatus();
+}
+
+BigSegmentStoreStatus BigSegmentStoreWrapper::PollStoreAndUpdateStatus() {
+    // Query the store outside the lock so a slow store doesn't block callers.
+    auto const metadata = store_->GetMetadata();
+    if (!metadata.has_value()) {
+        LD_LOG(logger_, LogLevel::kError)
+            << "Big Segment store status query returned error: "
+            << metadata.error();
+    }
+
+    BigSegmentStoreStatus new_status;
+    bool changed;
+    {
+        std::lock_guard lock(status_mutex_);
+        if (metadata.has_value()) {
+            new_status.available = true;
+            new_status.stale =
+                !metadata->has_value() || IsStale((*metadata)->last_up_to_date);
+        } else {
+            new_status.available = false;
+            // Availability is bad; carry the last-known staleness forward.
+            new_status.stale = last_status_.has_value() && last_status_->stale;
+        }
+        changed = !last_status_.has_value() || *last_status_ != new_status;
+        last_status_ = new_status;
+    }
+
+    // Broadcast after releasing the lock so a listener can't deadlock against
+    // it. Listeners are notified on the first poll and on any change.
+    if (changed) {
+        status_signal_(new_status);
+    }
+    return new_status;
+}
+
+bool BigSegmentStoreWrapper::IsStale(
+    std::chrono::system_clock::time_point last_up_to_date) const {
+    return (std::chrono::system_clock::now() - last_up_to_date) >= stale_after_;
+}
+
+std::unique_ptr<IConnection> BigSegmentStoreWrapper::OnStatusChange(
+    std::function<void(BigSegmentStoreStatus)> handler) {
+    return std::make_unique<internal::signals::SignalConnection>(
+        status_signal_.connect(std::move(handler)));
+}
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.cpp
@@ -142,8 +142,12 @@ BigSegmentStoreStatus BigSegmentStoreWrapper::GetStatus() {
         }
     }
     // No poll has completed yet; do one now so the caller gets an accurate
-    // staleness reading rather than a default.
-    return PollStoreAndUpdateStatus();
+    // staleness reading rather than a default. call_once coalesces concurrent
+    // first-callers onto a single store query.
+    std::call_once(first_poll_once_,
+                   [this] { PollStoreAndUpdateStatus(); });
+    std::lock_guard lock(status_mutex_);
+    return *last_status_;
 }
 
 BigSegmentStoreStatus BigSegmentStoreWrapper::PollStoreAndUpdateStatus() {

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
@@ -93,7 +93,8 @@ class BigSegmentStoreWrapper
 
     /**
      * @brief Registers a listener invoked whenever the store status changes
-     * (not on every poll). The returned connection unregisters on destruction.
+     * (not on every poll). Call Disconnect() on the returned connection to
+     * stop receiving events.
      */
     std::unique_ptr<IConnection> OnStatusChange(
         std::function<void(BigSegmentStoreStatus)> handler);

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
@@ -138,7 +138,14 @@ class BigSegmentStoreWrapper
     // Cancels the pending poll delay on destruction, ending the poll loop.
     async::CancellationSource poll_cancel_;
 
+    // Internally thread-safe.
     MembershipCache cache_;
+
+    // Broadcasts status changes to listeners registered via OnStatusChange.
+    boost::signals2::signal<void(BigSegmentStoreStatus)> status_signal_;
+
+    // Coalesces the cold-start fallback poll in GetStatus().
+    std::once_flag first_poll_once_;
 
     // In-flight store queries keyed by context key. Protected by load_mutex_.
     std::mutex load_mutex_;
@@ -147,8 +154,6 @@ class BigSegmentStoreWrapper
     // Protected by status_mutex_; nullopt until the first poll completes.
     std::mutex status_mutex_;
     std::optional<BigSegmentStoreStatus> last_status_;
-
-    boost::signals2::signal<void(BigSegmentStoreStatus)> status_signal_;
 };
 
 }  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_wrapper.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "big_segments_status.hpp"
+#include "membership_cache.hpp"
+
+#include <launchdarkly/server_side/config/built/big_segments_config.hpp>
+#include <launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp>
+
+#include <launchdarkly/async/cancellation.hpp>
+#include <launchdarkly/connection.hpp>
+#include <launchdarkly/logging/logger.hpp>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/signals2/signal.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace launchdarkly::server_side::data_components {
+
+/**
+ * @brief Internal layer between the evaluator and a customer-provided
+ * @ref integrations::IBigSegmentStore.
+ *
+ * Adds context-key hashing, an LRU membership cache, a background task that
+ * polls the store's metadata to track availability and staleness, and a
+ * status-change broadcaster.
+ *
+ * Construct with @ref std::make_shared and call @ref Start once to begin
+ * background polling; polling stops when the wrapper is destroyed.
+ *
+ * Thread-safe: @ref GetMembership, @ref GetStatus, and @ref OnStatusChange may
+ * be called concurrently from any number of evaluation threads, including while
+ * the background poll runs on the executor. The store is only ever queried with
+ * the relevant lock released, so a slow store never blocks unrelated callers.
+ */
+class BigSegmentStoreWrapper
+    : public std::enable_shared_from_this<BigSegmentStoreWrapper> {
+   public:
+    /**
+     * @param config Resolved Big Segments configuration.
+     * @param executor Executor the background poll runs on.
+     * @param logger Used for store-error and debug logging. Must outlive the
+     * wrapper.
+     */
+    BigSegmentStoreWrapper(config::built::BigSegmentsConfig const& config,
+                           boost::asio::any_io_executor executor,
+                           Logger const& logger);
+
+    ~BigSegmentStoreWrapper();
+
+    BigSegmentStoreWrapper(BigSegmentStoreWrapper const&) = delete;
+    BigSegmentStoreWrapper(BigSegmentStoreWrapper&&) = delete;
+    BigSegmentStoreWrapper& operator=(BigSegmentStoreWrapper const&) = delete;
+    BigSegmentStoreWrapper& operator=(BigSegmentStoreWrapper&&) = delete;
+
+    /**
+     * @brief Begins periodic metadata polling on the executor. Call once after
+     * construction.
+     */
+    void Start();
+
+    struct GetMembershipResult {
+        integrations::Membership membership;
+        BigSegmentsStatus status;
+    };
+
+    /**
+     * @brief Returns a context's Big Segments membership, with a status
+     * describing how trustworthy the answer is.
+     *
+     * May be called concurrently from multiple evaluation threads. If the
+     * status is @ref BigSegmentsStatus::kStoreError the lookup failed and the
+     * returned membership is empty.
+     *
+     * @param context_key The unhashed context key.
+     */
+    [[nodiscard]] GetMembershipResult GetMembership(
+        std::string const& context_key);
+
+    /**
+     * @brief Returns the current store health. If no metadata poll has
+     * completed yet, performs one synchronously on the calling thread first, so
+     * the first caller still gets an accurate staleness reading.
+     */
+    [[nodiscard]] BigSegmentStoreStatus GetStatus();
+
+    /**
+     * @brief Registers a listener invoked whenever the store status changes
+     * (not on every poll). The returned connection unregisters on destruction.
+     */
+    std::unique_ptr<IConnection> OnStatusChange(
+        std::function<void(BigSegmentStoreStatus)> handler);
+
+   private:
+    using StoreMembership = integrations::IBigSegmentStore::GetMembershipResult;
+
+    // A store query shared by all callers that miss the same key concurrently:
+    // the leader fills result and notifies; waiters block on cv until then.
+    struct InFlightQuery {
+        std::mutex mutex;
+        std::condition_variable cv;
+        std::optional<StoreMembership> result;
+    };
+
+    // Returns the membership for a key, querying the store on a cache miss and
+    // coalescing concurrent misses of the same key into one query.
+    [[nodiscard]] StoreMembership LoadMembership(
+        std::string const& context_key);
+
+    // Marks the store unavailable after an evaluation-time error, preserving
+    // the last-known staleness, and broadcasts if the status changed.
+    void MarkStoreUnavailable();
+
+    // Queries store metadata, atomically updates the status, broadcasts if it
+    // changed, and returns the new status.
+    BigSegmentStoreStatus PollStoreAndUpdateStatus();
+
+    [[nodiscard]] bool IsStale(
+        std::chrono::system_clock::time_point last_up_to_date) const;
+
+    // Arms a one-shot delay that polls then re-arms itself, until cancelled.
+    void ScheduleNextPoll();
+
+    std::shared_ptr<integrations::IBigSegmentStore> const store_;
+    std::chrono::milliseconds const stale_after_;
+    std::chrono::milliseconds const poll_interval_;
+    Logger const& logger_;
+
+    boost::asio::any_io_executor executor_;
+
+    // Cancels the pending poll delay on destruction, ending the poll loop.
+    async::CancellationSource poll_cancel_;
+
+    MembershipCache cache_;
+
+    // In-flight store queries keyed by context key. Protected by load_mutex_.
+    std::mutex load_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<InFlightQuery>> in_flight_;
+
+    // Protected by status_mutex_; nullopt until the first poll completes.
+    std::mutex status_mutex_;
+    std::optional<BigSegmentStoreStatus> last_status_;
+
+    boost::signals2::signal<void(BigSegmentStoreStatus)> status_signal_;
+};
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/big_segments_status.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segments_status.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace launchdarkly::server_side::data_components {
+
+/**
+ * @brief Trustworthiness of a Big Segments membership answer, surfaced on an
+ * evaluation's reason.
+ *
+ * - kHealthy: the store was queried successfully and its data is up to date.
+ * - kStale: queried successfully, but the data may be out of date.
+ * - kStoreError: the store query failed.
+ * - kNotConfigured: a flag referenced a Big Segment but no store is wired up,
+ *   or the segment has no generation.
+ */
+enum class BigSegmentsStatus { kHealthy, kStale, kStoreError, kNotConfigured };
+
+/**
+ * @brief Health of the Big Segments store as a whole, independent of any single
+ * context's membership.
+ */
+struct BigSegmentStoreStatus {
+    // The most recent store query or metadata poll succeeded.
+    bool available{false};
+    // The store's last-known update is older than the configured threshold.
+    bool stale{false};
+};
+
+inline bool operator==(BigSegmentStoreStatus const& a,
+                       BigSegmentStoreStatus const& b) {
+    return a.available == b.available && a.stale == b.stale;
+}
+
+inline bool operator!=(BigSegmentStoreStatus const& a,
+                       BigSegmentStoreStatus const& b) {
+    return !(a == b);
+}
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/membership_cache.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/membership_cache.cpp
@@ -1,0 +1,70 @@
+#include "membership_cache.hpp"
+
+#include <utility>
+
+namespace launchdarkly::server_side::data_components {
+
+MembershipCache::MembershipCache(
+    std::size_t capacity,
+    std::chrono::milliseconds ttl,
+    std::function<std::chrono::steady_clock::time_point()> clock)
+    : capacity_(capacity), ttl_(ttl), clock_(std::move(clock)) {}
+
+std::optional<integrations::Membership> MembershipCache::Get(
+    std::string const& key) {
+    std::lock_guard lock(mutex_);
+
+    auto const it = entries_.find(key);
+    if (it == entries_.end()) {
+        return std::nullopt;
+    }
+
+    if (clock_() >= it->second.expires_at) {
+        recency_.erase(it->second.recency_position);
+        entries_.erase(it);
+        return std::nullopt;
+    }
+
+    // Move to front as most-recently-used.
+    recency_.splice(recency_.begin(), recency_, it->second.recency_position);
+    return it->second.membership;
+}
+
+void MembershipCache::Set(std::string const& key,
+                          integrations::Membership membership) {
+    std::lock_guard lock(mutex_);
+
+    auto const expires_at = clock_() + ttl_;
+
+    auto const it = entries_.find(key);
+    if (it != entries_.end()) {
+        recency_.splice(recency_.begin(), recency_,
+                        it->second.recency_position);
+        it->second.membership = std::move(membership);
+        it->second.expires_at = expires_at;
+        return;
+    }
+
+    recency_.push_front(key);
+    entries_.emplace(
+        key, Entry{recency_.begin(), std::move(membership), expires_at});
+
+    if (entries_.size() > capacity_) {
+        auto const& lru_key = recency_.back();
+        entries_.erase(lru_key);
+        recency_.pop_back();
+    }
+}
+
+void MembershipCache::Clear() {
+    std::lock_guard lock(mutex_);
+    entries_.clear();
+    recency_.clear();
+}
+
+std::size_t MembershipCache::Size() const {
+    std::lock_guard lock(mutex_);
+    return entries_.size();
+}
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/membership_cache.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/membership_cache.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <launchdarkly/server_side/integrations/big_segments/big_segment_store_types.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace launchdarkly::server_side::data_components {
+
+/**
+ * @brief Bounded, time-expiring cache of Big Segment membership lookups, keyed
+ * by the unhashed context key.
+ *
+ * The cache holds at most a fixed number of entries; inserting beyond that
+ * evicts the least-recently-used entry. Each entry also has a time-to-live.
+ *
+ * Expiration is lazy — there is no background reaper. An expired entry is
+ * detected and dropped only when @ref Get is next called for its key (reported
+ * as a miss). Until then it keeps occupying a slot, counts toward @ref Size,
+ * and is eligible for normal LRU eviction like any live entry. The cache never
+ * exceeds its capacity regardless, because @ref Set evicts on insert.
+ *
+ * Thread-safe: every method is guarded by an internal mutex and may be called
+ * concurrently. Concurrent-load deduplication (querying the store once when
+ * several callers miss the same key at once) is not handled here; that is the
+ * caller's responsibility.
+ */
+class MembershipCache {
+   public:
+    /**
+     * @param capacity Maximum number of entries retained before LRU eviction.
+     * @param ttl How long an entry remains valid after insertion.
+     * @param clock Source of the current time, injectable for testing.
+     * Defaults to the steady clock.
+     */
+    MembershipCache(
+        std::size_t capacity,
+        std::chrono::milliseconds ttl,
+        std::function<std::chrono::steady_clock::time_point()> clock = [] {
+            return std::chrono::steady_clock::now();
+        });
+
+    /**
+     * @brief Returns the cached membership for a context key, or nullopt if the
+     * key is absent or its entry has expired. A hit refreshes the entry's LRU
+     * recency but not its expiration; an expired entry is removed.
+     */
+    [[nodiscard]] std::optional<integrations::Membership> Get(
+        std::string const& key);
+
+    /**
+     * @brief Inserts or replaces the membership for a context key, marking it
+     * most-recently-used and resetting its expiration. Evicts the least-
+     * recently-used entry if this pushes the cache over capacity.
+     */
+    void Set(std::string const& key, integrations::Membership membership);
+
+    /**
+     * @brief Removes all entries.
+     */
+    void Clear();
+
+    /**
+     * @brief Returns the number of entries currently held, including any that
+     * have expired but not yet been pruned.
+     */
+    [[nodiscard]] std::size_t Size() const;
+
+   private:
+    struct Entry {
+        // Position of this key in recency_, for O(1) LRU updates.
+        std::list<std::string>::iterator recency_position;
+        integrations::Membership membership;
+        std::chrono::steady_clock::time_point expires_at;
+    };
+
+    std::size_t const capacity_;
+    std::chrono::milliseconds const ttl_;
+    std::function<std::chrono::steady_clock::time_point()> const clock_;
+
+    mutable std::mutex mutex_;
+    // Most-recently-used at the front, least at the back. Protected by mutex_.
+    std::list<std::string> recency_;
+    std::unordered_map<std::string, Entry> entries_;
+};
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
+++ b/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
@@ -307,7 +307,7 @@ TEST(BigSegmentStoreWrapperMembershipTest,
     EXPECT_FALSE(wrapper->GetStatus().available);
 
     // The error was not cached, so the next lookup queries the store again.
-    wrapper->GetMembership("ctx");
+    (void)wrapper->GetMembership("ctx");
     EXPECT_EQ(2, store->MembershipCalls());
 }
 

--- a/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
+++ b/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
@@ -27,7 +27,8 @@ namespace {
 // times GetMetadata was called and lets a test block until a target count.
 class FakeBigSegmentStore : public integrations::IBigSegmentStore {
    public:
-    GetMembershipResult GetMembership(std::string const&) const override {
+    GetMembershipResult GetMembership(
+        std::string const&) const noexcept override {
         std::unique_lock lock(mutex_);
         ++membership_calls_;
         cv_.notify_all();
@@ -37,7 +38,7 @@ class FakeBigSegmentStore : public integrations::IBigSegmentStore {
         return membership_;
     }
 
-    GetMetadataResult GetMetadata() const override {
+    GetMetadataResult GetMetadata() const noexcept override {
         std::lock_guard lock(mutex_);
         ++metadata_calls_;
         cv_.notify_all();

--- a/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
+++ b/libs/server-sdk/tests/big_segment_store_wrapper_test.cpp
@@ -1,0 +1,368 @@
+#include <gtest/gtest.h>
+
+#include <data_components/big_segments/big_segment_store_wrapper.hpp>
+
+#include <launchdarkly/logging/null_logger.hpp>
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+using launchdarkly::server_side::data_components::BigSegmentsStatus;
+using launchdarkly::server_side::data_components::BigSegmentStoreStatus;
+using launchdarkly::server_side::data_components::BigSegmentStoreWrapper;
+namespace integrations = launchdarkly::server_side::integrations;
+namespace built = launchdarkly::server_side::config::built;
+using namespace std::chrono_literals;
+
+namespace {
+
+// In-memory store whose metadata response the test controls. Records how many
+// times GetMetadata was called and lets a test block until a target count.
+class FakeBigSegmentStore : public integrations::IBigSegmentStore {
+   public:
+    GetMembershipResult GetMembership(std::string const&) const override {
+        std::unique_lock lock(mutex_);
+        ++membership_calls_;
+        cv_.notify_all();
+        // If gated, hold the query "in flight" until ReleaseMembership opens
+        // it.
+        cv_.wait(lock, [this] { return gate_open_; });
+        return membership_;
+    }
+
+    GetMetadataResult GetMetadata() const override {
+        std::lock_guard lock(mutex_);
+        ++metadata_calls_;
+        cv_.notify_all();
+        return metadata_;
+    }
+
+    void SetMembership(GetMembershipResult membership) {
+        std::lock_guard lock(mutex_);
+        membership_ = std::move(membership);
+    }
+
+    void SetMetadata(GetMetadataResult metadata) {
+        std::lock_guard lock(mutex_);
+        metadata_ = std::move(metadata);
+    }
+
+    int MembershipCalls() const {
+        std::lock_guard lock(mutex_);
+        return membership_calls_;
+    }
+
+    int MetadataCalls() const {
+        std::lock_guard lock(mutex_);
+        return metadata_calls_;
+    }
+
+    void WaitForMembershipCalls(int n, std::chrono::milliseconds timeout) {
+        std::unique_lock lock(mutex_);
+        cv_.wait_for(lock, timeout, [&] { return membership_calls_ >= n; });
+    }
+
+    void WaitForMetadataCalls(int n, std::chrono::milliseconds timeout) {
+        std::unique_lock lock(mutex_);
+        cv_.wait_for(lock, timeout, [&] { return metadata_calls_ >= n; });
+    }
+
+    void BlockMembership() {
+        std::lock_guard lock(mutex_);
+        gate_open_ = false;
+    }
+
+    void ReleaseMembership() {
+        {
+            std::lock_guard lock(mutex_);
+            gate_open_ = true;
+        }
+        cv_.notify_all();
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    // Notified whenever a call is recorded or the gate opens. Tests wait on it
+    // for call counts; a gated GetMembership waits on it for the gate to open.
+    mutable std::condition_variable cv_;
+
+    // All of the following are protected by mutex_.
+    mutable int metadata_calls_ = 0;
+    mutable int membership_calls_ = 0;
+    GetMetadataResult metadata_ =
+        std::optional<integrations::StoreMetadata>{std::nullopt};
+    GetMembershipResult membership_ =
+        integrations::Membership::FromSegmentRefs({}, {});
+    // When false, GetMembership blocks until ReleaseMembership().
+    bool gate_open_ = true;
+};
+
+// Collects status broadcasts and lets a test block until a target count.
+class StatusCollector {
+   public:
+    void Add(BigSegmentStoreStatus status) {
+        std::lock_guard lock(mutex_);
+        statuses_.push_back(status);
+        cv_.notify_all();
+    }
+
+    bool WaitForCount(std::size_t n, std::chrono::milliseconds timeout) {
+        std::unique_lock lock(mutex_);
+        return cv_.wait_for(lock, timeout,
+                            [&] { return statuses_.size() >= n; });
+    }
+
+    std::vector<BigSegmentStoreStatus> Statuses() const {
+        std::lock_guard lock(mutex_);
+        return statuses_;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<BigSegmentStoreStatus> statuses_;
+};
+
+built::BigSegmentsConfig MakeConfig(
+    std::shared_ptr<integrations::IBigSegmentStore> store,
+    std::chrono::milliseconds poll_interval,
+    std::chrono::milliseconds stale_after) {
+    built::BigSegmentsConfig config;
+    config.store = std::move(store);
+    config.context_cache_size = 1000;
+    config.context_cache_time = 5s;
+    config.status_poll_interval = poll_interval;
+    config.stale_after = stale_after;
+    return config;
+}
+
+// Builds a wrapper over a store with the given metadata and returns the status
+// from its initial synchronous poll. The executor is never run, since GetStatus
+// polls inline when no background poll has happened yet.
+BigSegmentStoreStatus StatusForMetadata(
+    integrations::IBigSegmentStore::GetMetadataResult metadata) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(std::move(metadata));
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+    return wrapper->GetStatus();
+}
+
+}  // namespace
+
+TEST(BigSegmentStoreWrapperStatusTest, FreshMetadataIsHealthy) {
+    auto status = StatusForMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+    EXPECT_TRUE(status.available);
+    EXPECT_FALSE(status.stale);
+}
+
+TEST(BigSegmentStoreWrapperStatusTest, OldMetadataIsStale) {
+    auto status = StatusForMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now() - 5min});
+    EXPECT_TRUE(status.available);
+    EXPECT_TRUE(status.stale);
+}
+
+TEST(BigSegmentStoreWrapperStatusTest, NeverSyncedIsStale) {
+    auto status = StatusForMetadata(
+        std::optional<integrations::StoreMetadata>{std::nullopt});
+    EXPECT_TRUE(status.available);
+    EXPECT_TRUE(status.stale);
+}
+
+TEST(BigSegmentStoreWrapperStatusTest, StoreErrorIsUnavailable) {
+    auto status = StatusForMetadata(tl::make_unexpected("boom"));
+    EXPECT_FALSE(status.available);
+    EXPECT_FALSE(status.stale);
+}
+
+TEST(BigSegmentStoreWrapperStatusTest, GetStatusCachesFirstPollResult) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    auto first = wrapper->GetStatus();
+    auto second = wrapper->GetStatus();
+    EXPECT_EQ(first, second);
+
+    // Only the first GetStatus queries the store; the rest reuse its result.
+    EXPECT_EQ(1, store->MetadataCalls());
+}
+
+TEST(BigSegmentStoreWrapperStatusTest, BackgroundPollNotifiesOnlyOnChange) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto work_guard = boost::asio::make_work_guard(ioc);
+    std::thread io_thread([&ioc] { ioc.run(); });
+
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5ms, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    StatusCollector collector;
+    auto connection = wrapper->OnStatusChange(
+        [&collector](BigSegmentStoreStatus status) { collector.Add(status); });
+
+    wrapper->Start();
+
+    // First poll broadcasts the initial healthy status.
+    ASSERT_TRUE(collector.WaitForCount(1, 1s));
+
+    // Several more polls occur with unchanged metadata; none should broadcast.
+    store->WaitForMetadataCalls(5, 1s);
+
+    // A change flips availability and broadcasts exactly once more.
+    store->SetMetadata(tl::make_unexpected("boom"));
+    ASSERT_TRUE(collector.WaitForCount(2, 1s));
+
+    // Stop the io loop before the wrapper is destroyed so no poll runs during
+    // destruction.
+    work_guard.reset();
+    ioc.stop();
+    io_thread.join();
+
+    auto statuses = collector.Statuses();
+    ASSERT_EQ(2u, statuses.size());
+    EXPECT_TRUE(statuses[0].available);
+    EXPECT_FALSE(statuses[1].available);
+}
+
+TEST(BigSegmentStoreWrapperMembershipTest,
+     CacheMissReturnsMembershipFromStore) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+    store->SetMembership(
+        integrations::Membership::FromSegmentRefs({"segA.g1"}, {"segB.g2"}));
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    auto result = wrapper->GetMembership("ctx");
+    EXPECT_EQ(BigSegmentsStatus::kHealthy, result.status);
+    EXPECT_EQ(true, result.membership.CheckMembership("segA.g1"));
+    EXPECT_EQ(false, result.membership.CheckMembership("segB.g2"));
+}
+
+TEST(BigSegmentStoreWrapperMembershipTest, CacheHitAvoidsSecondQuery) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+    store->SetMembership(
+        integrations::Membership::FromSegmentRefs({"segA.g1"}, {}));
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    auto first = wrapper->GetMembership("ctx");
+    auto second = wrapper->GetMembership("ctx");
+    EXPECT_EQ(true, second.membership.CheckMembership("segA.g1"));
+    EXPECT_EQ(1, store->MembershipCalls());
+}
+
+TEST(BigSegmentStoreWrapperMembershipTest,
+     StoreErrorIsNotCachedAndMarksUnavailable) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+    store->SetMembership(tl::make_unexpected("boom"));
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    auto result = wrapper->GetMembership("ctx");
+    EXPECT_EQ(BigSegmentsStatus::kStoreError, result.status);
+    EXPECT_FALSE(result.membership.CheckMembership("segA.g1").has_value());
+    EXPECT_FALSE(wrapper->GetStatus().available);
+
+    // The error was not cached, so the next lookup queries the store again.
+    wrapper->GetMembership("ctx");
+    EXPECT_EQ(2, store->MembershipCalls());
+}
+
+TEST(BigSegmentStoreWrapperMembershipTest, StaleStoreMakesMembershipStale) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now() - 5min});
+    store->SetMembership(
+        integrations::Membership::FromSegmentRefs({"segA.g1"}, {}));
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    auto result = wrapper->GetMembership("ctx");
+    EXPECT_EQ(BigSegmentsStatus::kStale, result.status);
+    EXPECT_EQ(true, result.membership.CheckMembership("segA.g1"));
+}
+
+TEST(BigSegmentStoreWrapperMembershipTest, ConcurrentMissesShareOneStoreQuery) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+    store->SetMembership(
+        integrations::Membership::FromSegmentRefs({"segA.g1"}, {}));
+    store->BlockMembership();
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s, /*stale_after=*/2min),
+        ioc.get_executor(), logger);
+
+    std::optional<BigSegmentStoreWrapper::GetMembershipResult> r1;
+    std::optional<BigSegmentStoreWrapper::GetMembershipResult> r2;
+    std::thread t1([&] { r1 = wrapper->GetMembership("ctx"); });
+    std::thread t2([&] { r2 = wrapper->GetMembership("ctx"); });
+
+    // One caller becomes the leader and blocks in the store; while it is
+    // blocked the in-flight entry persists, so the brief pause lets the other
+    // caller reach the coalescing check and wait on that entry rather than
+    // issuing its own query. (If coalescing were broken the follower would call
+    // the store during the pause, pushing MembershipCalls to 2.)
+    store->WaitForMembershipCalls(1, 1s);
+    std::this_thread::sleep_for(50ms);
+    store->ReleaseMembership();
+
+    t1.join();
+    t2.join();
+
+    ASSERT_TRUE(r1.has_value());
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(true, r1->membership.CheckMembership("segA.g1"));
+    EXPECT_EQ(true, r2->membership.CheckMembership("segA.g1"));
+    EXPECT_EQ(1, store->MembershipCalls());
+}

--- a/libs/server-sdk/tests/big_segments_builder_test.cpp
+++ b/libs/server-sdk/tests/big_segments_builder_test.cpp
@@ -23,10 +23,10 @@ using namespace std::chrono_literals;
 class StubStore final : public IBigSegmentStore {
    public:
     GetMembershipResult GetMembership(
-        std::string const& /*context_hash*/) const override {
+        std::string const& /*context_hash*/) const noexcept override {
         return Membership::FromSegmentRefs({}, {});
     }
-    GetMetadataResult GetMetadata() const override {
+    GetMetadataResult GetMetadata() const noexcept override {
         return std::optional<StoreMetadata>{};
     }
 };

--- a/libs/server-sdk/tests/membership_cache_test.cpp
+++ b/libs/server-sdk/tests/membership_cache_test.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <data_components/big_segments/membership_cache.hpp>
+
+#include <chrono>
+#include <functional>
+
+using launchdarkly::server_side::data_components::MembershipCache;
+using launchdarkly::server_side::integrations::Membership;
+using namespace std::chrono_literals;
+
+namespace {
+
+// A clock whose value the test advances by hand, so TTL behavior is
+// deterministic rather than dependent on wall-clock timing.
+class FakeClock {
+   public:
+    void Advance(std::chrono::milliseconds by) { now_ += by; }
+
+    std::function<std::chrono::steady_clock::time_point()> AsFn() {
+        return [this] { return now_; };
+    }
+
+   private:
+    std::chrono::steady_clock::time_point now_{};
+};
+
+Membership MemberOf(std::string const& segment_ref) {
+    return Membership::FromSegmentRefs({segment_ref}, {});
+}
+
+}  // namespace
+
+TEST(MembershipCacheTest, MissOnAbsentKey) {
+    MembershipCache cache(10, 1000ms);
+    EXPECT_FALSE(cache.Get("nobody").has_value());
+}
+
+TEST(MembershipCacheTest, ReturnsStoredValue) {
+    MembershipCache cache(10, 1000ms);
+    cache.Set("a", MemberOf("seg.g1"));
+
+    auto result = cache.Get("a");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(true, result->CheckMembership("seg.g1"));
+}
+
+TEST(MembershipCacheTest, SetReplacesExistingValue) {
+    MembershipCache cache(10, 1000ms);
+    cache.Set("a", MemberOf("first.g1"));
+    cache.Set("a", MemberOf("second.g1"));
+
+    auto result = cache.Get("a");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->CheckMembership("first.g1").has_value());
+    EXPECT_EQ(true, result->CheckMembership("second.g1"));
+    EXPECT_EQ(1u, cache.Size());
+}
+
+TEST(MembershipCacheTest, EvictsLeastRecentlyUsedAtCapacity) {
+    MembershipCache cache(2, 1000ms);
+    cache.Set("a", MemberOf("a.g1"));
+    cache.Set("b", MemberOf("b.g1"));
+    cache.Set("c", MemberOf("c.g1"));  // evicts "a", the LRU
+
+    EXPECT_EQ(2u, cache.Size());
+    EXPECT_FALSE(cache.Get("a").has_value());
+    EXPECT_TRUE(cache.Get("b").has_value());
+    EXPECT_TRUE(cache.Get("c").has_value());
+}
+
+TEST(MembershipCacheTest, GetRefreshesRecency) {
+    MembershipCache cache(2, 1000ms);
+    cache.Set("a", MemberOf("a.g1"));
+    cache.Set("b", MemberOf("b.g1"));
+
+    // Touch "a" so "b" becomes the least-recently-used.
+    EXPECT_TRUE(cache.Get("a").has_value());
+
+    cache.Set("c", MemberOf("c.g1"));  // evicts "b" now, not "a"
+
+    EXPECT_TRUE(cache.Get("a").has_value());
+    EXPECT_FALSE(cache.Get("b").has_value());
+    EXPECT_TRUE(cache.Get("c").has_value());
+}
+
+TEST(MembershipCacheTest, ExpiresAfterTtlAndIsRemoved) {
+    FakeClock clock;
+    MembershipCache cache(10, 1000ms, clock.AsFn());
+    cache.Set("a", MemberOf("a.g1"));
+
+    clock.Advance(999ms);
+    EXPECT_TRUE(cache.Get("a").has_value());
+
+    clock.Advance(1ms);  // now exactly at the TTL boundary
+    EXPECT_FALSE(cache.Get("a").has_value());
+    EXPECT_EQ(0u, cache.Size());  // the expired entry is dropped, not retained
+}
+
+TEST(MembershipCacheTest, SetResetsExpiration) {
+    FakeClock clock;
+    MembershipCache cache(10, 1000ms, clock.AsFn());
+    cache.Set("a", MemberOf("a.g1"));
+
+    clock.Advance(600ms);
+    cache.Set("a", MemberOf("a.g1"));  // re-insert resets the TTL
+
+    clock.Advance(600ms);  // 1200ms since first set, 600ms since the second
+    EXPECT_TRUE(cache.Get("a").has_value());
+}
+
+TEST(MembershipCacheTest, ClearRemovesEverything) {
+    MembershipCache cache(10, 1000ms);
+    cache.Set("a", MemberOf("a.g1"));
+    cache.Set("b", MemberOf("b.g1"));
+
+    cache.Clear();
+
+    EXPECT_EQ(0u, cache.Size());
+    EXPECT_FALSE(cache.Get("a").has_value());
+    EXPECT_FALSE(cache.Get("b").has_value());
+}


### PR DESCRIPTION
## Summary

Internal layer between the evaluator and a customer-provided
`IBigSegmentStore`: hashes context keys, caches membership lookups, polls the
store's metadata in the background to track availability/staleness, and
broadcasts status changes. No caller yet — the evaluator and the public status
provider come later in the stack.

## Design notes

- Context keys are hashed to `base64(sha256(key))` using the standard base64
  alphabet (not the existing URL-safe `Base64UrlEncode`), so the lookup key
  matches what the Relay Proxy writes.
- Concurrent misses for the same key coalesce into a single store query rather
  than each hitting the store.
- The background poll is built on `async::Delay` + `CancellationSource`.
- A store error encountered during a membership lookup flips the store status to
  unavailable. The spec requires this; the Java and Go SDKs don't do it, so this
  is a deliberate divergence.
- Changes `StoreMetadata::last_up_to_date` from a bare `milliseconds` to a
  `system_clock::time_point`, so staleness math can't mix epochs. This touches
  the Redis and DynamoDB stores (one line each) and their metadata tests.

## Test plan

- [x] Added unit tests
- [x] Full server-sdk suite green (499/499)
- [x] DynamoDB source suite green (40/40) against DynamoDB Local
- [x] Redis source suite green (37/37) against a live Redis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `IBigSegmentStore` contract (`noexcept`, `StoreMetadata` type) and adds threaded/async polling plus store-error handling that affects how staleness and availability are reported; evaluator is not wired yet, limiting immediate eval impact.
> 
> **Overview**
> Adds **`BigSegmentStoreWrapper`**, the internal layer in front of `IBigSegmentStore`: hashes context keys as **`base64(sha256(key))`** via new **`Base64Encode`** (RFC 4648, not URL-safe), uses an LRU/TTL **`MembershipCache`**, coalesces concurrent lookups for the same key, polls metadata on a timer for availability/staleness, and broadcasts status changes. Membership lookups return **`BigSegmentsStatus`** (healthy/stale/store error); a failed lookup marks the store unavailable (per spec).
> 
> **`StoreMetadata::last_up_to_date`** is now a **`system_clock::time_point`** instead of raw milliseconds; Redis and DynamoDB stores and their tests are updated accordingly. **`IBigSegmentStore::GetMembership` / `GetMetadata`** are **`noexcept`**, with DynamoDB wrapping AWS calls in try/catch.
> 
> Supporting pieces: **`big_segments_status.hpp`**, **`#include <variant>`** in `promise.hpp`, and unit tests for the wrapper, cache, and standard base64.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b492dd143275828c1ca85c5fc5a1ff1fb6d8a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->