### PR TITLE
docs: Record DynamoDB persistent store support in SDK metadata and fix stale library docs

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -55,6 +55,7 @@
         "relayProxyDaemon": { "introduced": "1.2" },
         "relayProxyProxy": { "introduced": "1.0" },
         "storingData": { "introduced": "1.2" },
+        "storingDataDynamodb": { "introduced": "3.13" },
         "storingDataRedis": { "introduced": "1.2" },
         "testDataSource": { "introduced": "2.6" },
         "track": { "introduced": "1.0" },

--- a/libs/server-sdk-dynamodb-source/README.md
+++ b/libs/server-sdk-dynamodb-source/README.md
@@ -6,11 +6,8 @@ LaunchDarkly Server-Side SDK - DynamoDB Source for C/C++
 
 The LaunchDarkly Server-Side SDK DynamoDB Source for C/C++ is designed for use with the Server-Side SDK.
 
-This component will allow the Server-Side SDK to retrieve feature flag configurations from DynamoDB, rather than
+This component allows the Server-Side SDK to retrieve feature flag configurations from DynamoDB, rather than
 from LaunchDarkly.
-
-> [!NOTE]
-> The Big Segments store implementation will land in a subsequent release.
 
 LaunchDarkly overview
 -------------------------

--- a/libs/server-sdk-dynamodb-source/docs/doc.md
+++ b/libs/server-sdk-dynamodb-source/docs/doc.md
@@ -3,5 +3,6 @@
 The Server-side SDK DynamoDB Source can be used as a source of SDK data
 instead of the normal LaunchDarkly Streaming or Polling data sources.
 
-This library is currently a scaffold; the public API will land in a
-subsequent release.
+To create a DynamoDB Source, see [DynamoDBDataSource](@ref launchdarkly::server_side::integrations::DynamoDBDataSource).
+
+To use DynamoDB as a Big Segments store, see [DynamoDBBigSegmentStore](@ref launchdarkly::server_side::integrations::DynamoDBBigSegmentStore).


### PR DESCRIPTION
Records the C++ server SDK's DynamoDB persistent store support in SDK metadata and corrects the DynamoDB source library's own docs, which still described the library as unfinished.

- Adds `storingDataDynamodb` (introduced `3.13`) to the `cpp-server-sdk` entry in `.sdk_metadata.json`, so DynamoDB shows up as a supported persistent store in the SDK feature matrix. This is the LazyLoad/persistent-store capability (the DynamoDB analog of `storingDataRedis`).
- `libs/server-sdk-dynamodb-source/README.md`: updated to reflect that the Big Segments store has launched.
- `libs/server-sdk-dynamodb-source/docs/doc.md`: replaces the "currently a scaffold" text with Doxygen links to the shipped `DynamoDBDataSource` and `DynamoDBBigSegmentStore`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Records DynamoDB persistent-store support for the C++ server SDK and updates the DynamoDB source library docs that still described it as unfinished.
> 
> Adds `storingDataDynamodb` (introduced in `3.13`) to `.sdk_metadata.json` so DynamoDB appears in the SDK feature matrix alongside Redis.
> 
> Updates the DynamoDB source `README` and Doxygen overview to remove the "scaffold / coming later" language and point to the shipped `DynamoDBDataSource` and `DynamoDBBigSegmentStore` APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19084c1968290c14fffda857e772b60d4145d375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->