### PR TITLE
chore: add orchestration logging for FDv2 data system

### DIFF
--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -69,6 +69,8 @@ target_sources(${LIBNAME}
         data_systems/fdv2/source_manager.cpp
         data_systems/fdv2/fdv2_data_system.hpp
         data_systems/fdv2/fdv2_data_system.cpp
+        data_systems/fdv2/fdv1_adapter_synchronizer.hpp
+        data_systems/fdv2/fdv1_adapter_synchronizer.cpp
         data_systems/background_sync/sources/streaming/streaming_data_source.hpp
         data_systems/background_sync/sources/streaming/streaming_data_source.cpp
         data_systems/background_sync/sources/streaming/event_handler.hpp

--- a/libs/server-sdk/src/data_systems/fdv2/fdv1_adapter_synchronizer.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv1_adapter_synchronizer.cpp
@@ -1,0 +1,187 @@
+#include "fdv1_adapter_synchronizer.hpp"
+
+#include <utility>
+
+namespace launchdarkly::server_side::data_systems {
+
+using data_interfaces::FDv2SourceResult;
+
+// ----- State -----
+
+bool FDv1AdapterSynchronizer::State::TryStart() {
+    std::lock_guard lock(mutex_);
+    if (started_ || closed_) {
+        return false;
+    }
+    started_ = true;
+    return true;
+}
+
+bool FDv1AdapterSynchronizer::State::MarkClosed() {
+    std::lock_guard lock(mutex_);
+    closed_ = true;
+    return started_;
+}
+
+async::Future<FDv2SourceResult> FDv1AdapterSynchronizer::State::GetNext() {
+    std::lock_guard lock(mutex_);
+    if (!result_queue_.empty()) {
+        auto result = std::move(result_queue_.front());
+        result_queue_.pop_front();
+        return async::MakeFuture(std::move(result));
+    }
+    return pending_promise_.emplace().GetFuture();
+}
+
+void FDv1AdapterSynchronizer::State::ResolvePendingAsShutdown() {
+    std::optional<async::Promise<FDv2SourceResult>> promise;
+    {
+        std::lock_guard lock(mutex_);
+        if (pending_promise_) {
+            promise = std::move(pending_promise_);
+            pending_promise_.reset();
+        }
+    }
+    if (promise) {
+        promise->Resolve(FDv2SourceResult{FDv2SourceResult::Shutdown{}});
+    }
+}
+
+void FDv1AdapterSynchronizer::State::Notify(FDv2SourceResult result) {
+    std::optional<async::Promise<FDv2SourceResult>> promise;
+    {
+        std::lock_guard lock(mutex_);
+        if (closed_) {
+            return;
+        }
+        if (pending_promise_) {
+            promise = std::move(pending_promise_);
+            pending_promise_.reset();
+        } else {
+            result_queue_.push_back(std::move(result));
+            return;
+        }
+    }
+    // Resolve outside the lock — Promise::Resolve may invoke inline
+    // continuations that could call back into Notify or GetNext.
+    promise->Resolve(std::move(result));
+}
+
+// ----- ConvertingDestination -----
+
+FDv1AdapterSynchronizer::ConvertingDestination::ConvertingDestination(
+    std::weak_ptr<State> state)
+    : state_(std::move(state)) {}
+
+void FDv1AdapterSynchronizer::ConvertingDestination::Init(
+    data_model::SDKDataSet data_set) {
+    auto state = state_.lock();
+    if (!state) {
+        return;
+    }
+    data_interfaces::ChangeSetData changes;
+    changes.reserve(data_set.flags.size() + data_set.segments.size());
+    for (auto& [key, flag] : data_set.flags) {
+        changes.push_back({key, std::move(flag)});
+    }
+    for (auto& [key, segment] : data_set.segments) {
+        changes.push_back({key, std::move(segment)});
+    }
+    state->Notify(FDv2SourceResult{FDv2SourceResult::ChangeSet{
+        data_model::ChangeSet<data_interfaces::ChangeSetData>{
+            data_model::ChangeSetType::kFull, std::move(changes),
+            data_model::Selector{}}}});
+}
+
+void FDv1AdapterSynchronizer::ConvertingDestination::Upsert(
+    std::string const& key,
+    data_model::FlagDescriptor flag) {
+    auto state = state_.lock();
+    if (!state) {
+        return;
+    }
+    data_interfaces::ChangeSetData changes;
+    changes.push_back({key, std::move(flag)});
+    state->Notify(FDv2SourceResult{FDv2SourceResult::ChangeSet{
+        data_model::ChangeSet<data_interfaces::ChangeSetData>{
+            data_model::ChangeSetType::kPartial, std::move(changes),
+            data_model::Selector{}}}});
+}
+
+void FDv1AdapterSynchronizer::ConvertingDestination::Upsert(
+    std::string const& key,
+    data_model::SegmentDescriptor segment) {
+    auto state = state_.lock();
+    if (!state) {
+        return;
+    }
+    data_interfaces::ChangeSetData changes;
+    changes.push_back({key, std::move(segment)});
+    state->Notify(FDv2SourceResult{FDv2SourceResult::ChangeSet{
+        data_model::ChangeSet<data_interfaces::ChangeSetData>{
+            data_model::ChangeSetType::kPartial, std::move(changes),
+            data_model::Selector{}}}});
+}
+
+std::string const& FDv1AdapterSynchronizer::ConvertingDestination::Identity()
+    const {
+    static std::string const identity = "FDv1 adapter destination";
+    return identity;
+}
+
+// ----- FDv1AdapterSynchronizer -----
+
+FDv1AdapterSynchronizer::FDv1AdapterSynchronizer(
+    std::unique_ptr<data_interfaces::IDataSynchronizer> fdv1_source)
+    : state_(std::make_shared<State>()),
+      destination_(std::make_unique<ConvertingDestination>(state_)),
+      fdv1_source_(std::move(fdv1_source)) {}
+
+FDv1AdapterSynchronizer::~FDv1AdapterSynchronizer() {
+    Close();
+}
+
+async::Future<FDv2SourceResult> FDv1AdapterSynchronizer::Next(
+    data_model::Selector /*selector*/) {
+    auto closed = close_promise_.GetFuture();
+    if (closed.IsFinished()) {
+        return async::MakeFuture(
+            FDv2SourceResult{FDv2SourceResult::Shutdown{}});
+    }
+    if (state_->TryStart()) {
+        fdv1_source_->StartAsync(destination_.get(),
+                                 /*bootstrap_data=*/nullptr);
+    }
+    auto result_future = state_->GetNext();
+    if (result_future.IsFinished()) {
+        return result_future;
+    }
+    return async::WhenAny(closed, result_future)
+        .Then(
+            [state = state_, result_future](std::size_t const& idx) mutable
+                -> async::Future<FDv2SourceResult> {
+                if (idx == 0) {
+                    state->ResolvePendingAsShutdown();
+                    return async::MakeFuture(
+                        FDv2SourceResult{FDv2SourceResult::Shutdown{}});
+                }
+                return result_future;
+            },
+            async::kInlineExecutor);
+}
+
+void FDv1AdapterSynchronizer::Close() {
+    if (!close_promise_.Resolve(std::monostate{})) {
+        return;
+    }
+    if (state_->MarkClosed()) {
+        fdv1_source_->ShutdownAsync([] {});
+    }
+}
+
+std::string const& FDv1AdapterSynchronizer::Identity() const {
+    static std::string const identity = "FDv1 fallback adapter";
+    return identity;
+}
+
+}  // namespace launchdarkly::server_side::data_systems

--- a/libs/server-sdk/src/data_systems/fdv2/fdv1_adapter_synchronizer.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv1_adapter_synchronizer.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "../../data_interfaces/destination/idestination.hpp"
+#include "../../data_interfaces/source/idata_synchronizer.hpp"
+#include "../../data_interfaces/source/ifdv2_synchronizer.hpp"
+
+#include <launchdarkly/async/promise.hpp>
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace launchdarkly::server_side::data_systems {
+
+/**
+ * Adapts an FDv1 IDataSynchronizer to the IFDv2Synchronizer interface.
+ *
+ * FDv1 Init/Upsert callbacks delivered through an internal IDestination are
+ * translated into FDv2SourceResult::ChangeSet results, with empty selectors
+ * and fdv1_fallback = false (the directive does not re-fire from FDv1 data).
+ *
+ * Threading: Next() and Close() may be called from any thread; only one
+ * Next() may be outstanding at a time. The adapter blocks in its destructor
+ * waiting for the FDv1 source's ShutdownAsync completion, so no callbacks
+ * are in flight when the wrapped source is destroyed.
+ */
+class FDv1AdapterSynchronizer final
+    : public data_interfaces::IFDv2Synchronizer {
+   public:
+    explicit FDv1AdapterSynchronizer(
+        std::unique_ptr<data_interfaces::IDataSynchronizer> fdv1_source);
+
+    ~FDv1AdapterSynchronizer() override;
+
+    async::Future<data_interfaces::FDv2SourceResult> Next(
+        data_model::Selector selector) override;
+    void Close() override;
+    [[nodiscard]] std::string const& Identity() const override;
+
+   private:
+    /**
+     * Holds the lifecycle, result queue, and pending Next() promise; shared
+     * with the FDv1 source's IDestination via the inner ConvertingDestination.
+     * All methods are thread-safe.
+     */
+    class State {
+       public:
+        // Returns true if this call transitioned Initial → Started; false if
+        // already started or already closed. Used to gate the one-time
+        // StartAsync call on the wrapped FDv1 source.
+        bool TryStart();
+
+        // Marks the state closed and returns whether the source was started
+        // before the transition (so the caller knows whether ShutdownAsync
+        // needs to be called).
+        bool MarkClosed();
+
+        async::Future<data_interfaces::FDv2SourceResult> GetNext();
+
+        // Resolves any pending Next() promise with Shutdown and clears it.
+        // Called on the close path so the abandoned promise doesn't leave
+        // potential continuations dangling.
+        void ResolvePendingAsShutdown();
+
+        void Notify(data_interfaces::FDv2SourceResult result);
+
+       private:
+        // Protected by mutex_.
+        mutable std::mutex mutex_;
+        bool started_ = false;
+        bool closed_ = false;
+        std::optional<async::Promise<data_interfaces::FDv2SourceResult>>
+            pending_promise_;
+        std::deque<data_interfaces::FDv2SourceResult> result_queue_;
+    };
+
+    /**
+     * Translates FDv1 IDestination callbacks into FDv2 results queued on
+     * State. Thread-safe (delegates to State).
+     */
+    class ConvertingDestination final : public data_interfaces::IDestination {
+       public:
+        explicit ConvertingDestination(std::weak_ptr<State> state);
+        void Init(data_model::SDKDataSet data_set) override;
+        void Upsert(std::string const& key,
+                    data_model::FlagDescriptor flag) override;
+        void Upsert(std::string const& key,
+                    data_model::SegmentDescriptor segment) override;
+        [[nodiscard]] std::string const& Identity() const override;
+
+       private:
+        std::weak_ptr<State> state_;
+    };
+
+    // const after construction.
+    std::shared_ptr<State> const state_;
+    std::unique_ptr<ConvertingDestination> const destination_;
+    std::unique_ptr<data_interfaces::IDataSynchronizer> const fdv1_source_;
+
+    // Thread-safe primitive.
+    async::Promise<std::monostate> close_promise_;
+};
+
+}  // namespace launchdarkly::server_side::data_systems

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.cpp
@@ -43,6 +43,7 @@ FDv2DataSystem::FDv2DataSystem(
       store_(),
       change_notifier_(store_, store_),
       initialize_called_(false),
+      last_logged_synchronizer_interrupted_(false),
       closed_(false),
       selector_(),
       initializer_index_(0),
@@ -121,6 +122,9 @@ void FDv2DataSystem::RunNextInitializer() {
         } else {
             auto& factory = initializer_factories_[initializer_index_++];
             active_initializer_ = factory->Build();
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": starting initializer "
+                << active_initializer_->Identity();
             active_initializer_->Run().Then(
                 [this](data_interfaces::FDv2SourceResult const& result)
                     -> std::monostate {
@@ -152,6 +156,8 @@ void FDv2DataSystem::OnInitializerResult(
                     cs.change_set.selector.value.has_value();
                 ApplyChangeSet(std::move(cs.change_set));
                 if (has_selector) {
+                    LD_LOG(logger_, LogLevel::kInfo)
+                        << Identity() << ": initializer succeeded";
                     got_basis = true;
                 }
             },
@@ -211,6 +217,10 @@ void FDv2DataSystem::StartSynchronizers() {
         }
         active_synchronizer_ = source_manager_.NextSynchronizer();
         if (active_synchronizer_) {
+            LD_LOG(logger_, LogLevel::kInfo)
+                << Identity() << ": starting synchronizer "
+                << active_synchronizer_->Identity();
+            last_logged_synchronizer_interrupted_.store(false);
             active_conditions_ = BuildActiveConditions();
         } else {
             exhausted = true;
@@ -320,33 +330,37 @@ void FDv2DataSystem::OnSynchronizerResult(
     bool got_shutdown = false;
     bool advance = false;
 
-    std::visit(overloaded{
-                   [&](Result::ChangeSet& cs) {
-                       ApplyChangeSet(std::move(cs.change_set));
-                   },
-                   [&](Result::Shutdown&) { got_shutdown = true; },
-                   [&](Result::Interrupted const& iv) {
-                       LD_LOG(logger_, LogLevel::kWarn)
-                           << Identity() << ": synchronizer interrupted: "
-                           << iv.error.Message();
-                       status_manager_->SetState(
-                           DataSourceStatus::DataSourceState::kInterrupted,
-                           iv.error.Kind(), iv.error.Message());
-                   },
-                   [&](Result::TerminalError const& te) {
-                       LD_LOG(logger_, LogLevel::kWarn)
-                           << Identity() << ": synchronizer terminal error: "
-                           << te.error.Message();
-                       status_manager_->SetState(
-                           DataSourceStatus::DataSourceState::kInterrupted,
-                           te.error.Kind(), te.error.Message());
-                       advance = true;
-                   },
-                   [&](Result::Goodbye const&) {
-                       // The synchronizer handles this internally.
-                   },
-               },
-               result.value);
+    std::visit(
+        overloaded{
+            [&](Result::ChangeSet& cs) {
+                last_logged_synchronizer_interrupted_.store(false);
+                ApplyChangeSet(std::move(cs.change_set));
+            },
+            [&](Result::Shutdown&) { got_shutdown = true; },
+            [&](Result::Interrupted const& iv) {
+                if (!last_logged_synchronizer_interrupted_.exchange(true)) {
+                    LD_LOG(logger_, LogLevel::kInfo)
+                        << Identity()
+                        << ": synchronizer interrupted: " << iv.error.Message();
+                }
+                status_manager_->SetState(
+                    DataSourceStatus::DataSourceState::kInterrupted,
+                    iv.error.Kind(), iv.error.Message());
+            },
+            [&](Result::TerminalError const& te) {
+                LD_LOG(logger_, LogLevel::kWarn)
+                    << Identity()
+                    << ": synchronizer terminal error: " << te.error.Message();
+                status_manager_->SetState(
+                    DataSourceStatus::DataSourceState::kInterrupted,
+                    te.error.Kind(), te.error.Message());
+                advance = true;
+            },
+            [&](Result::Goodbye const&) {
+                // The synchronizer handles this internally.
+            },
+        },
+        result.value);
 
     {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
+++ b/libs/server-sdk/src/data_systems/fdv2/fdv2_data_system.hpp
@@ -283,6 +283,9 @@ class FDv2DataSystem final : public data_interfaces::IDataSystem {
     // Set by Initialize() to detect repeat or concurrent calls.
     std::atomic_bool initialize_called_;
 
+    // Suppresses consecutive "interrupted" logs from the active synchronizer.
+    std::atomic_bool last_logged_synchronizer_interrupted_;
+
     // Orchestration state, guarded by mutex_.
     std::mutex mutex_;
     bool closed_;

--- a/libs/server-sdk/tests/fdv1_adapter_synchronizer_test.cpp
+++ b/libs/server-sdk/tests/fdv1_adapter_synchronizer_test.cpp
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+
+#include <data_systems/fdv2/fdv1_adapter_synchronizer.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+using namespace launchdarkly;
+using namespace launchdarkly::server_side::data_interfaces;
+using namespace launchdarkly::server_side::data_systems;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Mock FDv1 source: records StartAsync and ShutdownAsync calls and exposes
+// the IDestination it was given so the test can drive Init/Upsert.
+class MockFDv1Source final : public IDataSynchronizer {
+   public:
+    void StartAsync(IDestination* destination,
+                    data_model::SDKDataSet const* bootstrap) override {
+        ++start_count;
+        destination_ = destination;
+        bootstrap_was_null = (bootstrap == nullptr);
+    }
+
+    void ShutdownAsync(std::function<void()> completion) override {
+        ++shutdown_count;
+        if (completion) {
+            completion();
+        }
+    }
+
+    std::string const& Identity() const override {
+        static std::string const id = "mock fdv1";
+        return id;
+    }
+
+    IDestination* destination_ = nullptr;
+    int start_count = 0;
+    int shutdown_count = 0;
+    bool bootstrap_was_null = false;
+};
+
+}  // namespace
+
+TEST(FDv1AdapterSynchronizerTest, FirstNextStartsFDv1Source) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    auto future = adapter.Next(data_model::Selector{});
+
+    EXPECT_EQ(1, source_ptr->start_count);
+    EXPECT_TRUE(source_ptr->bootstrap_was_null);
+    EXPECT_FALSE(future.IsFinished());
+}
+
+TEST(FDv1AdapterSynchronizerTest, SecondNextDoesNotRestartSource) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    auto first = adapter.Next(data_model::Selector{});
+    source_ptr->destination_->Init(data_model::SDKDataSet{});
+    auto result = first.WaitForResult(1s);
+    ASSERT_TRUE(result.has_value());
+    adapter.Next(data_model::Selector{});
+
+    EXPECT_EQ(1, source_ptr->start_count);
+}
+
+TEST(FDv1AdapterSynchronizerTest, FDv1InitProducesFullChangeSet) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    auto future = adapter.Next(data_model::Selector{});
+
+    data_model::SDKDataSet data_set;
+    data_model::Flag flag;
+    flag.key = "flagA";
+    flag.version = 1;
+    data_set.flags.emplace("flagA", data_model::FlagDescriptor(flag));
+    source_ptr->destination_->Init(std::move(data_set));
+
+    auto result = future.WaitForResult(1s);
+    ASSERT_TRUE(result.has_value());
+    auto* change_set = std::get_if<FDv2SourceResult::ChangeSet>(&result->value);
+    ASSERT_NE(change_set, nullptr);
+    EXPECT_EQ(data_model::ChangeSetType::kFull, change_set->change_set.type);
+    ASSERT_EQ(1u, change_set->change_set.data.size());
+    EXPECT_EQ("flagA", change_set->change_set.data[0].key);
+    EXPECT_FALSE(change_set->change_set.selector.value.has_value());
+    EXPECT_FALSE(result->fdv1_fallback);
+}
+
+TEST(FDv1AdapterSynchronizerTest, FDv1UpsertProducesPartialChangeSet) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    // Flag upsert.
+    auto flag_future = adapter.Next(data_model::Selector{});
+    data_model::Flag flag;
+    flag.key = "flagA";
+    flag.version = 2;
+    source_ptr->destination_->Upsert("flagA", data_model::FlagDescriptor(flag));
+
+    auto flag_result = flag_future.WaitForResult(1s);
+    ASSERT_TRUE(flag_result.has_value());
+    auto* flag_change_set =
+        std::get_if<FDv2SourceResult::ChangeSet>(&flag_result->value);
+    ASSERT_NE(flag_change_set, nullptr);
+    EXPECT_EQ(data_model::ChangeSetType::kPartial,
+              flag_change_set->change_set.type);
+    ASSERT_EQ(1u, flag_change_set->change_set.data.size());
+    EXPECT_EQ("flagA", flag_change_set->change_set.data[0].key);
+
+    // Segment upsert.
+    auto seg_future = adapter.Next(data_model::Selector{});
+    data_model::Segment seg;
+    seg.key = "segA";
+    seg.version = 3;
+    source_ptr->destination_->Upsert("segA",
+                                     data_model::SegmentDescriptor(seg));
+
+    auto seg_result = seg_future.WaitForResult(1s);
+    ASSERT_TRUE(seg_result.has_value());
+    auto* seg_change_set =
+        std::get_if<FDv2SourceResult::ChangeSet>(&seg_result->value);
+    ASSERT_NE(seg_change_set, nullptr);
+    EXPECT_EQ(data_model::ChangeSetType::kPartial,
+              seg_change_set->change_set.type);
+    ASSERT_EQ(1u, seg_change_set->change_set.data.size());
+    EXPECT_EQ("segA", seg_change_set->change_set.data[0].key);
+}
+
+TEST(FDv1AdapterSynchronizerTest, ClosePendingNextReturnsShutdown) {
+    auto source = std::make_unique<MockFDv1Source>();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    auto future = adapter.Next(data_model::Selector{});
+    EXPECT_FALSE(future.IsFinished());
+
+    adapter.Close();
+
+    auto result = future.WaitForResult(1s);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(
+        std::holds_alternative<FDv2SourceResult::Shutdown>(result->value));
+}
+
+TEST(FDv1AdapterSynchronizerTest, CloseShutsDownStartedFDv1Source) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    adapter.Next(data_model::Selector{});
+    adapter.Close();
+
+    EXPECT_EQ(1, source_ptr->shutdown_count);
+}
+
+TEST(FDv1AdapterSynchronizerTest, CloseWithoutStartDoesNotShutDownFDv1Source) {
+    auto source = std::make_unique<MockFDv1Source>();
+    auto* source_ptr = source.get();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    // No Next() call — FDv1 source was never started.
+    adapter.Close();
+
+    EXPECT_EQ(0, source_ptr->start_count);
+    EXPECT_EQ(0, source_ptr->shutdown_count);
+}
+
+TEST(FDv1AdapterSynchronizerTest, NextAfterCloseReturnsShutdown) {
+    auto source = std::make_unique<MockFDv1Source>();
+    FDv1AdapterSynchronizer adapter(std::move(source));
+
+    adapter.Close();
+    auto future = adapter.Next(data_model::Selector{});
+
+    auto result = future.WaitForResult(1s);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(
+        std::holds_alternative<FDv2SourceResult::Shutdown>(result->value));
+}


### PR DESCRIPTION
Stacked on #540. Adds the remaining orchestration logs required for diagnostic visibility in the FDv2 data system.

## Test plan
- [x] Existing server-sdk test suite green (498 tests)
- [x] No new tests — logs are pure side effects on a `Logger` not observed by existing tests