### PR TITLE
ci: Normalize Windows sha256sum output for actions/attest

### DIFF
--- a/.github/actions/sdk-release/action.yml
+++ b/.github/actions/sdk-release/action.yml
@@ -235,7 +235,7 @@ runs:
       id: hash-windows
       run: |
         CURL_SUFFIX="${{ steps.curl-suffix-windows.outputs.suffix }}"
-        echo "hashes-windows=$(sha256sum windows-msvc-x64-static.zip windows-msvc-x64-dynamic.zip windows-msvc-x64-static-debug.zip windows-msvc-x64-dynamic-debug.zip windows-msvc-x64-static-curl${CURL_SUFFIX}.zip windows-msvc-x64-dynamic-curl${CURL_SUFFIX}.zip windows-msvc-x64-static-debug-curl${CURL_SUFFIX}.zip windows-msvc-x64-dynamic-debug-curl${CURL_SUFFIX}.zip | base64 -w0)" >> "$GITHUB_OUTPUT"
+        echo "hashes-windows=$(sha256sum windows-msvc-x64-static.zip windows-msvc-x64-dynamic.zip windows-msvc-x64-static-debug.zip windows-msvc-x64-dynamic-debug.zip windows-msvc-x64-static-curl${CURL_SUFFIX}.zip windows-msvc-x64-dynamic-curl${CURL_SUFFIX}.zip windows-msvc-x64-static-debug-curl${CURL_SUFFIX}.zip windows-msvc-x64-dynamic-debug-curl${CURL_SUFFIX}.zip | sed 's/ \*/  /' | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Upload Windows Build Artifacts
       if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

Windows release jobs (client, server, server-redis) fail at `actions/attest@v4.1.0` with `Invalid Argument - subject name length exceeded 256 characters`. Git Bash's `sha256sum` emits binary-mode output (`<hash> *<name>`); the attest action only parses text-mode (`<hash>  <name>`), treats the `*` as a parse fail, and slurps the rest of the file into one giant subject name. Pipe through `sed 's/ \*/  /'` to normalize. Linux and macOS produce text-mode output natively.