### PR TITLE
ci: add pull-requests read permission to lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,7 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
-    # https://github.com/launchdarkly/gh-actions/commit/f1760cc538c362c2ab826a3bd22611743ef8f82c
+    # https://github.com/launchdarkly/gh-actions/commit/de4859c8d07c097d573fbcc4bd10b77efed0f5cc
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@de4859c8d07c097d573fbcc4bd10b77efed0f5cc


### PR DESCRIPTION
## Summary

The reusable `lint-pr-title.yml` in `gh-actions` was updated (`de4859c`) to declare `permissions: pull-requests: read` at the job level. Without a matching top-level `permissions` block in the calling workflow, `pull_request_target` runs hit `startup_failure`. Adds the missing `permissions` block, matching other LD repos (e.g. `swift-eventsource`, `go-server-sdk`).

Link to Devin session: https://app.devin.ai/sessions/43117682510646828d0bde0908f25835
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow permission and pin update with no application or runtime impact.
> 
> **Overview**
> Fixes **Lint PR title** failing at startup on `pull_request_target` by adding a workflow-level **`permissions: pull-requests: read`** block, aligned with the updated reusable workflow in `launchdarkly/gh-actions`.
> 
> The caller pin is bumped from `f1760cc` to **`de4859c`**, which expects that permission to be declared in the calling repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a137a5842c6378d37a2ceb7332f90685572171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->