### PR TITLE
fix: Redact anonymous context attributes in server-side custom events

### DIFF
--- a/libs/internal/src/events/asio_event_processor.cpp
+++ b/libs/internal/src/events/asio_event_processor.cpp
@@ -284,10 +284,15 @@ std::vector<OutputEvent> AsioEventProcessor<SDK>::Process(
                     }
                 }
 
+                auto filtered_context =
+                    std::is_same<SDK, config::shared::ServerSDK>::value
+                        ? filter_.FilterWithAnonymousRedaction(event.context)
+                        : filter_.Filter(event.context);
+
                 out.emplace_back(TrackEvent{
                     event.creation_date,
                     event.key,
-                    filter_.Filter(event.context),
+                    std::move(filtered_context),
                     event.data,
                     event.metric_value,
                 });


### PR DESCRIPTION
## Summary

The C++ event processor emitted custom (track) events using the non-redacting context filter, so anonymous contexts were sent with all attributes intact. Server-side SDKs now redact all attributes of anonymous contexts in custom events (matching feature-event behavior); client-side SDKs continue to send them unredacted (they redact anonymous attributes only in feature events).

- Gated the custom-event context filter on the SDK template type in `AsioEventProcessor<SDK>::Process`: `FilterWithAnonymousRedaction` for the server SDK, `Filter` for the client SDK.
- Mirrors the `redactAnonymousAllEvents` split in java-core / dotnet-core.
- Verified against the sdk-test-harness v3 custom-event tests: server redacts, client does not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what PII/context data leaves server-side custom events (privacy fix), but scope is limited to one code path and mirrors existing feature-event filtering.
> 
> **Overview**
> Server-side **custom (track) events** now run context through `FilterWithAnonymousRedaction` before emission, so **anonymous contexts no longer ship with full attributes** in those payloads. Client SDK track events still use the standard `Filter` path, unchanged.
> 
> The branch is chosen in `AsioEventProcessor<SDK>::Process` from the SDK template type, aligning track events with how full feature events already redact anonymous context on the server and with `redactAnonymousAllEvents` behavior in other SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0f065c9cbdcf83c905b19e8a71bfa34a65a143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->