### PR TITLE
ci: Fix Windows release attestation by writing CRLF checksums

### DIFF
--- a/.github/workflows/manual-sdk-release-artifacts.yml
+++ b/.github/workflows/manual-sdk-release-artifacts.yml
@@ -75,7 +75,7 @@ jobs:
           if [ -n "${HASHES_LINUX}" ]; then
             echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
           elif [ -n "${HASHES_WINDOWS}" ]; then
-            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+            echo "${HASHES_WINDOWS}" | $B64_DECODE | sed 's/$/\r/' > checksums.txt
           elif [ -n "${HASHES_MACOS}" ]; then
             echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -n "${HASHES_LINUX}" ]; then
             echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
           elif [ -n "${HASHES_WINDOWS}" ]; then
-            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+            echo "${HASHES_WINDOWS}" | $B64_DECODE | sed 's/$/\r/' > checksums.txt
           elif [ -n "${HASHES_MACOS}" ]; then
             echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
           fi
@@ -145,7 +145,7 @@ jobs:
           if [ -n "${HASHES_LINUX}" ]; then
             echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
           elif [ -n "${HASHES_WINDOWS}" ]; then
-            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+            echo "${HASHES_WINDOWS}" | $B64_DECODE | sed 's/$/\r/' > checksums.txt
           elif [ -n "${HASHES_MACOS}" ]; then
             echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
           fi
@@ -224,7 +224,7 @@ jobs:
           if [ -n "${HASHES_LINUX}" ]; then
             echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
           elif [ -n "${HASHES_WINDOWS}" ]; then
-            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+            echo "${HASHES_WINDOWS}" | $B64_DECODE | sed 's/$/\r/' > checksums.txt
           elif [ -n "${HASHES_MACOS}" ]; then
             echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
           fi
@@ -303,7 +303,7 @@ jobs:
           if [ -n "${HASHES_LINUX}" ]; then
             echo "${HASHES_LINUX}" | $B64_DECODE > checksums.txt
           elif [ -n "${HASHES_WINDOWS}" ]; then
-            echo "${HASHES_WINDOWS}" | $B64_DECODE > checksums.txt
+            echo "${HASHES_WINDOWS}" | $B64_DECODE | sed 's/$/\r/' > checksums.txt
           elif [ -n "${HASHES_MACOS}" ]; then
             echo "${HASHES_MACOS}" | $B64_DECODE > checksums.txt
           fi


### PR DESCRIPTION
## Summary

Windows release jobs fail at `actions/attest`: its parser splits `checksums.txt` on `os.EOL` (`'\r\n'` on Windows), but the Generate-checksums step writes LF-only. The whole file becomes a single record whose subject name exceeds 256 chars.

Pipe through `sed 's/$/\r/'` on the Windows branch to produce CRLF. Linux and macOS unchanged.

Confirmed on a Windows runner: `sha256sum` on Git Bash writes LF only, the base64 round-trip preserves it, and Node `os.EOL` on the runner is `"\r\n"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only line-ending tweak on the Windows checksum branch; no runtime SDK or security logic changes.
> 
> **Overview**
> Fixes **Windows release jobs** failing at `actions/attest` when parsing `checksums.txt`.
> 
> On the Windows matrix leg, the **Generate checksums file** step now pipes decoded hashes through `sed 's/$/\r/'` so each line ends with **CRLF**, matching how `actions/attest` splits on `os.EOL` (`\r\n`) on Windows. LF-only output was treated as one record and blew past subject name limits. **Linux and macOS** checksum generation is unchanged.
> 
> The same one-line change is applied everywhere that Windows hash output is written: `manual-sdk-release-artifacts.yml` and four release jobs in `release-please.yml` (client, server, redis, dynamodb).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840d1538a67496b9b458b618cca64b921ab81b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->