### PR TITLE
ci: Add sccache compiler cache

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -56,6 +56,8 @@ runs:
       if: inputs.use_curl == 'true' || inputs.install_curl == 'true'
       uses: ./.github/actions/install-curl
       id: install-curl
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
     - name: Build Library
       shell: bash
       run: ./scripts/build.sh ${{ inputs.cmake_target }} ON ${{ inputs.use_curl }}
@@ -82,6 +84,11 @@ runs:
       # This uses the binary, versus "make tests" because the binary
       # has better performance and output.
       run: ./build/gtest_${{ inputs.cmake_target }}
+
+    - name: sccache stats (after unit-test build)
+      if: always()
+      shell: bash
+      run: sccache --show-stats || true
 
     - name: Simulate Release (Linux/MacOS)
       if: inputs.simulate_release == 'true'
@@ -113,3 +120,8 @@ runs:
         Boost_DIR: 'C:\local\boost_1_87_0\lib64-msvc-14.3\cmake\Boost-1.87.0'
         CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
         CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
+
+    - name: sccache stats (final)
+      if: always()
+      shell: bash
+      run: sccache --show-stats || true

--- a/scripts/build-release-windows.sh
+++ b/scripts/build-release-windows.sh
@@ -40,7 +40,12 @@ fi
 
 sccache_args=()
 if command -v sccache >/dev/null 2>&1; then
-  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
+  sccache_args=(
+    -D CMAKE_C_COMPILER_LAUNCHER=sccache
+    -D CMAKE_CXX_COMPILER_LAUNCHER=sccache
+    -D CMAKE_POLICY_DEFAULT_CMP0141=NEW
+    -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+  )
 fi
 
 # Build a static release.

--- a/scripts/build-release-windows.sh
+++ b/scripts/build-release-windows.sh
@@ -38,6 +38,11 @@ else
   suffix=""
 fi
 
+sccache_args=()
+if command -v sccache >/dev/null 2>&1; then
+  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
+fi
+
 # Build a static release.
 mkdir -p "build-static${suffix}" && cd "build-static${suffix}"
 mkdir -p release
@@ -46,7 +51,8 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" \
                -D LD_CURL_NETWORKING="$build_curl" \
                -D BUILD_TESTING=OFF \
-               -D CMAKE_INSTALL_PREFIX=./release ..
+               -D CMAKE_INSTALL_PREFIX=./release \
+               "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .
@@ -62,7 +68,8 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE=Release \
                -D BUILD_TESTING=OFF \
                -D LD_BUILD_SHARED_LIBS=ON \
                -D LD_DYNAMIC_LINK_BOOST=OFF \
-               -D CMAKE_INSTALL_PREFIX=./release ..
+               -D CMAKE_INSTALL_PREFIX=./release \
+               "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .
@@ -76,7 +83,8 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug \
                -D LD_BUILD_REDIS_SUPPORT="$build_redis" \
                -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" \
                -D LD_CURL_NETWORKING="$build_curl" \
-               -D CMAKE_INSTALL_PREFIX=./release ..
+               -D CMAKE_INSTALL_PREFIX=./release \
+               "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .
@@ -93,7 +101,8 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE=Debug \
                -D LD_CURL_NETWORKING="$build_curl" \
                -D LD_BUILD_SHARED_LIBS=ON \
                -D LD_DYNAMIC_LINK_BOOST=OFF \
-               -D CMAKE_INSTALL_PREFIX=./release ..
+               -D CMAKE_INSTALL_PREFIX=./release \
+               "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -38,10 +38,15 @@ else
   suffix=""
 fi
 
+sccache_args=()
+if command -v sccache >/dev/null 2>&1; then
+  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
+fi
+
 # Build a static release.
 mkdir -p "build-static${suffix}" && cd "build-static${suffix}"
 mkdir -p release
-cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=./release ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=./release "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .
@@ -50,7 +55,7 @@ cd ..
 # Build a dynamic release.
 mkdir -p "build-dynamic${suffix}" && cd "build-dynamic${suffix}"
 mkdir -p release
-cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D LD_BUILD_SHARED_LIBS=ON -D CMAKE_INSTALL_PREFIX=./release ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D LD_BUILD_SHARED_LIBS=ON -D CMAKE_INSTALL_PREFIX=./release "${sccache_args[@]}" ..
 
 cmake --build . --target "$TARGET"
 cmake --install .

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -38,15 +38,10 @@ else
   suffix=""
 fi
 
-sccache_args=()
-if command -v sccache >/dev/null 2>&1; then
-  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
-fi
-
 # Build a static release.
 mkdir -p "build-static${suffix}" && cd "build-static${suffix}"
 mkdir -p release
-cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=./release "${sccache_args[@]}" ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=./release ..
 
 cmake --build . --target "$TARGET"
 cmake --install .
@@ -55,7 +50,7 @@ cd ..
 # Build a dynamic release.
 mkdir -p "build-dynamic${suffix}" && cd "build-dynamic${suffix}"
 mkdir -p release
-cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D LD_BUILD_SHARED_LIBS=ON -D CMAKE_INSTALL_PREFIX=./release "${sccache_args[@]}" ..
+cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D LD_BUILD_REDIS_SUPPORT="$build_redis" -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" -D LD_CURL_NETWORKING="$build_curl" -D BUILD_TESTING=OFF -D LD_BUILD_SHARED_LIBS=ON -D CMAKE_INSTALL_PREFIX=./release ..
 
 cmake --build . --target "$TARGET"
 cmake --install .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,7 +54,12 @@ fi
 
 sccache_args=()
 if command -v sccache >/dev/null 2>&1; then
-  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
+  sccache_args=(
+    -D CMAKE_C_COMPILER_LAUNCHER=sccache
+    -D CMAKE_CXX_COMPILER_LAUNCHER=sccache
+    -D CMAKE_POLICY_DEFAULT_CMP0141=NEW
+    -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+  )
 fi
 
 echo "==== Build Configuration ===="

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,6 +52,11 @@ if [ "$1" == "launchdarkly-cpp-server-otel" ] || [ "$1" == "gtest_launchdarkly-c
   build_otel_fetch_deps="ON"
 fi
 
+sccache_args=()
+if command -v sccache >/dev/null 2>&1; then
+  sccache_args=(-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache)
+fi
+
 echo "==== Build Configuration ===="
 echo "Target: $1"
 echo "CMAKE_BUILD_TYPE: $build_type"
@@ -63,6 +68,7 @@ echo "LD_BUILD_DYNAMODB_SUPPORT: $build_dynamodb"
 echo "LD_CURL_NETWORKING: $build_curl"
 echo "LD_BUILD_OTEL_SUPPORT: $build_otel"
 echo "LD_BUILD_OTEL_FETCH_DEPS: $build_otel_fetch_deps"
+echo "sccache: ${sccache_args[*]:-not detected}"
 echo "============================="
 
 cmake -G Ninja -D CMAKE_BUILD_TYPE="$build_type" \
@@ -74,6 +80,7 @@ cmake -G Ninja -D CMAKE_BUILD_TYPE="$build_type" \
                -D LD_BUILD_DYNAMODB_SUPPORT="$build_dynamodb" \
                -D LD_CURL_NETWORKING="$build_curl" \
                -D LD_BUILD_OTEL_SUPPORT="$build_otel" \
-               -D LD_BUILD_OTEL_FETCH_DEPS="$build_otel_fetch_deps" ..
+               -D LD_BUILD_OTEL_FETCH_DEPS="$build_otel_fetch_deps" \
+               "${sccache_args[@]}" ..
 
 cmake --build . --target "$1"


### PR DESCRIPTION
## Summary

Adds the `sccache` compiler cache to CI builds. Local cache only -- no cross-run backend yet -- so the benefit comes entirely from within-job hits. Notably, `build-dynamodb-windows` compiles the AWS SDK 5 times in one job (`build.sh` once + `build-release-windows.sh` four times for static/shared x release/debug); sccache should catch the redundant compilation across those sub-builds.

Changes:
- New install step in `.github/actions/ci/action.yml` (`mozilla-actions/sccache-action@v0.0.10`).
- Build scripts pass `-D CMAKE_C_COMPILER_LAUNCHER=sccache -D CMAKE_CXX_COMPILER_LAUNCHER=sccache` when `sccache` is on PATH; no-op locally.
- `sccache --show-stats` printed after the unit-test build and at the end of the job.

Adds a dependency on the `sccache` binary (Mozilla, MIT/Apache-2.0). No new runtime deps in the published SDKs.