### PR TITLE
fix: Disable Foxy separate compilation to avoid Boost.Asio ODR crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,12 @@ find_package(Boost 1.81 REQUIRED COMPONENTS json url coroutine)
 message(STATUS "LaunchDarkly: using Boost v${Boost_VERSION}")
 
 set(FOXY_BUILD_TESTING OFF)
+
+# Keep Boost.Asio header-only, matching how consumers compile it. Foxy's
+# separate-compilation mode bakes Asio internals into our library whose layout can
+# diverge from a consumer's build, causing ODR violations when linked. Force off.
+set(FOXY_FAST_BUILD OFF CACHE BOOL "Keep Boost.Asio header-only for ABI compatibility with consumers" FORCE)
+
 add_subdirectory(vendor/foxy)
 
 

--- a/libs/networking/src/CMakeLists.txt
+++ b/libs/networking/src/CMakeLists.txt
@@ -35,8 +35,6 @@ target_compile_features(${LIBNAME} PUBLIC cxx_std_17)
 target_compile_definitions(${LIBNAME}
     PUBLIC
         LD_CURL_NETWORKING
-        BOOST_ASIO_SEPARATE_COMPILATION=1
-        BOOST_BEAST_SEPARATE_COMPILATION=1
 )
 
 # Using PUBLIC_HEADERS would flatten the include.


### PR DESCRIPTION
## Summary

Linking the C++ client into an app that uses Boost.Asio directly crashed the app under Boost >= 1.91. Foxy's separate-compilation mode (`FOXY_FAST_BUILD`) baked Asio's out-of-line internals into our library with a layout that diverges from a consumer's header-only Asio, producing an ODR violation. Under ASan this surfaces as a heap-buffer-overflow in the reactor mutex constructor. Force `FOXY_FAST_BUILD=OFF` so Asio stays header-only everywhere, matching how consumers compile it.

Fixes #590.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CMake-only build configuration change with no runtime logic changes; primary effect is safer linking behavior for mixed SDK/consumer Asio builds.
> 
> **Overview**
> Fixes crashes when apps link this SDK alongside their own **Boost.Asio** usage (notably Boost **≥ 1.91**, issue **#590**).
> 
> The build now **forces `FOXY_FAST_BUILD=OFF`** before vendored Foxy is configured, so Foxy no longer enables separate compilation of Asio/Beast or links Foxy’s compiled `asio.cpp`/`beast.cpp` into the SDK. That keeps Asio **header-only** in the SDK artifact, aligned with typical consumer builds and avoiding **ODR** mismatches (e.g. ASan heap-buffer-overflow in reactor mutex setup).
> 
> The CURL networking target also **drops** the public `BOOST_ASIO_SEPARATE_COMPILATION` / `BOOST_BEAST_SEPARATE_COMPILATION` compile definitions that are no longer appropriate for this build mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4392bb341915d60f0b68a212677e310462bd70c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->