### PR TITLE
ci: Cache Windows boost install

### DIFF
--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -29,12 +29,22 @@ runs:
         toolset: ${{ inputs.toolset }}
         platform_version: ${{ inputs.platform_version }}
 
+    - name: Cache boost (Windows)
+      if: runner.os == 'Windows'
+      id: cache-boost-windows
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: 'C:\local\boost_1_87_0'
+        key: boost-windows-msvc-14.3-1.87.0
+
     - name: Download boost binaries from artifactory
       if: runner.os == 'Windows'
       id: boost-download
       shell: bash
       run: |
-        choco install boost-msvc-14.3 --version 1.87.0 -y --no-progress
+        if [ "${{ steps.cache-boost-windows.outputs.cache-hit }}" != "true" ]; then
+          choco install boost-msvc-14.3 --version 1.87.0 -y --no-progress
+        fi
         echo "BOOST_ROOT=C:\local\boost_1_87_0" >> $GITHUB_OUTPUT
         echo "Boost_DIR=C:\local\boost_1_87_0\lib64-msvc-14.3\cmake\Boost-1.87.0" >> $GITHUB_OUTPUT
 

--- a/.github/actions/install-curl/action.yml
+++ b/.github/actions/install-curl/action.yml
@@ -29,17 +29,26 @@ runs:
         echo "CURL_ROOT=$(brew --prefix curl)" >> $GITHUB_OUTPUT
 
     # Windows: Build CURL from source with MSVC using helper script
+    - name: Cache CURL (Windows)
+      if: runner.os == 'Windows'
+      id: cache-curl-windows
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: 'C:\curl-install'
+        key: curl-windows-8.11.1-${{ hashFiles('scripts/build-curl-windows.ps1') }}
+
     - name: Install CURL for Windows
       if: runner.os == 'Windows'
       id: windows-action
       shell: pwsh
       run: |
-        # Use the build script from the repository
-        & "${{ github.workspace }}\scripts\build-curl-windows.ps1" -Version "8.11.1" -InstallPrefix "C:\curl-install"
+        if ("${{ steps.cache-curl-windows.outputs.cache-hit }}" -ne "true") {
+          & "${{ github.workspace }}\scripts\build-curl-windows.ps1" -Version "8.11.1" -InstallPrefix "C:\curl-install"
 
-        if ($LASTEXITCODE -ne 0) {
-          Write-Error "CURL build failed"
-          exit 1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "CURL build failed"
+            exit 1
+          }
         }
 
         echo "CURL_ROOT=C:\curl-install" >> $env:GITHUB_OUTPUT

--- a/.github/actions/install-openssl/action.yml
+++ b/.github/actions/install-openssl/action.yml
@@ -27,12 +27,24 @@ runs:
     # The Windows runner has an older version of OpenSSL and needs to be upgraded.
     # Additionally, it seems to randomly be installed in OpenSSL-Win64 or OpenSSL depending on
     # the runner Github gives us.
+    - name: Cache OpenSSL (Windows)
+      if: runner.os == 'Windows'
+      id: cache-openssl-windows
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      with:
+        path: |
+          C:\Program Files\OpenSSL-Win64
+          C:\Program Files\OpenSSL
+        key: openssl-windows-4.0.1
+
     - name: Install for Windows
       id: choco-action
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        choco install openssl --version 4.0.1 -y --no-progress
+        if [ "${{ steps.cache-openssl-windows.outputs.cache-hit }}" != "true" ]; then
+          choco install openssl --version 4.0.1 -y --no-progress
+        fi
         if [ -d "C:\Program Files\OpenSSL-Win64" ]; then
           echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_OUTPUT
         else


### PR DESCRIPTION
## Summary

Adds `actions/cache` for the chocolatey-installed Boost directory (`C:\local\boost_1_87_0`) so the ~minutes-long `choco install boost-msvc-14.3` step is skipped on cache hit.

Key is fixed (`boost-windows-msvc-14.3-1.87.0`) since the version is pinned in the same step.

First of a small series of CI-speedup commits; opened as draft for cache-hit verification on the second run.