### PR TITLE
feat: expose Big Segments via public Client and Config APIs

### DIFF
--- a/libs/common/include/launchdarkly/error.hpp
+++ b/libs/common/include/launchdarkly/error.hpp
@@ -24,6 +24,7 @@ enum class Error : std::uint32_t {
     /* Client-side errors: 10000-19999 */
     /* Server-side errors: 20000-29999 */
     kConfig_DataSystem_LazyLoad_MissingSource = 20000,
+    kConfig_BigSegments_NullStore = 20001,
     kMax = std::numeric_limits<std::uint32_t>::max()
 };
 

--- a/libs/common/src/error.cpp
+++ b/libs/common/src/error.cpp
@@ -32,6 +32,8 @@ char const* ErrorToString(Error err) {
             return "sdk key: cannot be empty";
         case Error::kConfig_DataSystem_LazyLoad_MissingSource:
             return "data system: lazy load config requires a source";
+        case Error::kConfig_BigSegments_NullStore:
+            return "big segments: store must not be null";
         case Error::kMax:
             break;
     }

--- a/libs/server-sdk/include/launchdarkly/server_side/big_segment_store_status.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/big_segment_store_status.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <launchdarkly/connection.hpp>
+
+#include <functional>
+#include <memory>
+#include <ostream>
+
+namespace launchdarkly::server_side {
+
+/**
+ * The current health of a Big Segments store, independent of any single
+ * context's membership.
+ */
+class BigSegmentStoreStatus {
+   public:
+    BigSegmentStoreStatus(bool available, bool stale);
+
+    /**
+     * True if the most recent store query or metadata poll succeeded. If false,
+     * Big Segments membership cannot currently be evaluated reliably.
+     */
+    [[nodiscard]] bool IsAvailable() const;
+
+    /**
+     * True if the store's data has not been updated within the configured
+     * stale-after threshold. The data may still be queried; it is just older
+     * than desired.
+     */
+    [[nodiscard]] bool IsStale() const;
+
+   private:
+    bool available_;
+    bool stale_;
+};
+
+bool operator==(BigSegmentStoreStatus const& a, BigSegmentStoreStatus const& b);
+bool operator!=(BigSegmentStoreStatus const& a, BigSegmentStoreStatus const& b);
+
+/**
+ * Interface for accessing and listening to the Big Segments store status.
+ */
+class IBigSegmentStoreStatusProvider {
+   public:
+    /**
+     * The current status of the Big Segments store. If no store is configured,
+     * reports unavailable and not stale.
+     */
+    [[nodiscard]] virtual BigSegmentStoreStatus Status() const = 0;
+
+    /**
+     * Listen to changes to the Big Segments store status. The handler is
+     * invoked only when the status changes, not on every metadata poll.
+     *
+     * @param handler Function which will be called with the new status.
+     * @return A IConnection which can be used to stop listening to the status.
+     */
+    virtual std::unique_ptr<IConnection> OnBigSegmentStoreStatusChange(
+        std::function<void(BigSegmentStoreStatus status)> handler) = 0;
+
+    virtual ~IBigSegmentStoreStatusProvider() = default;
+    IBigSegmentStoreStatusProvider(IBigSegmentStoreStatusProvider const&) =
+        delete;
+    IBigSegmentStoreStatusProvider(IBigSegmentStoreStatusProvider&&) = delete;
+    IBigSegmentStoreStatusProvider& operator=(
+        IBigSegmentStoreStatusProvider const&) = delete;
+    IBigSegmentStoreStatusProvider& operator=(
+        IBigSegmentStoreStatusProvider&&) = delete;
+
+   protected:
+    IBigSegmentStoreStatusProvider() = default;
+};
+
+std::ostream& operator<<(std::ostream& out,
+                         BigSegmentStoreStatus const& status);
+
+}  // namespace launchdarkly::server_side

--- a/libs/server-sdk/include/launchdarkly/server_side/client.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/client.hpp
@@ -7,6 +7,7 @@
 #include <launchdarkly/value.hpp>
 
 #include <launchdarkly/server_side/all_flags_state.hpp>
+#include <launchdarkly/server_side/big_segment_store_status.hpp>
 #include <launchdarkly/server_side/data_source_status.hpp>
 
 #include <chrono>
@@ -277,10 +278,11 @@ class IClient {
      * @return The variation for the selected context, or default_value if the
      * flag is disabled in the LaunchDarkly control panel
      */
-    virtual std::string StringVariation(Context const& ctx,
-                                        FlagKey const& key,
-                                        std::string default_value,
-                                        hooks::HookContext const& hook_context) = 0;
+    virtual std::string StringVariation(
+        Context const& ctx,
+        FlagKey const& key,
+        std::string default_value,
+        hooks::HookContext const& hook_context) = 0;
 
     /**
      * Returns the string value of a feature flag for a given flag key, in an
@@ -499,6 +501,14 @@ class IClient {
      */
     virtual IDataSourceStatusProvider& DataSourceStatus() = 0;
 
+    /**
+     * Returns an interface for querying the status of a Big Segment store and
+     * subscribing to status changes. If Big Segments are not configured, the
+     * provider reports the store as unavailable.
+     * @return A Big Segment store status provider.
+     */
+    virtual IBigSegmentStoreStatusProvider& BigSegmentStoreStatus() = 0;
+
     virtual ~IClient() = default;
     IClient(IClient const& item) = delete;
     IClient(IClient&& item) = delete;
@@ -574,10 +584,11 @@ class Client : public IClient {
                                 FlagKey const& key,
                                 std::string default_value) override;
 
-    std::string StringVariation(Context const& ctx,
-                                FlagKey const& key,
-                                std::string default_value,
-                                hooks::HookContext const& hook_context) override;
+    std::string StringVariation(
+        Context const& ctx,
+        FlagKey const& key,
+        std::string default_value,
+        hooks::HookContext const& hook_context) override;
 
     EvaluationDetail<std::string> StringVariationDetail(
         Context const& ctx,
@@ -649,6 +660,8 @@ class Client : public IClient {
         hooks::HookContext const& hook_context) override;
 
     IDataSourceStatusProvider& DataSourceStatus() override;
+
+    IBigSegmentStoreStatusProvider& BigSegmentStoreStatus() override;
 
     /**
      * Returns the version of the SDK.

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/all_builders.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/all_builders.hpp
@@ -12,6 +12,8 @@
 #include <launchdarkly/server_side/config/builders/data_system/data_system_builder.hpp>
 #include <launchdarkly/server_side/config/builders/data_system/lazy_load_builder.hpp>
 
+#include <launchdarkly/server_side/config/builders/big_segments_builder.hpp>
+
 namespace launchdarkly::server_side::config::builders {
 
 using SDK = launchdarkly::config::shared::ServerSDK;

--- a/libs/server-sdk/include/launchdarkly/server_side/config/builders/big_segments_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/builders/big_segments_builder.hpp
@@ -3,6 +3,10 @@
 #include <launchdarkly/server_side/config/built/big_segments_config.hpp>
 #include <launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp>
 
+#include <launchdarkly/error.hpp>
+
+#include <tl/expected.hpp>
+
 #include <chrono>
 #include <cstddef>
 #include <memory>
@@ -68,12 +72,14 @@ class BigSegmentsBuilder {
     /**
      * @brief Resolves the configuration.
      *
+     * Returns an error if the store passed to the constructor was null.
+     *
      * If the configured @ref StatusPollInterval exceeds @ref StaleAfter,
      * the poll interval in the returned config is clamped to the
      * stale-after value so the SDK can detect staleness within one poll
      * cycle.
      */
-    [[nodiscard]] built::BigSegmentsConfig Build() const;
+    [[nodiscard]] tl::expected<built::BigSegmentsConfig, Error> Build() const;
 
    private:
     std::shared_ptr<integrations::IBigSegmentStore> store_;

--- a/libs/server-sdk/include/launchdarkly/server_side/config/config.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/config.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <launchdarkly/server_side/config/built/all_built.hpp>
+#include <launchdarkly/server_side/config/built/big_segments_config.hpp>
 #include <launchdarkly/server_side/config/built/data_system/data_system_config.hpp>
 #include <launchdarkly/server_side/hooks/hook.hpp>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace launchdarkly::server_side {
@@ -17,6 +19,7 @@ struct Config {
            config::built::Events events,
            std::optional<std::string> application_tag,
            config::built::DataSystemConfig data_system_config,
+           std::optional<config::built::BigSegmentsConfig> big_segments,
            config::built::HttpProperties http_properties,
            std::vector<std::shared_ptr<hooks::Hook>> hooks);
 
@@ -30,6 +33,13 @@ struct Config {
     [[nodiscard]] std::optional<std::string> const& ApplicationTag() const;
 
     config::built::DataSystemConfig const& DataSystemConfig() const;
+
+    /**
+     * The Big Segments configuration, or nullopt if Big Segments were not
+     * enabled via ConfigBuilder::BigSegments.
+     */
+    [[nodiscard]] std::optional<config::built::BigSegmentsConfig> const&
+    BigSegments() const;
 
     [[nodiscard]] config::built::HttpProperties const& HttpProperties() const;
 
@@ -46,6 +56,7 @@ struct Config {
     std::optional<std::string> application_tag_;
     config::built::Events events_;
     config::built::DataSystemConfig data_system_config_;
+    std::optional<config::built::BigSegmentsConfig> big_segments_;
     config::built::HttpProperties http_properties_;
     std::vector<std::shared_ptr<hooks::Hook>> hooks_;
 };

--- a/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
+++ b/libs/server-sdk/include/launchdarkly/server_side/config/config_builder.hpp
@@ -5,6 +5,7 @@
 #include <launchdarkly/server_side/hooks/hook.hpp>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace launchdarkly::server_side {
@@ -49,6 +50,16 @@ class ConfigBuilder {
      * @return Reference to a DataSystemBuilder.
      */
     config::builders::DataSystemBuilder& DataSystem();
+
+    /**
+     * Configures the SDK's Big Segments behavior. Pass a BigSegmentsBuilder
+     * constructed with the Big Segments store to use. If never called, Big
+     * Segments are not enabled and flags referencing them evaluate as if the
+     * context were not a member.
+     * @param builder A configured BigSegmentsBuilder.
+     * @return Reference to this.
+     */
+    ConfigBuilder& BigSegments(config::builders::BigSegmentsBuilder builder);
 
     /**
      * Sets the SDK's networking configuration, using an HttpPropertiesBuilder.
@@ -99,6 +110,7 @@ class ConfigBuilder {
     config::builders::AppInfoBuilder app_info_builder_;
     config::builders::EventsBuilder events_builder_;
     config::builders::DataSystemBuilder data_system_builder_;
+    std::optional<config::builders::BigSegmentsBuilder> big_segments_builder_;
     config::builders::HttpPropertiesBuilder http_properties_builder_;
     config::builders::LoggingBuilder logging_config_builder_;
     std::vector<std::shared_ptr<hooks::Hook>> hooks_;

--- a/libs/server-sdk/src/CMakeLists.txt
+++ b/libs/server-sdk/src/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(${LIBNAME}
         client.cpp
         client_impl.cpp
         data_source_status.cpp
+        big_segment_store_status.cpp
         instance_id.hpp
         instance_id.cpp
         config/config.cpp
@@ -49,6 +50,8 @@ target_sources(${LIBNAME}
         data_components/big_segments/membership_cache.cpp
         data_components/big_segments/big_segment_store_wrapper.hpp
         data_components/big_segments/big_segment_store_wrapper.cpp
+        data_components/big_segments/big_segment_store_status_provider.hpp
+        data_components/big_segments/big_segment_store_status_provider.cpp
         data_interfaces/destination/itransactional_destination.hpp
         data_components/memory_store/memory_store.hpp
         data_components/memory_store/memory_store.cpp

--- a/libs/server-sdk/src/big_segment_store_status.cpp
+++ b/libs/server-sdk/src/big_segment_store_status.cpp
@@ -1,0 +1,34 @@
+#include <launchdarkly/server_side/big_segment_store_status.hpp>
+
+namespace launchdarkly::server_side {
+
+BigSegmentStoreStatus::BigSegmentStoreStatus(bool const available,
+                                             bool const stale)
+    : available_(available), stale_(stale) {}
+
+bool BigSegmentStoreStatus::IsAvailable() const {
+    return available_;
+}
+
+bool BigSegmentStoreStatus::IsStale() const {
+    return stale_;
+}
+
+bool operator==(BigSegmentStoreStatus const& a,
+                BigSegmentStoreStatus const& b) {
+    return a.IsAvailable() == b.IsAvailable() && a.IsStale() == b.IsStale();
+}
+
+bool operator!=(BigSegmentStoreStatus const& a,
+                BigSegmentStoreStatus const& b) {
+    return !(a == b);
+}
+
+std::ostream& operator<<(std::ostream& out,
+                         BigSegmentStoreStatus const& status) {
+    out << "BigSegmentStoreStatus(available=" << std::boolalpha
+        << status.IsAvailable() << ", stale=" << status.IsStale() << ")";
+    return out;
+}
+
+}  // namespace launchdarkly::server_side

--- a/libs/server-sdk/src/client.cpp
+++ b/libs/server-sdk/src/client.cpp
@@ -123,7 +123,7 @@ std::string Client::StringVariation(Context const& ctx,
                                     std::string default_value,
                                     hooks::HookContext const& hook_context) {
     return client->StringVariation(ctx, key, std::move(default_value),
-                                    hook_context);
+                                   hook_context);
 }
 
 EvaluationDetail<std::string> Client::StringVariationDetail(
@@ -166,8 +166,7 @@ EvaluationDetail<double> Client::DoubleVariationDetail(
     FlagKey const& key,
     double default_value,
     hooks::HookContext const& hook_context) {
-    return client->DoubleVariationDetail(ctx, key, default_value,
-                                         hook_context);
+    return client->DoubleVariationDetail(ctx, key, default_value, hook_context);
 }
 
 int Client::IntVariation(Context const& ctx,
@@ -228,6 +227,10 @@ EvaluationDetail<Value> Client::JsonVariationDetail(
 
 IDataSourceStatusProvider& Client::DataSourceStatus() {
     return client->DataSourceStatus();
+}
+
+IBigSegmentStoreStatusProvider& Client::BigSegmentStoreStatus() {
+    return client->BigSegmentStoreStatus();
 }
 
 char const* Client::Version() {

--- a/libs/server-sdk/src/client_impl.cpp
+++ b/libs/server-sdk/src/client_impl.cpp
@@ -39,16 +39,16 @@ auto const kDataSourceShutdownWait = std::chrono::milliseconds(100);
 
 // Hook method names
 // Method names for hooks
-static const std::string kMethodBoolVariation = "BoolVariation";
-static const std::string kMethodBoolVariationDetail = "BoolVariationDetail";
-static const std::string kMethodStringVariation = "StringVariation";
-static const std::string kMethodStringVariationDetail = "StringVariationDetail";
-static const std::string kMethodDoubleVariation = "DoubleVariation";
-static const std::string kMethodDoubleVariationDetail = "DoubleVariationDetail";
-static const std::string kMethodIntVariation = "IntVariation";
-static const std::string kMethodIntVariationDetail = "IntVariationDetail";
-static const std::string kMethodJsonVariation = "JsonVariation";
-static const std::string kMethodJsonVariationDetail = "JsonVariationDetail";
+static std::string const kMethodBoolVariation = "BoolVariation";
+static std::string const kMethodBoolVariationDetail = "BoolVariationDetail";
+static std::string const kMethodStringVariation = "StringVariation";
+static std::string const kMethodStringVariationDetail = "StringVariationDetail";
+static std::string const kMethodDoubleVariation = "DoubleVariation";
+static std::string const kMethodDoubleVariationDetail = "DoubleVariationDetail";
+static std::string const kMethodIntVariation = "IntVariation";
+static std::string const kMethodIntVariationDetail = "IntVariationDetail";
+static std::string const kMethodJsonVariation = "JsonVariation";
+static std::string const kMethodJsonVariationDetail = "JsonVariationDetail";
 
 static std::unique_ptr<data_interfaces::IDataSystem> MakeDataSystem(
     config::built::HttpProperties const& http_properties,
@@ -141,7 +141,15 @@ ClientImpl::ClientImpl(Config config, std::string const& version)
                                           ioc_.get_executor(),
                                           http_properties_,
                                           logger_)),
-      evaluator_(logger_, *data_system_),
+      big_segment_store_(
+          config_.BigSegments()
+              ? std::make_shared<data_components::BigSegmentStoreWrapper>(
+                    *config_.BigSegments(),
+                    ioc_.get_executor(),
+                    logger_)
+              : nullptr),
+      big_segment_status_provider_(big_segment_store_),
+      evaluator_(logger_, *data_system_, big_segment_store_.get()),
       events_default_(event_processor_.get(), EventFactory::WithoutReasons()),
       events_with_reasons_(event_processor_.get(),
                            EventFactory::WithReasons()) {
@@ -156,6 +164,10 @@ ClientImpl::ClientImpl(Config config, std::string const& version)
         launchdarkly::config::shared::built::TlsOptions::VerifyMode::
             kVerifyNone) {
         LD_LOG(logger_, LogLevel::kInfo) << "TLS peer verification disabled";
+    }
+
+    if (big_segment_store_) {
+        big_segment_store_->Start();
     }
 
     run_thread_ = std::move(std::thread([&]() { ioc_.run(); }));
@@ -247,9 +259,9 @@ void ClientImpl::TrackInternal(Context const& ctx,
                                std::optional<Value> data,
                                std::optional<double> metric_value,
                                hooks::HookContext const& hook_context) {
-
     if (!ctx.Valid()) {
-        LD_LOG(logger_, LogLevel::kWarn) << "Track method called with an invalid context";
+        LD_LOG(logger_, LogLevel::kWarn)
+            << "Track method called with an invalid context";
         return;
     }
     // Execute afterTrack hooks before moving the data
@@ -259,8 +271,8 @@ void ClientImpl::TrackInternal(Context const& ctx,
     // In this SDK the data is type-safe, and will be enqueued, so it makes
     // minimal functional difference.
     if (!config_.Hooks().empty()) {
-        hooks::TrackSeriesContext series_context(ctx, event_name, metric_value,
-                                                  data, hook_context, std::nullopt);
+        hooks::TrackSeriesContext series_context(
+            ctx, event_name, metric_value, data, hook_context, std::nullopt);
         hooks::ExecuteAfterTrack(config_.Hooks(), series_context, logger_);
     }
 
@@ -367,7 +379,8 @@ EvaluationDetail<Value> ClientImpl::VariationInternal(
     std::optional<hooks::EvaluationSeriesExecutor> executor;
     if (!config_.Hooks().empty()) {
         hooks::EvaluationSeriesContext series_context(
-            key, context, default_value, method_name, hook_context, std::nullopt);
+            key, context, default_value, method_name, hook_context,
+            std::nullopt);
         // Executor only created if there are hooks.
         executor.emplace(config_.Hooks(), logger_);
         executor->BeforeEvaluation(series_context);
@@ -380,7 +393,8 @@ EvaluationDetail<Value> ClientImpl::VariationInternal(
         // Execute afterEvaluation hooks
         if (executor) {
             hooks::EvaluationSeriesContext series_context(
-                key, context, default_value, method_name, hook_context, std::nullopt);
+                key, context, default_value, method_name, hook_context,
+                std::nullopt);
             executor->AfterEvaluation(series_context, detail);
         }
 
@@ -401,7 +415,8 @@ EvaluationDetail<Value> ClientImpl::VariationInternal(
         // Execute afterEvaluation hooks
         if (executor) {
             hooks::EvaluationSeriesContext series_context(
-                key, context, default_value, method_name, hook_context, std::nullopt);
+                key, context, default_value, method_name, hook_context,
+                std::nullopt);
             executor->AfterEvaluation(series_context, detail);
         }
 
@@ -416,7 +431,8 @@ EvaluationDetail<Value> ClientImpl::VariationInternal(
     // Execute afterEvaluation hooks
     if (executor) {
         hooks::EvaluationSeriesContext series_context(
-            key, context, default_value, method_name, hook_context, std::nullopt);
+            key, context, default_value, method_name, hook_context,
+            std::nullopt);
         executor->AfterEvaluation(series_context, detail);
     }
 
@@ -484,7 +500,8 @@ EvaluationDetail<bool> ClientImpl::BoolVariationDetail(
     bool default_value) {
     static hooks::HookContext empty_hook_context;
     return VariationDetail<bool>(ctx, Value::Type::kBool, key, default_value,
-                                 empty_hook_context, kMethodBoolVariationDetail);
+                                 empty_hook_context,
+                                 kMethodBoolVariationDetail);
 }
 
 EvaluationDetail<bool> ClientImpl::BoolVariationDetail(
@@ -508,8 +525,8 @@ bool ClientImpl::BoolVariation(Context const& ctx,
                                IClient::FlagKey const& key,
                                bool default_value,
                                hooks::HookContext const& hook_context) {
-    return Variation(ctx, Value::Type::kBool, key, default_value,
-                     hook_context, kMethodBoolVariation);
+    return Variation(ctx, Value::Type::kBool, key, default_value, hook_context,
+                     kMethodBoolVariation);
 }
 
 EvaluationDetail<std::string> ClientImpl::StringVariationDetail(
@@ -540,10 +557,11 @@ std::string ClientImpl::StringVariation(Context const& ctx,
                      empty_hook_context, kMethodStringVariation);
 }
 
-std::string ClientImpl::StringVariation(Context const& ctx,
-                                        IClient::FlagKey const& key,
-                                        std::string default_value,
-                                        hooks::HookContext const& hook_context) {
+std::string ClientImpl::StringVariation(
+    Context const& ctx,
+    IClient::FlagKey const& key,
+    std::string default_value,
+    hooks::HookContext const& hook_context) {
     return Variation(ctx, Value::Type::kString, key, default_value,
                      hook_context, kMethodStringVariation);
 }
@@ -654,6 +672,10 @@ Value ClientImpl::JsonVariation(Context const& ctx,
 
 IDataSourceStatusProvider& ClientImpl::DataSourceStatus() {
     return status_manager_;
+}
+
+IBigSegmentStoreStatusProvider& ClientImpl::BigSegmentStoreStatus() {
+    return big_segment_status_provider_;
 }
 
 ClientImpl::~ClientImpl() {

--- a/libs/server-sdk/src/client_impl.hpp
+++ b/libs/server-sdk/src/client_impl.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "data_components/big_segments/big_segment_store_status_provider.hpp"
+#include "data_components/big_segments/big_segment_store_wrapper.hpp"
 #include "data_components/status_notifications/data_source_status_manager.hpp"
 #include "data_interfaces/system/idata_system.hpp"
 #include "evaluation/evaluator.hpp"
@@ -98,10 +100,11 @@ class ClientImpl : public IClient {
                                 FlagKey const& key,
                                 std::string default_value) override;
 
-    std::string StringVariation(Context const& ctx,
-                                FlagKey const& key,
-                                std::string default_value,
-                                hooks::HookContext const& hook_context) override;
+    std::string StringVariation(
+        Context const& ctx,
+        FlagKey const& key,
+        std::string default_value,
+        hooks::HookContext const& hook_context) override;
 
     EvaluationDetail<std::string> StringVariationDetail(
         Context const& ctx,
@@ -173,6 +176,8 @@ class ClientImpl : public IClient {
         hooks::HookContext const& hook_context) override;
 
     IDataSourceStatusProvider& DataSourceStatus() override;
+
+    IBigSegmentStoreStatusProvider& BigSegmentStoreStatus() override;
 
     ~ClientImpl();
 
@@ -253,6 +258,12 @@ class ClientImpl : public IClient {
     std::unique_ptr<data_interfaces::IDataSystem> data_system_;
 
     std::unique_ptr<events::IEventProcessor> event_processor_;
+
+    // Null when Big Segments are not configured. Declared before evaluator_ so
+    // its pointer can be handed to the evaluator, and before
+    // big_segment_status_provider_ which shares ownership.
+    std::shared_ptr<data_components::BigSegmentStoreWrapper> big_segment_store_;
+    data_components::BigSegmentStoreStatusProvider big_segment_status_provider_;
 
     mutable std::mutex init_mutex_;
     std::condition_variable init_waiter_;

--- a/libs/server-sdk/src/config/builders/big_segments_builder.cpp
+++ b/libs/server-sdk/src/config/builders/big_segments_builder.cpp
@@ -1,4 +1,4 @@
-#include "big_segments_builder.hpp"
+#include <launchdarkly/server_side/config/builders/big_segments_builder.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -55,7 +55,10 @@ BigSegmentsBuilder& BigSegmentsBuilder::StaleAfter(
     return *this;
 }
 
-built::BigSegmentsConfig BigSegmentsBuilder::Build() const {
+tl::expected<built::BigSegmentsConfig, Error> BigSegmentsBuilder::Build() const {
+    if (!store_) {
+        return tl::make_unexpected(Error::kConfig_BigSegments_NullStore);
+    }
     auto const poll = std::min(status_poll_interval_, stale_after_);
     return built::BigSegmentsConfig{store_, context_cache_size_,
                                     context_cache_time_, poll, stale_after_};

--- a/libs/server-sdk/src/config/config.cpp
+++ b/libs/server-sdk/src/config/config.cpp
@@ -10,6 +10,7 @@ Config::Config(std::string sdk_key,
                built::Events events,
                std::optional<std::string> application_tag,
                config::built::DataSystemConfig data_system_config,
+               std::optional<config::built::BigSegmentsConfig> big_segments,
                built::HttpProperties http_properties,
                std::vector<std::shared_ptr<hooks::Hook>> hooks)
     : sdk_key_(std::move(sdk_key)),
@@ -18,6 +19,7 @@ Config::Config(std::string sdk_key,
       events_(std::move(events)),
       application_tag_(std::move(application_tag)),
       data_system_config_(std::move(data_system_config)),
+      big_segments_(std::move(big_segments)),
       http_properties_(std::move(http_properties)),
       hooks_(std::move(hooks)) {}
 
@@ -39,6 +41,11 @@ std::optional<std::string> const& Config::ApplicationTag() const {
 
 config::built::DataSystemConfig const& Config::DataSystemConfig() const {
     return data_system_config_;
+}
+
+std::optional<config::built::BigSegmentsConfig> const& Config::BigSegments()
+    const {
+    return big_segments_;
 }
 
 built::HttpProperties const& Config::HttpProperties() const {

--- a/libs/server-sdk/src/config/config_builder.cpp
+++ b/libs/server-sdk/src/config/config_builder.cpp
@@ -84,11 +84,11 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
 
     std::optional<config::built::BigSegmentsConfig> big_segments_config;
     if (big_segments_builder_) {
-        auto built = big_segments_builder_->Build();
-        if (!built) {
-            return tl::make_unexpected(built.error());
+        auto big_segments = big_segments_builder_->Build();
+        if (!big_segments) {
+            return tl::make_unexpected(big_segments.error());
         }
-        big_segments_config = std::move(*built);
+        big_segments_config = std::move(*big_segments);
     }
 
     return {tl::in_place,

--- a/libs/server-sdk/src/config/config_builder.cpp
+++ b/libs/server-sdk/src/config/config_builder.cpp
@@ -21,6 +21,12 @@ config::builders::DataSystemBuilder& ConfigBuilder::DataSystem() {
     return data_system_builder_;
 }
 
+ConfigBuilder& ConfigBuilder::BigSegments(
+    config::builders::BigSegmentsBuilder builder) {
+    big_segments_builder_ = std::move(builder);
+    return *this;
+}
+
 config::builders::HttpPropertiesBuilder& ConfigBuilder::HttpProperties() {
     return http_properties_builder_;
 }
@@ -76,6 +82,15 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
 
     auto logging = logging_config_builder_.Build();
 
+    std::optional<config::built::BigSegmentsConfig> big_segments_config;
+    if (big_segments_builder_) {
+        auto built = big_segments_builder_->Build();
+        if (!built) {
+            return tl::make_unexpected(built.error());
+        }
+        big_segments_config = std::move(*built);
+    }
+
     return {tl::in_place,
             sdk_key,
             logging,
@@ -83,6 +98,7 @@ tl::expected<Config, Error> ConfigBuilder::Build() const {
             *events_config,
             app_tag,
             std::move(*data_system_config),
+            std::move(big_segments_config),
             std::move(http_properties),
             hooks_};
 }

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.cpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.cpp
@@ -1,0 +1,50 @@
+#include "big_segment_store_status_provider.hpp"
+
+#include <utility>
+
+namespace launchdarkly::server_side::data_components {
+
+namespace {
+
+// Returned when no store is configured: nothing to disconnect.
+class NoopConnection : public IConnection {
+   public:
+    void Disconnect() override {}
+};
+
+// Converts the internal status struct to the public status type. Both are named
+// BigSegmentStoreStatus, in this namespace and in server_side respectively.
+server_side::BigSegmentStoreStatus ToPublic(
+    data_components::BigSegmentStoreStatus const& status) {
+    return server_side::BigSegmentStoreStatus{status.available, status.stale};
+}
+
+}  // namespace
+
+BigSegmentStoreStatusProvider::BigSegmentStoreStatusProvider(
+    std::shared_ptr<BigSegmentStoreWrapper> wrapper)
+    : wrapper_(std::move(wrapper)) {}
+
+server_side::BigSegmentStoreStatus BigSegmentStoreStatusProvider::Status()
+    const {
+    if (!wrapper_) {
+        return server_side::BigSegmentStoreStatus{/* available= */ false,
+                                                  /* stale= */ false};
+    }
+    return ToPublic(wrapper_->GetStatus());
+}
+
+std::unique_ptr<IConnection>
+BigSegmentStoreStatusProvider::OnBigSegmentStoreStatusChange(
+    std::function<void(server_side::BigSegmentStoreStatus status)> handler) {
+    if (!wrapper_) {
+        return std::make_unique<NoopConnection>();
+    }
+    return wrapper_->OnStatusChange(
+        [handler = std::move(handler)](
+            data_components::BigSegmentStoreStatus status) {
+            handler(ToPublic(status));
+        });
+}
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.hpp
@@ -28,7 +28,7 @@ class BigSegmentStoreStatusProvider : public IBigSegmentStoreStatusProvider {
    public:
     /**
      * @param wrapper The wrapper to delegate to, or nullptr if Big Segments are
-     * not configured. Must outlive this provider.
+     * not configured.
      */
     explicit BigSegmentStoreStatusProvider(
         std::shared_ptr<BigSegmentStoreWrapper> wrapper);

--- a/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.hpp
+++ b/libs/server-sdk/src/data_components/big_segments/big_segment_store_status_provider.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "big_segment_store_wrapper.hpp"
+
+#include <launchdarkly/server_side/big_segment_store_status.hpp>
+
+#include <functional>
+#include <memory>
+
+namespace launchdarkly::server_side::data_components {
+
+/**
+ * @brief Adapts a BigSegmentStoreWrapper to the public
+ * IBigSegmentStoreStatusProvider, converting the internal status struct to the
+ * public type.
+ *
+ * Holds a null wrapper when Big Segments are not configured; in that case it
+ * reports the store as unavailable and not stale, and registered listeners
+ * never fire.
+ *
+ * Thread-safe: delegates to the wrapper, which is itself thread-safe.
+ *
+ * Note: the public status type server_side::BigSegmentStoreStatus is qualified
+ * throughout, since this namespace also has an internal struct of the same
+ * name.
+ */
+class BigSegmentStoreStatusProvider : public IBigSegmentStoreStatusProvider {
+   public:
+    /**
+     * @param wrapper The wrapper to delegate to, or nullptr if Big Segments are
+     * not configured. Must outlive this provider.
+     */
+    explicit BigSegmentStoreStatusProvider(
+        std::shared_ptr<BigSegmentStoreWrapper> wrapper);
+
+    [[nodiscard]] server_side::BigSegmentStoreStatus Status() const override;
+
+    std::unique_ptr<IConnection> OnBigSegmentStoreStatusChange(
+        std::function<void(server_side::BigSegmentStoreStatus status)> handler)
+        override;
+
+   private:
+    std::shared_ptr<BigSegmentStoreWrapper> wrapper_;
+};
+
+}  // namespace launchdarkly::server_side::data_components

--- a/libs/server-sdk/tests/big_segment_store_status_provider_test.cpp
+++ b/libs/server-sdk/tests/big_segment_store_status_provider_test.cpp
@@ -1,0 +1,166 @@
+#include <gtest/gtest.h>
+
+#include <data_components/big_segments/big_segment_store_status_provider.hpp>
+#include <data_components/big_segments/big_segment_store_wrapper.hpp>
+
+#include <launchdarkly/logging/null_logger.hpp>
+
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+using launchdarkly::server_side::BigSegmentStoreStatus;
+using launchdarkly::server_side::data_components::BigSegmentStoreStatusProvider;
+using launchdarkly::server_side::data_components::BigSegmentStoreWrapper;
+namespace integrations = launchdarkly::server_side::integrations;
+namespace built = launchdarkly::server_side::config::built;
+using namespace std::chrono_literals;
+
+namespace {
+
+// In-memory store whose metadata response the test controls.
+class FakeBigSegmentStore : public integrations::IBigSegmentStore {
+   public:
+    GetMembershipResult GetMembership(
+        std::string const&) const noexcept override {
+        return integrations::Membership::FromSegmentRefs({}, {});
+    }
+
+    GetMetadataResult GetMetadata() const noexcept override {
+        std::lock_guard lock(mutex_);
+        return metadata_;
+    }
+
+    void SetMetadata(GetMetadataResult metadata) {
+        std::lock_guard lock(mutex_);
+        metadata_ = std::move(metadata);
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    GetMetadataResult metadata_ =
+        std::optional<integrations::StoreMetadata>{std::nullopt};
+};
+
+built::BigSegmentsConfig MakeConfig(
+    std::shared_ptr<integrations::IBigSegmentStore> store,
+    std::chrono::milliseconds poll_interval) {
+    built::BigSegmentsConfig config;
+    config.store = std::move(store);
+    config.context_cache_size = 1000;
+    config.context_cache_time = 5s;
+    config.status_poll_interval = poll_interval;
+    config.stale_after = 2min;
+    return config;
+}
+
+}  // namespace
+
+TEST(BigSegmentStoreStatusProviderTest, UnconfiguredReportsUnavailable) {
+    BigSegmentStoreStatusProvider provider(nullptr);
+
+    auto const status = provider.Status();
+    EXPECT_FALSE(status.IsAvailable());
+    EXPECT_FALSE(status.IsStale());
+
+    // A listener can still be registered; it simply never fires.
+    bool fired = false;
+    auto connection = provider.OnBigSegmentStoreStatusChange(
+        [&fired](BigSegmentStoreStatus) { fired = true; });
+    ASSERT_NE(connection, nullptr);
+    connection->Disconnect();
+    EXPECT_FALSE(fired);
+}
+
+TEST(BigSegmentStoreStatusProviderTest, DelegatesStatusToWrapper) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s), ioc.get_executor(), logger);
+
+    BigSegmentStoreStatusProvider provider(wrapper);
+
+    // The wrapper polls inline on the first GetStatus, so fresh metadata is
+    // reported as available and not stale.
+    auto const status = provider.Status();
+    EXPECT_TRUE(status.IsAvailable());
+    EXPECT_FALSE(status.IsStale());
+}
+
+TEST(BigSegmentStoreStatusProviderTest, StaleMetadataReportedAsStale) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now() - 5min});
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5s), ioc.get_executor(), logger);
+
+    BigSegmentStoreStatusProvider provider(wrapper);
+
+    auto const status = provider.Status();
+    EXPECT_TRUE(status.IsAvailable());
+    EXPECT_TRUE(status.IsStale());
+}
+
+TEST(BigSegmentStoreStatusProviderTest, ListenerReceivesConvertedPublicStatus) {
+    auto store = std::make_shared<FakeBigSegmentStore>();
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now()});
+
+    auto logger = launchdarkly::logging::NullLogger();
+    boost::asio::io_context ioc;
+    auto work_guard = boost::asio::make_work_guard(ioc);
+    std::thread io_thread([&ioc] { ioc.run(); });
+
+    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
+        MakeConfig(store, /*poll_interval=*/5ms), ioc.get_executor(), logger);
+
+    BigSegmentStoreStatusProvider provider(wrapper);
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::optional<BigSegmentStoreStatus> last;
+    auto connection = provider.OnBigSegmentStoreStatusChange(
+        [&](BigSegmentStoreStatus status) {
+            std::lock_guard lock(mutex);
+            last = status;
+            cv.notify_all();
+        });
+
+    wrapper->Start();
+
+    // First poll broadcasts the initial healthy status through the adapter.
+    {
+        std::unique_lock lock(mutex);
+        ASSERT_TRUE(cv.wait_for(
+            lock, 1s, [&] { return last.has_value() && last->IsAvailable(); }));
+        EXPECT_FALSE(last->IsStale());
+    }
+
+    // A store error flips availability, which the listener observes.
+    store->SetMetadata(tl::make_unexpected("boom"));
+    {
+        std::unique_lock lock(mutex);
+        ASSERT_TRUE(cv.wait_for(lock, 1s, [&] {
+            return last.has_value() && !last->IsAvailable();
+        }));
+    }
+
+    connection->Disconnect();
+
+    work_guard.reset();
+    ioc.stop();
+    io_thread.join();
+}

--- a/libs/server-sdk/tests/big_segment_store_status_provider_test.cpp
+++ b/libs/server-sdk/tests/big_segment_store_status_provider_test.cpp
@@ -44,8 +44,7 @@ class FakeBigSegmentStore : public integrations::IBigSegmentStore {
 
    private:
     mutable std::mutex mutex_;
-    GetMetadataResult metadata_ =
-        std::optional<integrations::StoreMetadata>{std::nullopt};
+    GetMetadataResult metadata_;
 };
 
 built::BigSegmentsConfig MakeConfig(
@@ -78,43 +77,7 @@ TEST(BigSegmentStoreStatusProviderTest, UnconfiguredReportsUnavailable) {
     EXPECT_FALSE(fired);
 }
 
-TEST(BigSegmentStoreStatusProviderTest, DelegatesStatusToWrapper) {
-    auto store = std::make_shared<FakeBigSegmentStore>();
-    store->SetMetadata(
-        integrations::StoreMetadata{std::chrono::system_clock::now()});
-
-    auto logger = launchdarkly::logging::NullLogger();
-    boost::asio::io_context ioc;
-    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
-        MakeConfig(store, /*poll_interval=*/5s), ioc.get_executor(), logger);
-
-    BigSegmentStoreStatusProvider provider(wrapper);
-
-    // The wrapper polls inline on the first GetStatus, so fresh metadata is
-    // reported as available and not stale.
-    auto const status = provider.Status();
-    EXPECT_TRUE(status.IsAvailable());
-    EXPECT_FALSE(status.IsStale());
-}
-
-TEST(BigSegmentStoreStatusProviderTest, StaleMetadataReportedAsStale) {
-    auto store = std::make_shared<FakeBigSegmentStore>();
-    store->SetMetadata(
-        integrations::StoreMetadata{std::chrono::system_clock::now() - 5min});
-
-    auto logger = launchdarkly::logging::NullLogger();
-    boost::asio::io_context ioc;
-    auto wrapper = std::make_shared<BigSegmentStoreWrapper>(
-        MakeConfig(store, /*poll_interval=*/5s), ioc.get_executor(), logger);
-
-    BigSegmentStoreStatusProvider provider(wrapper);
-
-    auto const status = provider.Status();
-    EXPECT_TRUE(status.IsAvailable());
-    EXPECT_TRUE(status.IsStale());
-}
-
-TEST(BigSegmentStoreStatusProviderTest, ListenerReceivesConvertedPublicStatus) {
+TEST(BigSegmentStoreStatusProviderTest, StatusAndListenerReflectStoreTransitions) {
     auto store = std::make_shared<FakeBigSegmentStore>();
     store->SetMetadata(
         integrations::StoreMetadata{std::chrono::system_clock::now()});
@@ -141,21 +104,34 @@ TEST(BigSegmentStoreStatusProviderTest, ListenerReceivesConvertedPublicStatus) {
 
     wrapper->Start();
 
-    // First poll broadcasts the initial healthy status through the adapter.
+    // Fresh metadata is reported as available and not stale.
+    {
+        std::unique_lock lock(mutex);
+        ASSERT_TRUE(cv.wait_for(lock, 1s, [&] {
+            return last.has_value() && last->IsAvailable() && !last->IsStale();
+        }));
+        EXPECT_EQ(provider.Status(), *last);
+    }
+
+    // Old metadata is reported as available but stale.
+    store->SetMetadata(
+        integrations::StoreMetadata{std::chrono::system_clock::now() - 5min});
     {
         std::unique_lock lock(mutex);
         ASSERT_TRUE(cv.wait_for(
-            lock, 1s, [&] { return last.has_value() && last->IsAvailable(); }));
-        EXPECT_FALSE(last->IsStale());
+            lock, 1s, [&] { return last.has_value() && last->IsStale(); }));
+        EXPECT_TRUE(last->IsAvailable());
+        EXPECT_EQ(provider.Status(), *last);
     }
 
-    // A store error flips availability, which the listener observes.
+    // A store error flips availability.
     store->SetMetadata(tl::make_unexpected("boom"));
     {
         std::unique_lock lock(mutex);
         ASSERT_TRUE(cv.wait_for(lock, 1s, [&] {
             return last.has_value() && !last->IsAvailable();
         }));
+        EXPECT_EQ(provider.Status(), *last);
     }
 
     connection->Disconnect();

--- a/libs/server-sdk/tests/big_segments_builder_test.cpp
+++ b/libs/server-sdk/tests/big_segments_builder_test.cpp
@@ -3,7 +3,7 @@
 #include <launchdarkly/server_side/integrations/big_segments/big_segment_store_types.hpp>
 #include <launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp>
 
-#include "config/builders/big_segments_builder.hpp"
+#include <launchdarkly/server_side/config/builders/big_segments_builder.hpp>
 
 #include <chrono>
 #include <memory>
@@ -40,24 +40,25 @@ std::shared_ptr<IBigSegmentStore> MakeStubStore() {
 TEST(BigSegmentsBuilderTest, DefaultsMatchSpec) {
     auto store = MakeStubStore();
     auto const cfg = BigSegmentsBuilder(store).Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.context_cache_size, 1000u);
-    EXPECT_EQ(cfg.context_cache_time, 5s);
-    EXPECT_EQ(cfg.status_poll_interval, 5s);
-    EXPECT_EQ(cfg.stale_after, 2min);
+    EXPECT_EQ(cfg->context_cache_size, 1000u);
+    EXPECT_EQ(cfg->context_cache_time, 5s);
+    EXPECT_EQ(cfg->status_poll_interval, 5s);
+    EXPECT_EQ(cfg->stale_after, 2min);
 }
 
 TEST(BigSegmentsBuilderTest, BuildPreservesStoreIdentity) {
     auto store = MakeStubStore();
     auto const cfg = BigSegmentsBuilder(store).Build();
-    EXPECT_EQ(cfg.store.get(), store.get());
+    ASSERT_TRUE(cfg);
+    EXPECT_EQ(cfg->store.get(), store.get());
 }
 
-TEST(BigSegmentsBuilderTest, AcceptsNullStore) {
-    // The builder doesn't validate the store; downstream components treat a
-    // null store as "Big Segments not configured".
+TEST(BigSegmentsBuilderTest, NullStoreIsRejected) {
     auto const cfg = BigSegmentsBuilder(nullptr).Build();
-    EXPECT_EQ(cfg.store, nullptr);
+    ASSERT_FALSE(cfg);
+    EXPECT_EQ(cfg.error(), launchdarkly::Error::kConfig_BigSegments_NullStore);
 }
 
 TEST(BigSegmentsBuilderTest, SettersOverrideEachField) {
@@ -68,11 +69,12 @@ TEST(BigSegmentsBuilderTest, SettersOverrideEachField) {
                          .StatusPollInterval(13s)
                          .StaleAfter(60s)
                          .Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.context_cache_size, 7u);
-    EXPECT_EQ(cfg.context_cache_time, 11s);
-    EXPECT_EQ(cfg.status_poll_interval, 13s);
-    EXPECT_EQ(cfg.stale_after, 60s);
+    EXPECT_EQ(cfg->context_cache_size, 7u);
+    EXPECT_EQ(cfg->context_cache_time, 11s);
+    EXPECT_EQ(cfg->status_poll_interval, 13s);
+    EXPECT_EQ(cfg->stale_after, 60s);
 }
 
 TEST(BigSegmentsBuilderTest, ZeroDurationsAreCoercedToDefaults) {
@@ -82,10 +84,11 @@ TEST(BigSegmentsBuilderTest, ZeroDurationsAreCoercedToDefaults) {
                          .StatusPollInterval(0ms)
                          .StaleAfter(0ms)
                          .Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.context_cache_time, 5s);
-    EXPECT_EQ(cfg.status_poll_interval, 5s);
-    EXPECT_EQ(cfg.stale_after, 2min);
+    EXPECT_EQ(cfg->context_cache_time, 5s);
+    EXPECT_EQ(cfg->status_poll_interval, 5s);
+    EXPECT_EQ(cfg->stale_after, 2min);
 }
 
 TEST(BigSegmentsBuilderTest, NegativeDurationsAreCoercedToDefaults) {
@@ -95,10 +98,11 @@ TEST(BigSegmentsBuilderTest, NegativeDurationsAreCoercedToDefaults) {
                          .StatusPollInterval(-1ms)
                          .StaleAfter(-1ms)
                          .Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.context_cache_time, 5s);
-    EXPECT_EQ(cfg.status_poll_interval, 5s);
-    EXPECT_EQ(cfg.stale_after, 2min);
+    EXPECT_EQ(cfg->context_cache_time, 5s);
+    EXPECT_EQ(cfg->status_poll_interval, 5s);
+    EXPECT_EQ(cfg->stale_after, 2min);
 }
 
 TEST(BigSegmentsBuilderTest, BuildClampsPollIntervalToStaleAfter) {
@@ -109,9 +113,10 @@ TEST(BigSegmentsBuilderTest, BuildClampsPollIntervalToStaleAfter) {
                          .StatusPollInterval(10s)
                          .StaleAfter(3s)
                          .Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.status_poll_interval, 3s);
-    EXPECT_EQ(cfg.stale_after, 3s);
+    EXPECT_EQ(cfg->status_poll_interval, 3s);
+    EXPECT_EQ(cfg->stale_after, 3s);
 }
 
 TEST(BigSegmentsBuilderTest, BuildPreservesPollIntervalWhenWithinStaleAfter) {
@@ -120,9 +125,10 @@ TEST(BigSegmentsBuilderTest, BuildPreservesPollIntervalWhenWithinStaleAfter) {
                          .StatusPollInterval(3s)
                          .StaleAfter(10s)
                          .Build();
+    ASSERT_TRUE(cfg);
 
-    EXPECT_EQ(cfg.status_poll_interval, 3s);
-    EXPECT_EQ(cfg.stale_after, 10s);
+    EXPECT_EQ(cfg->status_poll_interval, 3s);
+    EXPECT_EQ(cfg->stale_after, 10s);
 }
 
 TEST(BigSegmentsBuilderTest, BuildIsRepeatable) {
@@ -132,8 +138,10 @@ TEST(BigSegmentsBuilderTest, BuildIsRepeatable) {
 
     auto const cfg1 = builder.Build();
     auto const cfg2 = builder.Build();
+    ASSERT_TRUE(cfg1);
+    ASSERT_TRUE(cfg2);
 
-    EXPECT_EQ(cfg1.context_cache_size, cfg2.context_cache_size);
-    EXPECT_EQ(cfg1.context_cache_time, cfg2.context_cache_time);
-    EXPECT_EQ(cfg1.store.get(), cfg2.store.get());
+    EXPECT_EQ(cfg1->context_cache_size, cfg2->context_cache_size);
+    EXPECT_EQ(cfg1->context_cache_time, cfg2->context_cache_time);
+    EXPECT_EQ(cfg1->store.get(), cfg2->store.get());
 }

--- a/libs/server-sdk/tests/config_builder_test.cpp
+++ b/libs/server-sdk/tests/config_builder_test.cpp
@@ -3,13 +3,31 @@
 #include <launchdarkly/logging/null_logger.hpp>
 #include <launchdarkly/server_side/client.hpp>
 #include <launchdarkly/server_side/config/config_builder.hpp>
+#include <launchdarkly/server_side/integrations/big_segments/ibig_segment_store.hpp>
 
 #include "config/builders/data_system/defaults.hpp"
 #include "data_systems/background_sync/sources/streaming/streaming_data_source.hpp"
 
+#include <chrono>
+
 using namespace launchdarkly;
 using namespace launchdarkly::server_side;
 using namespace launchdarkly::server_side::config;
+
+namespace {
+// Minimal store so a non-null pointer can be threaded through the config.
+class StubBigSegmentStore : public server_side::integrations::IBigSegmentStore {
+   public:
+    GetMembershipResult GetMembership(
+        std::string const&) const noexcept override {
+        return server_side::integrations::Membership::FromSegmentRefs({}, {});
+    }
+    GetMetadataResult GetMetadata() const noexcept override {
+        return std::optional<server_side::integrations::StoreMetadata>{
+            std::nullopt};
+    }
+};
+}  // namespace
 
 class ConfigBuilderTest : public ::testing::Test {
     // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
@@ -126,6 +144,43 @@ TEST_F(ConfigBuilderTest, DefaultConstruction_EventDefaultsAreUsed) {
     ASSERT_EQ(cfg->Events(),
               ::launchdarkly::config::shared::Defaults<
                   launchdarkly::config::shared::ServerSDK>::Defaults::Events());
+}
+
+TEST_F(ConfigBuilderTest, BigSegmentsAbsentByDefault) {
+    ConfigBuilder builder("sdk-123");
+    auto cfg = builder.Build();
+    ASSERT_TRUE(cfg);
+    EXPECT_FALSE(cfg->BigSegments().has_value());
+}
+
+TEST_F(ConfigBuilderTest, BigSegmentsRoundTripsBuilderTunables) {
+    using namespace std::chrono_literals;
+    auto store = std::make_shared<StubBigSegmentStore>();
+
+    ConfigBuilder builder("sdk-123");
+    builder.BigSegments(builders::BigSegmentsBuilder(store)
+                            .ContextCacheSize(50)
+                            .ContextCacheTime(10s)
+                            .StatusPollInterval(20s)
+                            .StaleAfter(3min));
+
+    auto cfg = builder.Build();
+    ASSERT_TRUE(cfg);
+    ASSERT_TRUE(cfg->BigSegments().has_value());
+    EXPECT_EQ(cfg->BigSegments()->store, store);
+    EXPECT_EQ(cfg->BigSegments()->context_cache_size, 50u);
+    EXPECT_EQ(cfg->BigSegments()->context_cache_time, 10s);
+    EXPECT_EQ(cfg->BigSegments()->status_poll_interval, 20s);
+    EXPECT_EQ(cfg->BigSegments()->stale_after, 3min);
+}
+
+TEST_F(ConfigBuilderTest, BigSegmentsWithNullStoreFailsBuild) {
+    ConfigBuilder builder("sdk-123");
+    builder.BigSegments(builders::BigSegmentsBuilder(nullptr));
+
+    auto cfg = builder.Build();
+    ASSERT_FALSE(cfg);
+    EXPECT_EQ(cfg.error(), Error::kConfig_BigSegments_NullStore);
 }
 
 TEST_F(ConfigBuilderTest, CanDisableDataSystem) {


### PR DESCRIPTION
# Expose Big Segments to customer code

Makes the server-side Big Segments feature reachable from customer code: a public config method to wire a store, and a status provider on the client for querying store health and subscribing to changes. Builds on SDK-2366-2.

## What's in

- Promotes `BigSegmentsBuilder` to the public include tree and adds `ConfigBuilder::BigSegments(BigSegmentsBuilder)`, surfaced as an optional `Config::BigSegments()`.
- New public `IBigSegmentStoreStatusProvider` and `BigSegmentStoreStatus` (`IsAvailable()`/`IsStale()`), plus `Client::BigSegmentStoreStatus()`.
- `ClientImpl` constructs the `BigSegmentStoreWrapper` from config, hands it to the evaluator, and starts its background poll. An internal adapter exposes the wrapper's status broadcaster as the public provider.
- `BigSegmentsBuilder::Build()` now returns a new error code when the store is null.

## Design notes

- The status surface mirrors `DataSourceStatus`: the accessor is `Status()`, and listeners use `OnBigSegmentStoreStatusChange(handler) -> IConnection`.
- When no store is configured, the provider reports the store as unavailable and registered listeners never fire.

## Testing

Unit tests added for the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flag evaluation wiring and add a new public config surface; misconfiguration or store outages can affect Big Segment targeting, though behavior is gated on optional config and mirrors existing data-source status patterns.
> 
> **Overview**
> This PR wires **Big Segments** into the public server SDK: customers can attach a store via config and observe store health on the client, similar to data source status.
> 
> **Configuration:** `ConfigBuilder::BigSegments(BigSegmentsBuilder)` stores an optional `BigSegmentsConfig` on `Config`. `BigSegmentsBuilder::Build()` now returns `tl::expected` and fails with `kConfig_BigSegments_NullStore` when the store pointer is null (previously a null store was allowed through).
> 
> **Client runtime:** When Big Segments are configured, `ClientImpl` creates `BigSegmentStoreWrapper`, passes it to the evaluator, starts background metadata polling, and exposes status through `Client::BigSegmentStoreStatus()`.
> 
> **Public status API:** New `BigSegmentStoreStatus` (`IsAvailable` / `IsStale`) and `IBigSegmentStoreStatusProvider` with `Status()` and `OnBigSegmentStoreStatusChange` → `IConnection`. An internal adapter maps the wrapper to this API; with no store configured, status is unavailable/not stale and listeners are no-ops.
> 
> Unit tests cover builder validation, config round-trip, and status provider behavior (including transitions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11902fa852d36bf17345153bc0eabbb0469e053a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->