### PR TITLE
ci: Enable dynamodb-source releases via release-please

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -59,6 +59,9 @@ runs:
         WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
+        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
+        CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
+        CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
 
     - name: Build Linux Artifacts (CURL)
       if: runner.os == 'Linux'
@@ -146,6 +149,9 @@ runs:
         Boost_DIR: ${{ steps.install-boost.outputs.Boost_DIR }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
+        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
+        CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
+        CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
       run: ./scripts/build-release-windows.sh ${{ inputs.sdk_cmake_target }}
 
     - name: Build Windows Artifacts (CURL)
@@ -253,6 +259,9 @@ runs:
         WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
+        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
+        CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
+        CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
 
     - name: Build Mac Artifacts (CURL)
       if: runner.os == 'macOS'

--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -59,7 +59,7 @@ runs:
         WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
-        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
+        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) on Linux/macOS, regardless of LD_CURL_NETWORKING.
         CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
         CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
 
@@ -149,9 +149,6 @@ runs:
         Boost_DIR: ${{ steps.install-boost.outputs.Boost_DIR }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
-        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
-        CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
-        CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
       run: ./scripts/build-release-windows.sh ${{ inputs.sdk_cmake_target }}
 
     - name: Build Windows Artifacts (CURL)
@@ -259,7 +256,7 @@ runs:
         WORKSPACE: ${{ inputs.sdk_path }}
         BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
         OPENSSL_ROOT_DIR: ${{ steps.install-openssl.outputs.OPENSSL_ROOT_DIR }}
-        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) regardless of LD_CURL_NETWORKING.
+        # aws-sdk-cpp (dynamodb-source) calls find_package(CURL) on Linux/macOS, regardless of LD_CURL_NETWORKING.
         CURL_ROOT: ${{ steps.install-curl.outputs.CURL_ROOT }}
         CMAKE_PREFIX_PATH: ${{ steps.install-curl.outputs.CURL_ROOT }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,8 @@ jobs:
       package-server-tag: ${{ steps.release.outputs['libs/server-sdk--tag_name'] }}
       package-server-redis-released: ${{ steps.release.outputs['libs/server-sdk-redis-source--release_created'] }}
       package-server-redis-tag: ${{ steps.release.outputs['libs/server-sdk-redis-source--tag_name'] }}
+      package-server-dynamodb-released: ${{ steps.release.outputs['libs/server-sdk-dynamodb-source--release_created'] }}
+      package-server-dynamodb-tag: ${{ steps.release.outputs['libs/server-sdk-dynamodb-source--tag_name'] }}
       package-server-otel-released: ${{ steps.release.outputs['libs/server-sdk-otel--release_created'] }}
       package-server-otel-tag: ${{ steps.release.outputs['libs/server-sdk-otel--tag_name'] }}
     steps:
@@ -266,6 +268,85 @@ jobs:
         with:
           subject-checksums: checksums.txt
 
+  release-server-dynamodb:
+    strategy:
+      matrix:
+        # Each of the platforms for which release-artifacts need generated.
+        os: [ ubuntu-22.04, windows-2022, macos-15-large ]
+    runs-on: ${{ matrix.os }}
+    needs: [ 'release-please' ]
+    if: ${{ needs.release-please.outputs.package-server-dynamodb-released  == 'true'}}
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - id: release-server-dynamodb
+        name: Full release of libs/server-sdk-dynamodb-source
+        uses: ./.github/actions/sdk-release
+        with:
+          # The tag of the release to upload artifacts to.
+          tag_name: ${{ needs.release-please.outputs.package-server-dynamodb-tag }}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          sdk_path: 'libs/server-sdk-dynamodb-source'
+          sdk_cmake_target: 'launchdarkly-cpp-server-dynamodb-source'
+      - name: Generate checksums file
+        env:
+          HASHES_LINUX: ${{ steps.release-server-dynamodb.outputs.hashes-linux }}
+          HASHES_WINDOWS: ${{ steps.release-server-dynamodb.outputs.hashes-windows }}
+          HASHES_MACOS: ${{ steps.release-server-dynamodb.outputs.hashes-macos }}
+        run: |
+          # BSD base64 (macOS) uses -D to decode; GNU base64 (Linux/Windows) uses -d.
+          if [[ "$OSTYPE" == darwin* ]]; then B64_DECODE="base64 -D"; else B64_DECODE="base64 -d"; fi
+          if [ -n "${HASHES_LINUX}" ]; then
+            echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
+          elif [ -n "${HASHES_WINDOWS}" ]; then
+            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+          elif [ -n "${HASHES_MACOS}" ]; then
+            echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
+          fi
+        shell: bash
+      # https://github.com/actions/attest/releases/tag/v4.1.0
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: checksums.txt
+
+  release-server-dynamodb-mac-arm64:
+    runs-on: macos-15
+    needs: [ 'release-please' ]
+    if: ${{ needs.release-please.outputs.package-server-dynamodb-released  == 'true'}}
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.0
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - id: release-server-dynamodb
+        name: Full release of libs/server-sdk-dynamodb-source (macOS arm64)
+        uses: ./.github/actions/sdk-release
+        with:
+          tag_name: ${{ needs.release-please.outputs.package-server-dynamodb-tag }}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          sdk_path: 'libs/server-sdk-dynamodb-source'
+          sdk_cmake_target: 'launchdarkly-cpp-server-dynamodb-source'
+          mac_artifact_arch: 'arm64'
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.release-server-dynamodb.outputs.hashes-macos }}
+        run: |
+          # This job always runs on macOS, so use -D (BSD base64 decode).
+          echo "${HASHES}" | base64 -D > checksums.txt
+        shell: bash
+      # https://github.com/actions/attest/releases/tag/v4.1.0
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: checksums.txt
+
   publish-release-client:
     needs: ['release-please', 'release-client', 'release-client-mac-arm64']
     if: ${{ needs.release-please.outputs.package-client-released == 'true' }}
@@ -309,6 +390,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.release-please.outputs.package-server-redis-tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false
+
+  publish-release-server-dynamodb:
+    needs: ['release-please', 'release-server-dynamodb', 'release-server-dynamodb-mac-arm64']
+    if: ${{ needs.release-please.outputs.package-server-dynamodb-released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.package-server-dynamodb-tag }}
         run: >
           gh release edit "$TAG_NAME"
           --repo ${{ github.repository }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,6 +39,7 @@
       "extra-files": [
         "CMakeLists.txt"
       ],
+      "draft": true,
       "force-tag-creation": true
     },
     "libs/server-sdk-otel": {


### PR DESCRIPTION
## Summary

Wires `libs/server-sdk-dynamodb-source` into the release-please draft + publish flow so its releases cut and un-draft automatically, same as client/server/redis.

- `"draft": true` in `release-please-config.json` for dynamodb.
- `release-server-dynamodb` (matrix) + `-mac-arm64` + `publish-release-server-dynamodb` jobs in `release-please.yml`. Mirrors the redis pattern.
- `sdk-release` action passes `CURL_ROOT` and `CMAKE_PREFIX_PATH` to its Linux and macOS Boost.Beast build steps. aws-sdk-cpp calls `find_package(CURL)` on Linux/macOS regardless of `LD_CURL_NETWORKING`; on macOS the hint is needed because homebrew's curl isn't in cmake's default search path. Windows uses WinHTTP, so aws-sdk-cpp doesn't need libcurl there and the env isn't passed.

The dynamodb release path has never been cut end-to-end. Per-package CI builds dynamodb daily, but the `sdk-release` composite action hasn't been run against it -- the first real release may surface latent issues.
