### PR TITLE
chore: Correct file/test data source and web proxy feature metadata

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -25,7 +25,8 @@
         "privateAttrs": { "introduced": "1.0" },
         "relayProxyProxy": { "introduced": "1.0" },
         "track": { "introduced": "1.0" },
-        "variationDetail": { "introduced": "1.1" }
+        "variationDetail": { "introduced": "1.1" },
+        "webProxy": { "introduced": "3.11" }
       }
     },
     "cpp-server-sdk": {

--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -47,7 +47,7 @@
         "contexts": { "introduced": "3.0" },
         "experimentation": { "introduced": "2.4" },
         "fdv2": { "introduced": "3.12" },
-        "fileDataSource": { "introduced": "2.6" },
+        "fileDataSource": { "introduced": "2.6", "removed": "3.0" },
         "hooks": { "introduced": "3.10" },
         "inlineContextCustomEvents": { "introduced": "3.9" },
         "offlineMode": { "introduced": "1.0" },
@@ -57,7 +57,7 @@
         "storingData": { "introduced": "1.2" },
         "storingDataDynamodb": { "introduced": "3.13" },
         "storingDataRedis": { "introduced": "1.2" },
-        "testDataSource": { "introduced": "2.6" },
+        "testDataSource": { "introduced": "2.6", "removed": "3.0" },
         "track": { "introduced": "1.0" },
         "variationDetail": { "introduced": "1.0" }
       }


### PR DESCRIPTION
## Summary

- Marks `fileDataSource` and `testDataSource` as removed in 3.0 for the C++ server SDK. Both are v2.x C server SDK features; the 3.x SDK has no file or test data source, but the feature matrix implied current support (introduced 2.6 with no removal).
- Records `webProxy` as introduced in 3.11 for the C++ client SDK (`HttpPropertiesBuilder::Proxy` / `LDClientConfigBuilder_HttpProperties_Proxy`, available when the SDK is built with `-DLD_CURL_NETWORKING=ON`).

Validated by running sdk-meta's `ingest` tool against the edited file and confirming the resulting feature rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates **`.sdk_metadata.json`** so the C++ SDK feature matrix matches actual product support.
> 
> For the **C++ server SDK**, **`fileDataSource`** and **`testDataSource`** now include **`removed": "3.0"`** alongside their 2.6 introduction. That stops the matrix from implying current support in 3.x, where those v2.x C server data-source features are not present.
> 
> For the **C++ client SDK**, **`webProxy`** is added with **`introduced": "3.11"`**, reflecting configurable HTTP proxy support (e.g. **`HttpPropertiesBuilder::Proxy`** / **`LDClientConfigBuilder_HttpProperties_Proxy`** when built with CURL networking).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20f841da1d40f80e6c6f7c4f6d00e8397b0436d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->