### PR TITLE
ci: Update OpenSSL version in install-openssl action

### DIFF
--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -32,7 +32,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 3.6.2 -y --no-progress
+        choco install openssl --version 4.0.1 -y --no-progress
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only dependency version pin on Windows runners; no application or auth logic changes, though a major OpenSSL bump could affect Windows build/link if the package or APIs differ.
> 
> **Overview**
> Bumps the **Windows** CI OpenSSL install from **3.6.2** to **4.0.1** via Chocolatey in `install-openssl`. Linux and macOS steps are unchanged; only the `choco install openssl --version` pin is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0e676a019afcb4a7ff05591880b1993eb2cfeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->