### PR TITLE
feat: evaluate big segments

### DIFF
--- a/libs/server-sdk/src/evaluation/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/evaluation_stack.cpp
@@ -2,6 +2,30 @@
 
 namespace launchdarkly::server_side::evaluation {
 
+namespace {
+// Ranks statuses by how little they can be trusted, so the least-trustworthy
+// status wins when several Big Segments are queried in one evaluation
+// (NOT_CONFIGURED > STORE_ERROR > STALE > HEALTHY). Note this ordering is
+// independent of the enum's underlying values.
+int Precedence(enum EvaluationReason::BigSegmentsStatus status) {
+    switch (status) {
+        case EvaluationReason::BigSegmentsStatus::kHealthy:
+            return 0;
+        case EvaluationReason::BigSegmentsStatus::kStale:
+            return 1;
+        case EvaluationReason::BigSegmentsStatus::kStoreError:
+            return 2;
+        case EvaluationReason::BigSegmentsStatus::kNotConfigured:
+            return 3;
+    }
+    return 0;
+}
+}  // namespace
+
+EvaluationStack::EvaluationStack(
+    data_components::BigSegmentStoreWrapper* big_segment_store)
+    : big_segment_store_(big_segment_store) {}
+
 Guard::Guard(std::unordered_set<std::string>& set, std::string key)
     : set_(set), key_(std::move(key)) {
     set_.insert(key_);
@@ -25,6 +49,45 @@ std::optional<Guard> EvaluationStack::NoticeSegment(std::string segment_key) {
         return std::nullopt;
     }
     return std::make_optional<Guard>(segments_seen_, std::move(segment_key));
+}
+
+data_components::BigSegmentStoreWrapper* EvaluationStack::BigSegmentStore()
+    const {
+    return big_segment_store_;
+}
+
+void EvaluationStack::RecordBigSegmentsStatus(enum EvaluationReason::BigSegmentsStatus status) {
+    if (!big_segments_status_ ||
+        Precedence(status) > Precedence(*big_segments_status_)) {
+        big_segments_status_ = status;
+    }
+}
+
+std::optional<enum EvaluationReason::BigSegmentsStatus>
+EvaluationStack::BigSegmentsStatus() const {
+    return big_segments_status_;
+}
+
+integrations::Membership const* EvaluationStack::FindMembership(
+    std::string const& context_key) const {
+    auto const it = memberships_.find(context_key);
+    if (it == memberships_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+void EvaluationStack::StoreMembership(std::string context_key,
+                                      integrations::Membership membership) {
+    memberships_.emplace(std::move(context_key), std::move(membership));
+}
+
+void EvaluationStack::RecordStoreError(std::string context_key) {
+    store_error_keys_.insert(std::move(context_key));
+}
+
+bool EvaluationStack::DidStoreError(std::string const& context_key) const {
+    return store_error_keys_.find(context_key) != store_error_keys_.end();
 }
 
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/evaluation_stack.cpp
+++ b/libs/server-sdk/src/evaluation/evaluation_stack.cpp
@@ -9,14 +9,16 @@ namespace {
 // independent of the enum's underlying values.
 int Precedence(enum EvaluationReason::BigSegmentsStatus status) {
     switch (status) {
-        case EvaluationReason::BigSegmentsStatus::kHealthy:
+        case EvaluationReason::BigSegmentsStatus::kNone:
             return 0;
-        case EvaluationReason::BigSegmentsStatus::kStale:
+        case EvaluationReason::BigSegmentsStatus::kHealthy:
             return 1;
-        case EvaluationReason::BigSegmentsStatus::kStoreError:
+        case EvaluationReason::BigSegmentsStatus::kStale:
             return 2;
-        case EvaluationReason::BigSegmentsStatus::kNotConfigured:
+        case EvaluationReason::BigSegmentsStatus::kStoreError:
             return 3;
+        case EvaluationReason::BigSegmentsStatus::kNotConfigured:
+            return 4;
     }
     return 0;
 }
@@ -56,14 +58,14 @@ data_components::BigSegmentStoreWrapper* EvaluationStack::BigSegmentStore()
     return big_segment_store_;
 }
 
-void EvaluationStack::RecordBigSegmentsStatus(enum EvaluationReason::BigSegmentsStatus status) {
-    if (!big_segments_status_ ||
-        Precedence(status) > Precedence(*big_segments_status_)) {
+void EvaluationStack::RecordBigSegmentsStatus(
+    enum EvaluationReason::BigSegmentsStatus status) {
+    if (Precedence(status) > Precedence(big_segments_status_)) {
         big_segments_status_ = status;
     }
 }
 
-std::optional<enum EvaluationReason::BigSegmentsStatus>
+enum EvaluationReason::BigSegmentsStatus
 EvaluationStack::BigSegmentsStatus() const {
     return big_segments_status_;
 }

--- a/libs/server-sdk/src/evaluation/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_stack.hpp
@@ -84,10 +84,11 @@ class EvaluationStack {
     void RecordBigSegmentsStatus(enum EvaluationReason::BigSegmentsStatus status);
 
     /**
-     * @return The aggregated Big Segments status, or std::nullopt if no Big
-     * Segment was queried during this evaluation.
+     * @return The aggregated Big Segments status, or kNone if no Big Segment
+     * was queried during this evaluation.
      */
-    [[nodiscard]] std::optional<enum EvaluationReason::BigSegmentsStatus> BigSegmentsStatus() const;
+    [[nodiscard]] enum EvaluationReason::BigSegmentsStatus BigSegmentsStatus()
+        const;
 
     /**
      * Returns the cached membership for a context key looked up earlier in this
@@ -121,7 +122,8 @@ class EvaluationStack {
     std::unordered_set<std::string> segments_seen_;
 
     data_components::BigSegmentStoreWrapper* big_segment_store_;
-    std::optional<enum EvaluationReason::BigSegmentsStatus> big_segments_status_;
+    enum EvaluationReason::BigSegmentsStatus big_segments_status_ =
+        EvaluationReason::BigSegmentsStatus::kNone;
     // Keyed by unhashed context key. Empty until the first Big Segment lookup.
     std::unordered_map<std::string, integrations::Membership> memberships_;
     std::unordered_set<std::string> store_error_keys_;

--- a/libs/server-sdk/src/evaluation/evaluation_stack.hpp
+++ b/libs/server-sdk/src/evaluation/evaluation_stack.hpp
@@ -1,8 +1,16 @@
 #pragma once
 
+#include <launchdarkly/data/evaluation_reason.hpp>
+#include <launchdarkly/server_side/integrations/big_segments/big_segment_store_types.hpp>
+
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
+
+namespace launchdarkly::server_side::data_components {
+class BigSegmentStoreWrapper;
+}  // namespace launchdarkly::server_side::data_components
 
 namespace launchdarkly::server_side::evaluation {
 
@@ -26,12 +34,22 @@ struct Guard {
 };
 
 /**
- * EvaluationStack is used to track which segments and flags have been noticed
- * during evaluation in order to detect circular references.
+ * EvaluationStack holds the per-evaluation state for a single top-level flag
+ * evaluation: the prerequisite/segment chains used for circular-reference
+ * detection, plus the Big Segments status and membership cache that a Big
+ * Segment lookup populates.
+ *
+ * Not thread-safe: a fresh instance is created per top-level evaluation and is
+ * never shared across threads.
  */
 class EvaluationStack {
    public:
-    EvaluationStack() = default;
+    /**
+     * @param big_segment_store Non-owning pointer to the Big Segment store
+     * wrapper, or nullptr if no store is configured. Must outlive the stack.
+     */
+    explicit EvaluationStack(
+        data_components::BigSegmentStoreWrapper* big_segment_store = nullptr);
 
     /**
      * If the given prerequisite key has not been seen, marks it as seen
@@ -52,9 +70,61 @@ class EvaluationStack {
      */
     [[nodiscard]] std::optional<Guard> NoticeSegment(std::string segment_key);
 
+    /**
+     * @return The Big Segment store wrapper, or nullptr if none is configured.
+     */
+    [[nodiscard]] data_components::BigSegmentStoreWrapper* BigSegmentStore()
+        const;
+
+    /**
+     * Records the status of a Big Segment lookup. If multiple lookups occur in
+     * one evaluation, the least-trustworthy status wins (NOT_CONFIGURED >
+     * STORE_ERROR > STALE > HEALTHY).
+     */
+    void RecordBigSegmentsStatus(enum EvaluationReason::BigSegmentsStatus status);
+
+    /**
+     * @return The aggregated Big Segments status, or std::nullopt if no Big
+     * Segment was queried during this evaluation.
+     */
+    [[nodiscard]] std::optional<enum EvaluationReason::BigSegmentsStatus> BigSegmentsStatus() const;
+
+    /**
+     * Returns the cached membership for a context key looked up earlier in this
+     * evaluation, or nullptr if that key has not been queried yet.
+     */
+    [[nodiscard]] integrations::Membership const* FindMembership(
+        std::string const& context_key) const;
+
+    /**
+     * Caches a context key's membership so later Big Segment lookups for the
+     * same key in this evaluation reuse it instead of re-querying the store.
+     */
+    void StoreMembership(std::string context_key,
+                         integrations::Membership membership);
+
+    /**
+     * Records that the Big Segment store returned an error for the given
+     * context key during this evaluation. Subsequent Big Segment lookups for
+     * the same key must be treated as non-matches without re-querying.
+     */
+    void RecordStoreError(std::string context_key);
+
+    /**
+     * @return True if a Big Segment store lookup for the given context key has
+     * already errored during this evaluation.
+     */
+    [[nodiscard]] bool DidStoreError(std::string const& context_key) const;
+
    private:
     std::unordered_set<std::string> prerequisites_seen_;
     std::unordered_set<std::string> segments_seen_;
+
+    data_components::BigSegmentStoreWrapper* big_segment_store_;
+    std::optional<enum EvaluationReason::BigSegmentsStatus> big_segments_status_;
+    // Keyed by unhashed context key. Empty until the first Big Segment lookup.
+    std::unordered_map<std::string, integrations::Membership> memberships_;
+    std::unordered_set<std::string> store_error_keys_;
 };
 
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/evaluator.cpp
+++ b/libs/server-sdk/src/evaluation/evaluator.cpp
@@ -53,8 +53,9 @@ EvaluationDetail<Value> Evaluator::Evaluate(
     EventScope const& event_scope) {
     EvaluationStack stack{big_segment_store_};
     auto detail = Evaluate(std::nullopt, flag, context, stack, event_scope);
-    if (auto status = stack.BigSegmentsStatus()) {
-        return WithBigSegmentsStatus(std::move(detail), *status);
+    auto status = stack.BigSegmentsStatus();
+    if (status != EvaluationReason::BigSegmentsStatus::kNone) {
+        return WithBigSegmentsStatus(std::move(detail), status);
     }
     return detail;
 }

--- a/libs/server-sdk/src/evaluation/evaluator.cpp
+++ b/libs/server-sdk/src/evaluation/evaluator.cpp
@@ -20,8 +20,26 @@ std::optional<std::size_t> TargetMatchVariation(
     launchdarkly::Context const& context,
     Flag::Target const& target);
 
-Evaluator::Evaluator(Logger& logger, data_interfaces::IStore const& source)
-    : logger_(logger), source_(source) {}
+namespace {
+EvaluationDetail<Value> WithBigSegmentsStatus(EvaluationDetail<Value> detail,
+                                              enum EvaluationReason::BigSegmentsStatus status) {
+    auto const& maybe_reason = detail.Reason();
+    if (!maybe_reason) {
+        return detail;
+    }
+    EvaluationReason const& reason = *maybe_reason;
+    EvaluationReason updated(
+        reason.Kind(), reason.ErrorKind(), reason.RuleIndex(), reason.RuleId(),
+        reason.PrerequisiteKey(), reason.InExperiment(), status);
+    return EvaluationDetail<Value>(detail.Value(), detail.VariationIndex(),
+                                   std::move(updated));
+}
+}  // namespace
+
+Evaluator::Evaluator(Logger& logger,
+                     data_interfaces::IStore const& source,
+                     data_components::BigSegmentStoreWrapper* big_segment_store)
+    : logger_(logger), source_(source), big_segment_store_(big_segment_store) {}
 
 EvaluationDetail<Value> Evaluator::Evaluate(
     data_model::Flag const& flag,
@@ -33,8 +51,12 @@ EvaluationDetail<Value> Evaluator::Evaluate(
     Flag const& flag,
     launchdarkly::Context const& context,
     EventScope const& event_scope) {
-    EvaluationStack stack;
-    return Evaluate(std::nullopt, flag, context, stack, event_scope);
+    EvaluationStack stack{big_segment_store_};
+    auto detail = Evaluate(std::nullopt, flag, context, stack, event_scope);
+    if (auto status = stack.BigSegmentsStatus()) {
+        return WithBigSegmentsStatus(std::move(detail), *status);
+    }
+    return detail;
 }
 
 EvaluationDetail<Value> Evaluator::Evaluate(

--- a/libs/server-sdk/src/evaluation/evaluator.hpp
+++ b/libs/server-sdk/src/evaluation/evaluator.hpp
@@ -21,8 +21,14 @@ class Evaluator {
      * threads in parallel, the given logger and IStore must be thread safe.
      * @param logger A logger for recording errors or warnings.
      * @param source The flag/segment source.
+     * @param big_segment_store Non-owning pointer to the Big Segment store
+     * wrapper, or nullptr if Big Segments are not configured. If non-null it
+     * must outlive the Evaluator and be safe to call from multiple threads.
      */
-    Evaluator(Logger& logger, data_interfaces::IStore const& source);
+    Evaluator(
+        Logger& logger,
+        data_interfaces::IStore const& source,
+        data_components::BigSegmentStoreWrapper* big_segment_store = nullptr);
 
     /**
      * Evaluates a flag for a given context.
@@ -69,5 +75,6 @@ class Evaluator {
 
     Logger& logger_;
     data_interfaces::IStore const& source_;
+    data_components::BigSegmentStoreWrapper* big_segment_store_;
 };
 }  // namespace launchdarkly::server_side::evaluation

--- a/libs/server-sdk/src/evaluation/rules.cpp
+++ b/libs/server-sdk/src/evaluation/rules.cpp
@@ -2,9 +2,87 @@
 #include "bucketing.hpp"
 #include "operators.hpp"
 
+#include "../data_components/big_segments/big_segment_store_wrapper.hpp"
+
+#include <optional>
+#include <string>
+#include <utility>
+
 namespace launchdarkly::server_side::evaluation {
 
 using namespace data_model;
+
+namespace {
+
+// Maps the wrapper's internal status to the public reason status.
+enum EvaluationReason::BigSegmentsStatus ToBigSegmentsStatus(
+    data_components::BigSegmentsStatus status) {
+    switch (status) {
+        case data_components::BigSegmentsStatus::kHealthy:
+            return EvaluationReason::BigSegmentsStatus::kHealthy;
+        case data_components::BigSegmentsStatus::kStale:
+            return EvaluationReason::BigSegmentsStatus::kStale;
+        case data_components::BigSegmentsStatus::kStoreError:
+            return EvaluationReason::BigSegmentsStatus::kStoreError;
+        case data_components::BigSegmentsStatus::kNotConfigured:
+            return EvaluationReason::BigSegmentsStatus::kNotConfigured;
+    }
+    return EvaluationReason::BigSegmentsStatus::kHealthy;
+}
+
+std::string MakeBigSegmentRef(Segment const& segment) {
+    return segment.key + ".g" + std::to_string(*segment.generation);
+}
+
+// Evaluates membership in an unbounded (Big) segment. Returns true/false for a
+// definite match/non-match, or std::nullopt when the membership has no entry
+// for this segment and evaluation should fall through to the segment's rules.
+std::optional<bool> MatchBigSegment(Segment const& segment,
+                                    Context const& context,
+                                    EvaluationStack& stack) {
+    if (!segment.generation) {
+        // Without a generation the segment ref can't be formed.
+        stack.RecordBigSegmentsStatus(EvaluationReason::BigSegmentsStatus::kNotConfigured);
+        return false;
+    }
+
+    // An absent or empty unboundedContextKind defaults to "user".
+    ContextKind const kind =
+        (segment.unboundedContextKind && !segment.unboundedContextKind->t.empty())
+            ? *segment.unboundedContextKind
+            : ContextKind{"user"};
+    Value const& context_key = context.Get(kind, "key");
+    if (!context_key.IsString()) {
+        return false;
+    }
+    std::string const& key = context_key.AsString();
+
+    if (stack.DidStoreError(key)) {
+        return false;
+    }
+
+    integrations::Membership const* membership = stack.FindMembership(key);
+    if (!membership) {
+        auto* store = stack.BigSegmentStore();
+        if (!store) {
+            stack.RecordBigSegmentsStatus(EvaluationReason::BigSegmentsStatus::kNotConfigured);
+            return false;
+        }
+        auto result = store->GetMembership(key);
+        auto const status = ToBigSegmentsStatus(result.status);
+        stack.RecordBigSegmentsStatus(status);
+        if (status == EvaluationReason::BigSegmentsStatus::kStoreError) {
+            stack.RecordStoreError(key);
+            return false;
+        }
+        stack.StoreMembership(key, std::move(result.membership));
+        membership = stack.FindMembership(key);
+    }
+
+    return membership->CheckMembership(MakeBigSegmentRef(segment));
+}
+
+}  // namespace
 
 bool MaybeNegate(Clause const& clause, bool value) {
     if (clause.negate) {
@@ -161,8 +239,11 @@ tl::expected<bool, Error> Contains(Segment const& segment,
     }
 
     if (segment.unbounded) {
-        // TODO(sc209881): set big segment status to NOT_CONFIGURED.
-        return false;
+        if (auto match = MatchBigSegment(segment, context, stack)) {
+            return *match;
+        }
+        // The membership had no entry for this segment; fall through to its
+        // include/exclude lists and rules.
     }
 
     if (IsTargeted(context, segment.included, segment.includedContexts)) {

--- a/libs/server-sdk/src/evaluation/rules.cpp
+++ b/libs/server-sdk/src/evaluation/rules.cpp
@@ -42,15 +42,16 @@ std::optional<bool> MatchBigSegment(Segment const& segment,
                                     EvaluationStack& stack) {
     if (!segment.generation) {
         // Without a generation the segment ref can't be formed.
-        stack.RecordBigSegmentsStatus(EvaluationReason::BigSegmentsStatus::kNotConfigured);
+        stack.RecordBigSegmentsStatus(
+            EvaluationReason::BigSegmentsStatus::kNotConfigured);
         return false;
     }
 
     // An absent or empty unboundedContextKind defaults to "user".
-    ContextKind const kind =
-        (segment.unboundedContextKind && !segment.unboundedContextKind->t.empty())
-            ? *segment.unboundedContextKind
-            : ContextKind{"user"};
+    ContextKind const kind = (segment.unboundedContextKind &&
+                              !segment.unboundedContextKind->t.empty())
+                                 ? *segment.unboundedContextKind
+                                 : ContextKind{"user"};
     Value const& context_key = context.Get(kind, "key");
     if (!context_key.IsString()) {
         return false;
@@ -65,7 +66,8 @@ std::optional<bool> MatchBigSegment(Segment const& segment,
     if (!membership) {
         auto* store = stack.BigSegmentStore();
         if (!store) {
-            stack.RecordBigSegmentsStatus(EvaluationReason::BigSegmentsStatus::kNotConfigured);
+            stack.RecordBigSegmentsStatus(
+                EvaluationReason::BigSegmentsStatus::kNotConfigured);
             return false;
         }
         auto result = store->GetMembership(key);
@@ -242,16 +244,16 @@ tl::expected<bool, Error> Contains(Segment const& segment,
         if (auto match = MatchBigSegment(segment, context, stack)) {
             return *match;
         }
-        // The membership had no entry for this segment; fall through to its
-        // include/exclude lists and rules.
-    }
+        // Big segments don't use the regular include/exclude target lists; a
+        // membership miss falls through directly to the segment's rules.
+    } else {
+        if (IsTargeted(context, segment.included, segment.includedContexts)) {
+            return true;
+        }
 
-    if (IsTargeted(context, segment.included, segment.includedContexts)) {
-        return true;
-    }
-
-    if (IsTargeted(context, segment.excluded, segment.excludedContexts)) {
-        return false;
+        if (IsTargeted(context, segment.excluded, segment.excludedContexts)) {
+            return false;
+        }
     }
 
     for (auto const& rule : segment.rules) {

--- a/libs/server-sdk/tests/big_segment_evaluator_test.cpp
+++ b/libs/server-sdk/tests/big_segment_evaluator_test.cpp
@@ -207,7 +207,8 @@ TEST_F(BigSegmentEvaluatorTest, ContextLacksUnboundedKindDoesNotQuery) {
         eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
 
     EXPECT_EQ(*detail, Value(true));
-    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), std::nullopt);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kNone);
     EXPECT_EQ(fake_->MembershipCalls(), 0);
 }
 

--- a/libs/server-sdk/tests/big_segment_evaluator_test.cpp
+++ b/libs/server-sdk/tests/big_segment_evaluator_test.cpp
@@ -1,0 +1,322 @@
+#include <gtest/gtest.h>
+
+#include "evaluation/evaluator.hpp"
+#include "test_store.hpp"
+
+#include <data_components/big_segments/big_segment_store_wrapper.hpp>
+#include <data_components/memory_store/memory_store.hpp>
+
+#include <launchdarkly/context_builder.hpp>
+#include <launchdarkly/logging/null_logger.hpp>
+
+#include <boost/asio/io_context.hpp>
+
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+using namespace launchdarkly;
+using namespace launchdarkly::server_side;
+namespace integrations = launchdarkly::server_side::integrations;
+namespace built = launchdarkly::server_side::config::built;
+using data_components::BigSegmentStoreWrapper;
+using namespace std::chrono_literals;
+
+namespace {
+
+// In-memory store for evaluator tests. GetMembership returns queued responses
+// in order (the last one sticks once the queue is exhausted); metadata is
+// fixed. The store ignores the hashed key it is passed.
+class FakeBigSegmentStore : public integrations::IBigSegmentStore {
+   public:
+    GetMembershipResult GetMembership(
+        std::string const&) const noexcept override {
+        std::lock_guard lock(mutex_);
+        ++membership_calls_;
+        if (responses_.size() > 1) {
+            auto front = responses_.front();
+            responses_.pop_front();
+            return front;
+        }
+        if (!responses_.empty()) {
+            return responses_.front();
+        }
+        return integrations::Membership::FromSegmentRefs({}, {});
+    }
+
+    GetMetadataResult GetMetadata() const noexcept override {
+        std::lock_guard lock(mutex_);
+        return metadata_;
+    }
+
+    void PushMembership(GetMembershipResult response) {
+        std::lock_guard lock(mutex_);
+        responses_.push_back(std::move(response));
+    }
+
+    void SetMetadata(GetMetadataResult metadata) {
+        std::lock_guard lock(mutex_);
+        metadata_ = std::move(metadata);
+    }
+
+    int MembershipCalls() const {
+        std::lock_guard lock(mutex_);
+        return membership_calls_;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    mutable int membership_calls_ = 0;
+    mutable std::deque<GetMembershipResult> responses_;
+    // Defaults to fresh metadata so a successful lookup reports HEALTHY.
+    GetMetadataResult metadata_ = std::optional<integrations::StoreMetadata>{
+        integrations::StoreMetadata{std::chrono::system_clock::now()}};
+};
+
+// A membership that includes a context in the given segment ref.
+integrations::Membership Included(std::string const& ref) {
+    return integrations::Membership::FromSegmentRefs({ref}, {});
+}
+
+// A membership that excludes a context from the given segment ref.
+integrations::Membership Excluded(std::string const& ref) {
+    return integrations::Membership::FromSegmentRefs({}, {ref});
+}
+
+std::string UnboundedSegment(std::string const& key,
+                             std::string const& kind,
+                             bool with_generation,
+                             std::string const& rules) {
+    std::string json = R"({"key":")" + key +
+                       R"(","unbounded":true,"unboundedContextKind":")" + kind +
+                       R"(","included":[],"excluded":[],"rules":[)" + rules +
+                       R"(],"salt":"salty","version":1)";
+    if (with_generation) {
+        json += R"(,"generation":1)";
+    }
+    json += "}";
+    return json;
+}
+
+// A flag that serves variation 0 (false) when any of its segmentMatch rules
+// matches, otherwise its fallthrough variation 1 (true). One rule per segment.
+std::string FlagMatchingSegments(std::vector<std::string> const& segment_keys) {
+    std::string rules;
+    for (std::size_t i = 0; i < segment_keys.size(); ++i) {
+        if (i != 0) {
+            rules += ",";
+        }
+        rules += R"({"id":"rule-)" + std::to_string(i) +
+                 R"(","clauses":[{"op":"segmentMatch","values":[")" +
+                 segment_keys[i] + R"("]}],"variation":0,"trackEvents":false})";
+    }
+    return R"({"key":"flag","version":42,"on":true,"targets":[],"rules":[)" +
+           rules +
+           R"(],"prerequisites":[],"fallthrough":{"variation":1},)"
+           R"("offVariation":0,"variations":[false,true],"salt":"salty"})";
+}
+
+// A segment rule that matches a user whose key is "alice".
+char const* kRuleMatchesAlice =
+    R"({"id":"seg-rule","clauses":[{"attribute":"key","op":"in",)"
+    R"("values":["alice"],"contextKind":"user"}]})";
+
+class BigSegmentEvaluatorTest : public ::testing::Test {
+   public:
+    BigSegmentEvaluatorTest()
+        : logger_(logging::NullLogger()),
+          fake_(std::make_shared<FakeBigSegmentStore>()) {
+        store_.Init({});
+    }
+
+    void UpsertFlag(std::string const& json) {
+        store_.Upsert("flag", test_store::Flag(json.c_str()));
+    }
+
+    void UpsertSegment(std::string const& key, std::string const& json) {
+        store_.Upsert(key, test_store::Segment(json.c_str()));
+    }
+
+    // Builds a wrapper over the fake store and an evaluator that uses it.
+    evaluation::Evaluator EvaluatorWithStore() {
+        built::BigSegmentsConfig config;
+        config.store = fake_;
+        config.context_cache_size = 1000;
+        config.context_cache_time = 5s;
+        config.status_poll_interval = 5s;
+        config.stale_after = 2min;
+        wrapper_ = std::make_shared<BigSegmentStoreWrapper>(
+            config, ioc_.get_executor(), logger_);
+        return evaluation::Evaluator{logger_, store_, wrapper_.get()};
+    }
+
+    // An evaluator with no Big Segment store configured.
+    evaluation::Evaluator EvaluatorWithoutStore() {
+        return evaluation::Evaluator{logger_, store_};
+    }
+
+   protected:
+    Logger logger_;
+    boost::asio::io_context ioc_;
+    data_components::MemoryStore store_;
+    std::shared_ptr<FakeBigSegmentStore> fake_;
+    std::shared_ptr<BigSegmentStoreWrapper> wrapper_;
+};
+
+Context AliceUser() {
+    return ContextBuilder().Kind("user", "alice").Build();
+}
+
+TEST_F(BigSegmentEvaluatorTest, NoStoreConfiguredIsNotConfigured) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+
+    auto eval = EvaluatorWithoutStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));  // No match -> fallthrough.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kNotConfigured);
+}
+
+TEST_F(BigSegmentEvaluatorTest, MissingGenerationIsNotConfigured) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user",
+                                             /*with_generation=*/false, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kNotConfigured);
+    EXPECT_EQ(fake_->MembershipCalls(), 0);  // Never queried the store.
+}
+
+TEST_F(BigSegmentEvaluatorTest, ContextLacksUnboundedKindDoesNotQuery) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "org", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+
+    auto eval = EvaluatorWithStore();
+    // Context has no "org" kind, so there is no key to look up.
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), std::nullopt);
+    EXPECT_EQ(fake_->MembershipCalls(), 0);
+}
+
+TEST_F(BigSegmentEvaluatorTest, IncludedMembershipMatches) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    fake_->PushMembership(Included("bigseg.g1"));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(false));  // Segment match -> rule variation.
+    EXPECT_EQ(detail.Reason()->Kind(), EvaluationReason::Kind::kRuleMatch);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+}
+
+TEST_F(BigSegmentEvaluatorTest, ExcludedMembershipDoesNotMatch) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    fake_->PushMembership(Excluded("bigseg.g1"));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));  // Excluded -> fallthrough.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+}
+
+TEST_F(BigSegmentEvaluatorTest, NoMembershipEntryFallsThroughToRules) {
+    UpsertSegment("bigseg",
+                  UnboundedSegment("bigseg", "user", true, kRuleMatchesAlice));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    // Membership has no entry for bigseg.g1, so the segment's rules decide.
+    fake_->PushMembership(integrations::Membership::FromSegmentRefs({}, {}));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(false));  // Segment rule matches alice.
+    EXPECT_EQ(detail.Reason()->Kind(), EvaluationReason::Kind::kRuleMatch);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+}
+
+TEST_F(BigSegmentEvaluatorTest, StaleStoreReportsStale) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    fake_->PushMembership(Included("bigseg.g1"));
+    // Last update older than stale_after (2min) -> stale.
+    fake_->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now() - 1h});
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(false));  // Still matches; only trust differs.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kStale);
+}
+
+TEST_F(BigSegmentEvaluatorTest, StoreErrorReportsStoreError) {
+    UpsertSegment("bigseg", UnboundedSegment("bigseg", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    fake_->PushMembership(tl::make_unexpected(std::string("boom")));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));  // Empty membership -> fallthrough.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kStoreError);
+}
+
+TEST_F(BigSegmentEvaluatorTest, StatusResolvesByWorstPrecedence) {
+    UpsertSegment("bigsegA", UnboundedSegment("bigsegA", "user", true, ""));
+    UpsertSegment("bigsegB", UnboundedSegment("bigsegB", "org", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigsegA", "bigsegB"}));
+    // First lookup (user key) succeeds with no entry -> HEALTHY; second lookup
+    // (org key) errors -> STORE_ERROR. STORE_ERROR must win.
+    fake_->PushMembership(integrations::Membership::FromSegmentRefs({}, {}));
+    fake_->PushMembership(tl::make_unexpected(std::string("boom")));
+
+    auto context =
+        ContextBuilder().Kind("user", "alice").Kind("org", "org1").Build();
+    auto eval = EvaluatorWithStore();
+    auto detail = eval.Evaluate(store_.GetFlag("flag")->item.value(), context);
+
+    EXPECT_EQ(*detail, Value(true));  // Neither segment matched.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kStoreError);
+    EXPECT_EQ(fake_->MembershipCalls(), 2);
+}
+
+TEST_F(BigSegmentEvaluatorTest, QueriesStoreOncePerContextKey) {
+    // Two big segments of the same kind resolve to the same context key.
+    UpsertSegment("bigsegA", UnboundedSegment("bigsegA", "user", true, ""));
+    UpsertSegment("bigsegB", UnboundedSegment("bigsegB", "user", true, ""));
+    UpsertFlag(FlagMatchingSegments({"bigsegA", "bigsegB"}));
+    fake_->PushMembership(integrations::Membership::FromSegmentRefs({}, {}));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));
+    EXPECT_EQ(fake_->MembershipCalls(), 1);
+}
+
+}  // namespace

--- a/libs/server-sdk/tests/big_segment_evaluator_test.cpp
+++ b/libs/server-sdk/tests/big_segment_evaluator_test.cpp
@@ -223,7 +223,8 @@ TEST_F(BigSegmentEvaluatorTest, IncludedMembershipMatches) {
 
     EXPECT_EQ(*detail, Value(false));  // Segment match -> rule variation.
     EXPECT_EQ(detail.Reason()->Kind(), EvaluationReason::Kind::kRuleMatch);
-    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kHealthy);
 }
 
 TEST_F(BigSegmentEvaluatorTest, ExcludedMembershipDoesNotMatch) {
@@ -236,7 +237,8 @@ TEST_F(BigSegmentEvaluatorTest, ExcludedMembershipDoesNotMatch) {
         eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
 
     EXPECT_EQ(*detail, Value(true));  // Excluded -> fallthrough.
-    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kHealthy);
 }
 
 TEST_F(BigSegmentEvaluatorTest, NoMembershipEntryFallsThroughToRules) {
@@ -252,7 +254,30 @@ TEST_F(BigSegmentEvaluatorTest, NoMembershipEntryFallsThroughToRules) {
 
     EXPECT_EQ(*detail, Value(false));  // Segment rule matches alice.
     EXPECT_EQ(detail.Reason()->Kind(), EvaluationReason::Kind::kRuleMatch);
-    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kHealthy);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kHealthy);
+}
+
+TEST_F(BigSegmentEvaluatorTest, RegularIncludeListIgnoredForBigSegment) {
+    // A big segment's regular include list must be ignored; only store
+    // membership (and then the segment's rules) decide matching.
+    std::string const segment =
+        R"({"key":"bigseg","unbounded":true,"unboundedContextKind":"user",)"
+        R"("included":["alice"],"excluded":[],"rules":[],"salt":"salty",)"
+        R"("version":1,"generation":1})";
+    UpsertSegment("bigseg", segment);
+    UpsertFlag(FlagMatchingSegments({"bigseg"}));
+    // The store has no entry for alice, so the regular include list must not
+    // produce a match.
+    fake_->PushMembership(integrations::Membership::FromSegmentRefs({}, {}));
+
+    auto eval = EvaluatorWithStore();
+    auto detail =
+        eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
+
+    EXPECT_EQ(*detail, Value(true));  // Include list ignored -> fallthrough.
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kHealthy);
 }
 
 TEST_F(BigSegmentEvaluatorTest, StaleStoreReportsStale) {
@@ -268,7 +293,8 @@ TEST_F(BigSegmentEvaluatorTest, StaleStoreReportsStale) {
         eval.Evaluate(store_.GetFlag("flag")->item.value(), AliceUser());
 
     EXPECT_EQ(*detail, Value(false));  // Still matches; only trust differs.
-    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(), EvaluationReason::BigSegmentsStatus::kStale);
+    EXPECT_EQ(detail.Reason()->BigSegmentsStatus(),
+              EvaluationReason::BigSegmentsStatus::kStale);
 }
 
 TEST_F(BigSegmentEvaluatorTest, StoreErrorReportsStoreError) {


### PR DESCRIPTION
# Evaluate big segments

Wires the big segment store wrapper into the server-side evaluator so flags referencing big segments actually evaluate, and annotates the reason with the big segments status. Builds on SDK-2366, which introduced the `EvaluationReason::BigSegmentsStatus` type.

## What's in

- Big segment matching in `rules.cpp`:
  - looks up membership for the unbounded context kind
  - tests the `<key>.g<generation>` segment ref
  - short-circuits to non-match on a store error
  - falls through to the segment's rules on a membership miss
- `EvaluationStack` carries the per-evaluation status, membership cache, and per-key store-error set, so a context key is queried at most once per evaluation.
- The aggregated status is stamped onto the returned `EvaluationReason`.

## Design notes

When one evaluation queries multiple big segments with differing statuses, the least-trustworthy status wins (`NOT_CONFIGURED` > `STORE_ERROR` > `STALE` > `HEALTHY`). This follows the spec but diverges from Java/Go, which take the last status written.

## Testing

Added unit tests covering each evaluation branch against an in-memory store.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core segment-matching and evaluation-reason behavior for flags using big segments; incorrect membership or status aggregation could change targeting outcomes, though behavior is heavily unit-tested.
> 
> **Overview**
> **Big segment evaluation** is wired into the server-side flag evaluator: unbounded segments now resolve membership via `BigSegmentStoreWrapper` instead of always returning non-match with a TODO.
> 
> `EvaluationStack` is extended with a non-owning store pointer, per-evaluation membership cache (one store lookup per context key), per-key store-error short-circuit, and aggregated **BigSegmentsStatus** using worst-wins precedence (`NOT_CONFIGURED` > `STORE_ERROR` > `STALE` > `HEALTHY`). `Evaluator` accepts an optional big-segment store, seeds the stack from it, and stamps the aggregated status onto the returned `EvaluationReason` when any big segment was consulted.
> 
> In `Contains` / `MatchBigSegment`, big segments use the unbounded context kind’s key, check `<segmentKey>.g<generation>`, treat store errors as non-match without retry, skip regular include/exclude lists, and fall through to segment rules on membership miss. New gtest coverage exercises not-configured, healthy/stale/error paths, precedence, caching, and rule fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b37b9a8de84937aacfd79117888a67cca88ef1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->