### PR TITLE
chore: record fdv2 and big segments support in sdk metadata

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -43,8 +43,10 @@
       "features": {
         "allFlags": { "introduced": "1.0" },
         "appMetadata": { "introduced": "3.0" },
+        "bigSegments": { "introduced": "3.13" },
         "contexts": { "introduced": "3.0" },
         "experimentation": { "introduced": "2.4" },
+        "fdv2": { "introduced": "3.12" },
         "fileDataSource": { "introduced": "2.6" },
         "hooks": { "introduced": "3.10" },
         "inlineContextCustomEvents": { "introduced": "3.9" },


### PR DESCRIPTION
## Summary

Records FDv2 and Big Segments support for the C++ Server SDK in `.sdk_metadata.json`.

- Adds `"fdv2": { "introduced": "3.12" }` under `cpp-server-sdk`
- Adds `"bigSegments": { "introduced": "3.13" }` under `cpp-server-sdk`
- `cpp-client-sdk` left unchanged — it already records `bigSegments` at 1.0, and has no FDv2 support yet

**FDv2 — 3.12.0** (2026-07-01) is the first *released* version containing it. The configuration builder, orchestrator, and FDv1 adapter synchronizer are attributed to 3.11.0 in the changelog and a `launchdarkly-cpp-server-v3.11.0` tag exists, but 3.11.0 was never published as a release — the 2026-06-29 release round stayed in draft. sdk-meta's `releases.json` likewise has no 3.11 entry.

**Big Segments — 3.13.0** (2026-07-24), the release that added the C bindings (#573), completing the feature across both the C++ and C surfaces.

sdk-meta ingests this file, so merging closes the gap where neither feature appears for C++ Server in the SDK feature matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates **`.sdk_metadata.json`** so the C++ Server SDK’s feature matrix matches shipped capabilities: **`fdv2`** at **3.12** and **`bigSegments`** at **3.13**. The C++ client SDK block is unchanged (it already lists big segments; it still has no FDv2 entry).
> 
> sdk-meta consumes this file, so merging closes the gap where those features were missing from external SDK feature reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3230bac22a8bf240600a63aedd4a9f9d5f7aab8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->